### PR TITLE
Fix small gh action errors

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -1,6 +1,6 @@
-name: Python package
+name: Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
Give a brief summary of the changes.
- Rename gh actions from `Python package` to `Tests`
- Make the also trigger at PRs not only pushes