### PR TITLE
Fix kinetic spectrum matrix irf

### DIFF
--- a/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_matrix.py
+++ b/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_matrix.py
@@ -10,7 +10,7 @@ from .spectral_irf import IrfGaussianCoherentArtifact
 
 def kinetic_spectrum_matrix(dataset_descriptor=None, axis=None, index=None, irf=None):
 
-    clp_label, matrix = kinetic_image_matrix(dataset_descriptor, axis, index, irf)
+    clp_label, matrix = kinetic_image_matrix(dataset_descriptor, axis, index, dataset_descriptor.irf)
 
     if isinstance(dataset_descriptor.irf, IrfGaussianCoherentArtifact):
         irf_clp_label, irf_matrix = \

--- a/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_matrix.py
+++ b/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_matrix.py
@@ -10,11 +10,12 @@ from .spectral_irf import IrfGaussianCoherentArtifact
 
 def kinetic_spectrum_matrix(dataset_descriptor=None, axis=None, index=None, irf=None):
 
-    clp_label, matrix = kinetic_image_matrix(dataset_descriptor, axis, index, dataset_descriptor.irf)
+    clp_label, matrix = kinetic_image_matrix(
+        dataset_descriptor, axis, index, dataset_descriptor.irf)
 
     if isinstance(dataset_descriptor.irf, IrfGaussianCoherentArtifact):
         irf_clp_label, irf_matrix = \
-                dataset_descriptor.irf.calculate_coherent_artifact(axis)
+            dataset_descriptor.irf.calculate_coherent_artifact(axis)
         if matrix is None:
             clp_label = irf_clp_label
             matrix = irf_matrix

--- a/glotaran/builtin/models/kinetic_spectrum/test/test_spectral_irf.py
+++ b/glotaran/builtin/models/kinetic_spectrum/test/test_spectral_irf.py
@@ -105,7 +105,7 @@ class SimpleIrfDispersion:
     time_p2 = np.linspace(2, 5, 30, endpoint=False)
     time_p3 = np.geomspace(5, 10, num=20)
     time = np.concatenate([time_p1, time_p2, time_p3])
-    spectral = np.arange(300, 500, 5)
+    spectral = np.arange(300, 500, 100)
     axis = {"time": time, "spectral": spectral}
 
 
@@ -214,7 +214,7 @@ class MultiIrfDispersion:
     })
 
     time = np.arange(-1, 5, 0.2)
-    spectral = np.arange(300, 500, 25)
+    spectral = np.arange(300, 500, 100)
     axis = {"time": time, "spectral": spectral}
 
 


### PR DESCRIPTION
Small bugfix 

irf was none when running test_spectral_irf.py ... the test would pass but the entire kinetic trace would remain zero, this fixes that and tests still pass 