### PR TITLE
Add pre-commit autoupdate workflow

### DIFF
--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -1,0 +1,33 @@
+name: "Update pre-commit config"
+# You need to set an access token as a secret ACTION_TRIGGER_TOKEN on this repo
+# in order for the PR to trigger the CI.
+# For more details see: https://github.com/technote-space/create-pr-action#github_token
+# If you don't want the PR to trigger the CI (NOT RECOMMENDED), comment out the GITHUB_TOKEN line.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # At 07:00 on each Monday.
+  workflow_dispatch:
+
+jobs:
+  update-pre-commit:
+    name: Autoupdate pre-commit config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-autoupdate
+      - name: Update pre-commit config packages
+        uses: technote-space/create-pr-action@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.ACTION_TRIGGER_TOKEN }}
+          EXECUTE_COMMANDS: |
+            pip install pre-commit
+            pre-commit autoupdate || (exit 0);
+            pre-commit run -a || (exit 0);
+          COMMIT_MESSAGE: "⬆️ UPGRADE: Autoupdate pre-commit config"
+          PR_BRANCH_NAME: "pre-commit-config-update-${PR_ID}"
+          PR_TITLE: "⬆️ UPGRADE: Autoupdate pre-commit config"

--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -6,7 +6,7 @@ name: "Update pre-commit config"
 
 on:
   schedule:
-    - cron: "0 7 * * 1" # At 07:00 on each Monday.
+    - cron: "0 20 * * 5" # At 20:00 on each Friday.
   workflow_dispatch:
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,14 +14,14 @@ repos:
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.2
     hooks:
-    - id: pyupgrade
-      args: [--py36-plus]
+      - id: pyupgrade
+        args: [--py36-plus]
   - repo: https://github.com/python/black
     rev: 20.8b1
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/timothycrosley/isort
+  - repo: https://github.com/PyCQA/isort
     rev: 5.5.0
     hooks:
       - id: isort
@@ -45,7 +45,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/myint/rstcheck
-    rev: '3f92957478422df87bd730abde66f089cc1ee19b'
+    rev: "3f92957478422df87bd730abde66f089cc1ee19b"
     hooks:
       - id: rstcheck
         additional_dependencies: [rstcheck, sphinx]


### PR DESCRIPTION
This adds a workflow which runs `pre-commit autoupdate` on schedule or manually triggered with `workflow_dispatch`, and makes a PR if there are new versions of tool.

@jsnel In order for this to trigger the CI at PR's you need [create an access token](https://github.com/technote-space/create-pr-action#github_token) and add it as secret `ACTION_TRIGGER_TOKEN` to the repo.
