### PR TITLE
Update test_optimization.py to fix #397

### DIFF
--- a/glotaran/analysis/test/test_optimization.py
+++ b/glotaran/analysis/test/test_optimization.py
@@ -221,7 +221,7 @@ def test_fitting(suite, index_dependend, grouped):
     assert dataset.data.shape == (cal_axis.size, est_axis.size)
 
     data = {'dataset1': dataset}
-    scheme = Scheme(model=model, parameter=initial, data=data, nfev=5)
+    scheme = Scheme(model=model, parameter=initial, data=data, nfev=10)
 
     result = optimize(scheme)
     print(result.optimized_parameter)


### PR DESCRIPTION
This fixes some failing optimization test due to a change in lmfit 1.0.1,
where the argument ``max_nfev`` was changed slightly with the intention to
uniformly specify the maximum number of function evalutions (see their PR 610),
this effectively reduces the number of iteration that were run resulting in
a failure to converge within the fixed number of iterations.

Brief summary of the changes:
Increased nfev from 5 to 10 to allow for more iteration to get convergence.

**Closing issues**

Closes #397 
