### PR TITLE
Use sphinx >= 3.0 for the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,7 +58,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
     'numpydoc',
-    'sphinx_autodoc_typehints',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
 ]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -20,10 +20,9 @@ netCDF4==1.5.3
 setuptools==41.2
 
 # documentation dependencies
-Sphinx>=1.8.0
+Sphinx>=3.0.0
 sphinx-rtd-theme>=0.3.1
 numpydoc>=0.8.0
-sphinx_autodoc_typehints>=1.6.0
 matplotlib>=3.0.0
 IPython>=7.2.0
 


### PR DESCRIPTION
Deprecated `sphinx-autodoc-typehints` and use intrinsic typehint support of `sphinx>=3.0.0`.
I checked the output and it is the same, but the deprecation warning are gone (build log is about 1600 lines shorter).

**Testing**

Passing the tests is mandatory.

**Closing issues**

closes #359 
