### PR TITLE
Configure codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 1
+        base: auto


### PR DESCRIPTION
Sometimes codecov has some unwanted fluctuation see [here](https://github.com/glotaran/pyglotaran/pull/268#issuecomment-557838960), which mayresult in a [failed test](https://codecov.io/gh/glotaran/pyglotaran/compare/0ab31ad91c6dc64118f0377784469dc65e769ad5...9de901948b4578712d6b0bd8d8358f7cce8aabd7).

This PR adds a `.codecov.yml` so codecov won't complain about false fluctuations in coverage which are less than 1%.