### PR TITLE
use gh actions for testing

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -1,0 +1,100 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+      - name: Lint with flake8
+        run: |
+          flake8 glotaran
+
+  docs:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install -r requirements_dev.txt
+      - name: Build docs
+        run: |
+          make --directory=docs clean html
+
+  docs-links:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install -r requirements_dev.txt
+      - name: Check doc links
+        run: |
+          make --directory=docs clean linkcheck
+
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: [lint, docs]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_dev.txt
+      - name: Run tests
+        run: |
+          py.test --cov=glotaran --cov-config .coveragerc glotaran
+
+  deploy:
+    runs-on: [ubuntu-latest]
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    needs: test
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_dev.txt
+      - name: Build dist
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 pyGloTarAn is a python library for global and target analysis
 
 [![latest release](https://pypip.in/version/glotaran/badge.svg)](https://pypi.org/project/glotaran/)
-[![Build Status Linux + OsX](https://travis-ci.org/glotaran/pyglotaran.svg?branch=master)](https://travis-ci.org/glotaran/pyglotaran)
-[![Build Status Windows](https://ci.appveyor.com/api/projects/status/76gkx10wyn2cd049?svg=true)](https://ci.appveyor.com/project/glotaran/pyglotaran)
+[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fglotaran%2Fpyglotaran%2Fbadge&style=popout)](https://actions-badge.atrox.dev/glotaran/pyglotaran/goto)
 [![Documentation Status](https://readthedocs.org/projects/glotaran/badge/?version=latest)](https://glotaran.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://coveralls.io/repos/github/glotaran/pyglotaran/badge.svg?branch=master)](https://coveralls.io/github/glotaran/pyglotaran?branch=master)
 


### PR DESCRIPTION
## Give a brief summary of the changes.
This PR switches the CI/CD from travis-ci.org and appveyor.org, to [GitHub Actions](https://help.github.com/en/actions/automating-your-workflow-with-github-actions).

### Testing

Tests still fail, due to a [flake8 issue](https://github.com/s-weigand/glotaran/runs/303356941) and [an also locally broken test](https://github.com/s-weigand/glotaran/runs/303376399). With those 2 issues fixed, `pyglotaran` managed to [pass the test suite](https://github.com/s-weigand/glotaran/commit/2539bf867785d7c5e5196a44f5f6973699236af9/checks?check_suite_id=311387898).

### TODO
Sadly for the moment we will lose some convenience services:
- **coveralls**: Atm the normal clients don't support actions and the action doesn't support the coverage output of `pytest-cov` ([see](https://github.com/coverallsapp/github-action/issues/15)).
- **Slack integration**: The there are already [quite some slack action](https://github.com/marketplace?utf8=%E2%9C%93&type=actions&query=slack), 
I need to figure out which one to use and how to configure it. @joernweissenborn  I also need access to the secret slack token.
- **Deployment**: The deployment is added to the actions, but for it to work @jsnel or I need to add our [PyPi token](https://pypi.org/help/#apitoken) to the `secrets` of the `glotaran/pyglotaran` repo.
- **Deactivate good old travis and appveyor**

**Closing issues**

closes #245 