### PR TITLE
Use codecov instead of coveralls

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -103,13 +103,20 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
+          pip install -e .
           python -m pip install -r requirements_dev.txt
       - name: Show installed packages
         run: pip freeze
       - name: Run tests
         run: |
-          py.test --cov=glotaran --cov-config .coveragerc -k 'not IrfDispersion' glotaran
+          pytest --cov=./ --cov-report term --cov-report xml --cov-config .coveragerc -k 'not IrfDispersion' glotaran
+
+      - name: Codecov Upload
+        continue-on-error: true
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+          file: ./coverage.xml
 
   deploy:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -21,7 +21,6 @@ jobs:
 
   docs:
     runs-on: [ubuntu-latest]
-    needs: [test]
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python 3.7
@@ -42,7 +41,6 @@ jobs:
 
   docs-links:
     runs-on: [ubuntu-latest]
-    needs: [test]
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python 3.7
@@ -88,7 +86,7 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
-    needs: [lint]
+    needs: lint
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -121,7 +119,7 @@ jobs:
   deploy:
     runs-on: [ubuntu-latest]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    needs: test
+    needs: [test, docs]
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python 3.7

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ pyGloTarAn is a python library for global and target analysis
 [![latest release](https://pypip.in/version/glotaran/badge.svg)](https://pypi.org/project/glotaran/)
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fglotaran%2Fpyglotaran%2Fbadge&style=popout)](https://actions-badge.atrox.dev/glotaran/pyglotaran/goto)
 [![Documentation Status](https://readthedocs.org/projects/glotaran/badge/?version=latest)](https://glotaran.readthedocs.io/en/latest/?badge=latest)
-[![Coverage Status](https://coveralls.io/repos/github/glotaran/pyglotaran/badge.svg?branch=master)](https://coveralls.io/github/glotaran/pyglotaran?branch=master)
+[![Coverage Status](https://codecov.io/gh/glotaran/pyglotaran/branch/master/graph/badge.svg)](https://codecov.io/gh/glotaran/pyglotaran)
 
 ## Warning
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ install_requires = [
     'cloudpickle>=1.2',  # Needed by dask
     'dask[bag]>=2.8',
     'lmfit>=0.9.13',
+    'netCDF4>=1.5',
     'numba>=0.44',
     'numpy>=1.16',
     'pandas>=0.24',
@@ -15,13 +16,6 @@ install_requires = [
     'setuptools>=41.0',
     'xarray>=0.14',
 ]
-
-# TODO: set a new genereal min version for netCDF4
-# when they deploy windows wheels again
-if sys.platform == "win32":
-    install_requires.append('netCDF4>=1.4,<=1.5.3')
-else:
-    install_requires.append('netCDF4>=1.4')
 
 
 with open("README.md", "r") as fh:


### PR DESCRIPTION
Coveralls doesn't support github actions  for none javascript projects yet, so my proposal is to use codecov.
This PR exchanges coveralls.io with codecov.io and also removes `netCDF` upperboundry as @joernweissenborn wanted.