### PR TITLE
Fix doc dependencies

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,13 @@
+version: 2
+
+formats: all
+
 build:
   image: latest
 
 python:
-  version: 3.6
-  setup_py_install: true
+  version: 3.7
+  install:
+    - requirements: requirements_dev.txt
+    - method: pip
+      path: .

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 # general install dependencies
 pip>=18.0
 wheel>=0.30.0
-setuptools>=41.0
+setuptools>=41.2
 
 # needed to release new versions
 bump2version>=0.5.11

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,6 @@
 # general install dependencies
 pip>=18.0
 wheel>=0.30.0
-setuptools>=41.2
 
 # needed to release new versions
 bump2version>=0.5.11
@@ -18,6 +17,7 @@ pandas==1.0.1
 pyyaml==5.3.1
 xarray==0.15.1
 netCDF4==1.5.3
+setuptools==41.2
 
 # documentation dependencies
 Sphinx>=1.8.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     'pandas>=0.25.2',
     'pyyaml>=5.2',
     'scipy>=1.3.2',
-    'setuptools>=41.0',
+    'setuptools>=41.2',
     'xarray>=0.14',
 ]
 


### PR DESCRIPTION
This fixes the failing build of the docs on RTD.
Changes:
- Set minimum requirement of `setuptools>=41.2`, which is needed by `xarray`
- Made `setuptools` a pinned version in `requirements_dev.txt` since it is a peerdependency of xarray and a dependency of `pyglotaran`. This fixed version should not be updated by `dependabot`
- Updated ` readthedocs.yml` to version 2 style

**Closing issues**

closes #354 