### PR TITLE
[CI] Add linkcheck summary

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -57,7 +57,9 @@ jobs:
       - name: Check doc links
         run: |
           python docs/source/generate_api_doc.py
-          make --directory=docs clean linkcheck
+          make --directory=docs clean linkcheck | tee linkcheck-summary.txt
+      - name: Linkcheck summary
+        run: cat linkcheck-summary.txt | grep -E "(\(line.*\)|writing output)"
 
   api-docs-up-to-date:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -60,6 +60,7 @@ jobs:
           make --directory=docs clean linkcheck $@ | tee linkcheck-output.txt
           exit ${PIPESTATUS[0]}
       - name: Linkcheck summary
+        if: ${{ always() }}
         run: cat linkcheck-output.txt | grep -E "(\(line.*\)|writing output)"
 
   api-docs-up-to-date:

--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -57,9 +57,10 @@ jobs:
       - name: Check doc links
         run: |
           python docs/source/generate_api_doc.py
-          make --directory=docs clean linkcheck | tee linkcheck-summary.txt
+          make --directory=docs clean linkcheck $@ | tee linkcheck-output.txt
+          exit ${PIPESTATUS[0]}
       - name: Linkcheck summary
-        run: cat linkcheck-summary.txt | grep -E "(\(line.*\)|writing output)"
+        run: cat linkcheck-output.txt | grep -E "(\(line.*\)|writing output)"
 
   api-docs-up-to-date:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added 'Linkcheck summary' step to CI job 'docs-links', which only shows linkcheck related output.

**Testing**

Passing the tests is mandatory.

**Closing issues**
closes #357 
