### PR TITLE
Adapted to changes in codecov action

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -109,10 +109,8 @@ jobs:
           pytest --cov=./ --cov-report term --cov-report xml --cov-config .coveragerc -k 'not IrfDispersion' glotaran
 
       - name: Codecov Upload
-        continue-on-error: true
         uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.xml
 
   deploy:


### PR DESCRIPTION
- `continue-on-error` was deprecated
- `token` isn't needed anymore for public repos and dropping it allows codcov upload from fork PRs