### PR TITLE
Fix 'not valid as a type' type checking errors

### DIFF
--- a/glotaran/analysis/simulation.py
+++ b/glotaran/analysis/simulation.py
@@ -1,21 +1,25 @@
 """Functions for simulating a global analysis model."""
+from __future__ import annotations
 
-import typing
+from typing import TYPE_CHECKING
 
 import numpy as np
 import xarray as xr
 
-from glotaran.parameter import ParameterGroup
+if TYPE_CHECKING:
+    from typing import Dict
+    from typing import Union
 
-T_Model = typing.TypeVar("glotaran.model.Model")
+    from glotaran.model import Model
+    from glotaran.parameter import ParameterGroup
 
 
 def simulate(
-    model: T_Model,
+    model: Model,
     dataset: str,
     parameter: ParameterGroup,
-    axes: typing.Dict[str, np.ndarray] = None,
-    clp: typing.Union[np.ndarray, xr.DataArray] = None,
+    axes: Dict[str, np.ndarray] = None,
+    clp: Union[np.ndarray, xr.DataArray] = None,
     noise=False,
     noise_std_dev=1.0,
     noise_seed=None,

--- a/glotaran/builtin/models/kinetic_image/__init__.py
+++ b/glotaran/builtin/models/kinetic_image/__init__.py
@@ -1,3 +1,1 @@
-from . import kinetic_image_model
-
-KineticImageModel = kinetic_image_model.KineticImageModel
+from .kinetic_image_model import KineticImageModel  # noqa: F401

--- a/glotaran/builtin/models/kinetic_image/kinetic_image_result.py
+++ b/glotaran/builtin/models/kinetic_image/kinetic_image_result.py
@@ -1,22 +1,29 @@
-import typing
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 import xarray as xr
 
-from glotaran.parameter import ParameterGroup
-
 from .irf import IrfMultiGaussian
 
-T_KineticImageModel = typing.TypeVar("glotaran.builtin.models.kinetic_image.KineticImageModel")
+if TYPE_CHECKING:
+    from typing import Dict
+    from typing import List
+    from typing import Union
+
+    from glotaran.parameter import ParameterGroup
+
+    from .kinetic_image_model import KineticImageModel
 
 
 def finalize_kinetic_image_result(
-    model: T_KineticImageModel,
-    global_indices: typing.List[typing.List[object]],
-    reduced_clp_labels: typing.Union[typing.Dict[str, typing.List[str]], np.ndarray],
-    reduced_clps: typing.Union[typing.Dict[str, np.ndarray], np.ndarray],
+    model: KineticImageModel,
+    global_indices: List[List[object]],
+    reduced_clp_labels: Union[Dict[str, List[str]], np.ndarray],
+    reduced_clps: Union[Dict[str, np.ndarray], np.ndarray],
     parameter: ParameterGroup,
-    data: typing.Dict[str, xr.Dataset],
+    data: Dict[str, xr.Dataset],
 ):
 
     for label in model.dataset:

--- a/glotaran/builtin/models/kinetic_spectrum/__init__.py
+++ b/glotaran/builtin/models/kinetic_spectrum/__init__.py
@@ -1,3 +1,1 @@
-from . import kinetic_spectrum_model
-
-KineticSpectrumModel = kinetic_spectrum_model.KineticSpectrumModel
+from .kinetic_spectrum_model import KineticSpectrumModel  # noqa: F401

--- a/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_model.py
+++ b/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_model.py
@@ -1,12 +1,13 @@
-import typing
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 
-from glotaran.builtin.models.kinetic_image.kinetic_image_megacomplex import KineticImageMegacomplex
-from glotaran.builtin.models.kinetic_image.kinetic_image_model import KineticImageModel
 from glotaran.model import model
-from glotaran.parameter import ParameterGroup
 
+from ..kinetic_image.kinetic_image_megacomplex import KineticImageMegacomplex
+from ..kinetic_image.kinetic_image_model import KineticImageModel
 from .kinetic_spectrum_dataset_descriptor import KineticSpectrumDatasetDescriptor
 from .kinetic_spectrum_matrix import kinetic_spectrum_matrix
 from .kinetic_spectrum_result import finalize_kinetic_spectrum_result
@@ -22,19 +23,21 @@ from .spectral_relations import apply_spectral_relations
 from .spectral_relations import retrieve_related_clps
 from .spectral_shape import SpectralShape
 
-T_KineticSpectrumModel = typing.TypeVar(
-    "glotaran.builtin.models.kinetic_spectrum.KineticSpectrumModel"
-)
+if TYPE_CHECKING:
+    from typing import List
+    from typing import Union
+
+    from glotaran.parameter import ParameterGroup
 
 
-def has_kinetic_model_constraints(model: T_KineticSpectrumModel) -> bool:
+def has_kinetic_model_constraints(model: KineticSpectrumModel) -> bool:
     return len(model.spectral_relations) + len(model.spectral_constraints) != 0
 
 
 def apply_kinetic_model_constraints(
-    model: T_KineticSpectrumModel,
+    model: KineticSpectrumModel,
     parameter: ParameterGroup,
-    clp_labels: typing.List[str],
+    clp_labels: List[str],
     matrix: np.ndarray,
     index: float,
 ):
@@ -44,11 +47,11 @@ def apply_kinetic_model_constraints(
 
 
 def retrieve_spectral_clps(
-    model: T_KineticSpectrumModel,
+    model: KineticSpectrumModel,
     parameter: ParameterGroup,
-    clp_labels: typing.List[str],
-    reduced_clp_labels: typing.List[str],
-    reduced_clps: typing.Union[np.ndarray, typing.List[np.ndarray]],
+    clp_labels: List[str],
+    reduced_clp_labels: List[str],
+    reduced_clps: Union[np.ndarray, List[np.ndarray]],
     global_axis: np.ndarray,
 ):
     if not has_kinetic_model_constraints(model):
@@ -66,7 +69,7 @@ def retrieve_spectral_clps(
     return full_clp
 
 
-def index_dependent(model: T_KineticSpectrumModel):
+def index_dependent(model: KineticSpectrumModel):
     if any(
         isinstance(irf, IrfSpectralMultiGaussian) and irf.dispersion_center is not None
         for irf in model.irf.values()
@@ -77,7 +80,7 @@ def index_dependent(model: T_KineticSpectrumModel):
     return len(model.spectral_constraints) != 0
 
 
-def grouped(model: T_KineticSpectrumModel):
+def grouped(model: KineticSpectrumModel):
     return len(model.dataset) != 1
 
 

--- a/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_result.py
+++ b/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_result.py
@@ -1,35 +1,37 @@
-import typing
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import numpy as np
-import xarray as xr
 
-from glotaran.builtin.models.kinetic_image.irf import IrfMultiGaussian
-from glotaran.builtin.models.kinetic_image.kinetic_image_result import (
-    retrieve_decay_assocatiated_data,
-)
-from glotaran.builtin.models.kinetic_image.kinetic_image_result import retrieve_irf
-from glotaran.builtin.models.kinetic_image.kinetic_image_result import (
-    retrieve_species_assocatiated_data,
-)
-from glotaran.parameter import ParameterGroup
-
+from ..kinetic_image.irf import IrfMultiGaussian
+from ..kinetic_image.kinetic_image_result import retrieve_decay_assocatiated_data
+from ..kinetic_image.kinetic_image_result import retrieve_irf
+from ..kinetic_image.kinetic_image_result import retrieve_species_assocatiated_data
 from .spectral_constraints import OnlyConstraint
 from .spectral_constraints import ZeroConstraint
 from .spectral_irf import IrfGaussianCoherentArtifact
 from .spectral_irf import IrfSpectralMultiGaussian
 
-T_KineticSpectrumModel = typing.TypeVar(
-    "glotaran.builtin.models.kinetic_spectrum.KineticSpectrumModel"
-)
+if TYPE_CHECKING:
+    from typing import Dict
+    from typing import List
+    from typing import Union
+
+    import xarray as xr
+
+    from glotaran.parameter import ParameterGroup
+
+    from .kinetic_spectrum_model import KineticSpectrumModel
 
 
 def finalize_kinetic_spectrum_result(
-    model: T_KineticSpectrumModel,
-    global_indices: typing.List[typing.List[object]],
-    reduced_clp_labels: typing.Union[typing.Dict[str, typing.List[str]], np.ndarray],
-    reduced_clps: typing.Union[typing.Dict[str, np.ndarray], np.ndarray],
+    model: KineticSpectrumModel,
+    global_indices: List[List[object]],
+    reduced_clp_labels: Union[Dict[str, List[str]], np.ndarray],
+    reduced_clps: Union[Dict[str, np.ndarray], np.ndarray],
     parameter: ParameterGroup,
-    data: typing.Dict[str, xr.Dataset],
+    data: Dict[str, xr.Dataset],
 ):
 
     for label in model.dataset:

--- a/glotaran/builtin/models/kinetic_spectrum/spectral_constraints.py
+++ b/glotaran/builtin/models/kinetic_spectrum/spectral_constraints.py
@@ -1,21 +1,25 @@
 """This package contains compartment constraint items."""
+from __future__ import annotations
 
-import typing
-
-import numpy as np
+from typing import TYPE_CHECKING
+from typing import List
+from typing import Tuple
 
 from glotaran.model import model_attribute
 from glotaran.model import model_attribute_typed
 
-T_KineticSpectrumModel = typing.TypeVar(
-    "glotaran.builtin.models.kinetic_spectrum.KineticSpectrumModel"
-)
+if TYPE_CHECKING:
+    from typing import Any
+
+    import numpy as np
+
+    from .kinetic_spectrum_model import KineticSpectrumModel
 
 
 @model_attribute(
     properties={
         "compartment": str,
-        "interval": typing.List[typing.Tuple[float, float]],
+        "interval": List[Tuple[float, float]],
     },
     has_type=True,
     no_label=True,
@@ -24,13 +28,13 @@ class OnlyConstraint:
     """A only constraint sets the calculated matrix row of a compartment to 0
     outside the given intervals."""
 
-    def applies(self, index: any) -> bool:
+    def applies(self, index: Any) -> bool:
         """
         Returns true if the index is in one of the intervals.
 
         Parameters
         ----------
-        index : any
+        index :
 
         Returns
         -------
@@ -49,7 +53,7 @@ class OnlyConstraint:
 @model_attribute(
     properties={
         "compartment": str,
-        "interval": typing.List[typing.Tuple[float, float]],
+        "interval": List[Tuple[float, float]],
     },
     has_type=True,
     no_label=True,
@@ -58,13 +62,13 @@ class ZeroConstraint:
     """A zero constraint sets the calculated matrix row of a compartment to 0
     in the given intervals."""
 
-    def applies(self, index: any) -> bool:
+    def applies(self, index: Any) -> bool:
         """
         Returns true if the indexx is in one of the intervals.
 
         Parameters
         ----------
-        index : any
+        index :
 
         Returns
         -------
@@ -99,8 +103,8 @@ class SpectralConstraint:
 
 
 def apply_spectral_constraints(
-    model: T_KineticSpectrumModel, clp_labels: typing.List[str], matrix: np.ndarray, index: float
-) -> typing.Tuple[typing.List[str], np.ndarray]:
+    model: KineticSpectrumModel, clp_labels: List[str], matrix: np.ndarray, index: float
+) -> Tuple[List[str], np.ndarray]:
     for constraint in model.spectral_constraints:
         if isinstance(constraint, (OnlyConstraint, ZeroConstraint)) and constraint.applies(index):
             idx = [not label == constraint.compartment for label in clp_labels]

--- a/glotaran/builtin/models/kinetic_spectrum/spectral_penalties.py
+++ b/glotaran/builtin/models/kinetic_spectrum/spectral_penalties.py
@@ -1,17 +1,23 @@
 """This package contains compartment constraint items."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from typing import List
 from typing import Tuple
-from typing import TypeVar
-from typing import Union
 
 import numpy as np
 
 from glotaran.model import model_attribute
 from glotaran.parameter import Parameter
-from glotaran.parameter import ParameterGroup
 
-T_KineticSpectrumModel = TypeVar("glotaran.builtin.models.kinetic_spectrum.KineticSpectrumModel")
+if TYPE_CHECKING:
+    from typing import Any
+    from typing import Union
+
+    from glotaran.parameter import ParameterGroup
+
+    from .kinetic_spectrum_model import KineticSpectrumModel
 
 
 @model_attribute(
@@ -30,13 +36,13 @@ class EqualAreaPenalty:
     of the e matrix of one or more target compartmants to resiudal. The additional
     residual is scaled with the weight."""
 
-    def applies(self, index: any) -> bool:
+    def applies(self, index: Any) -> bool:
         """
-        Returns true if the indexx is in one of the intervals.
+        Returns true if the index is in one of the intervals.
 
         Parameters
         ----------
-        index : any
+        index :
 
         Returns
         -------
@@ -52,12 +58,12 @@ class EqualAreaPenalty:
         return any([applies(i) for i in self.interval])
 
 
-def has_spectral_penalties(model: T_KineticSpectrumModel) -> bool:
+def has_spectral_penalties(model: KineticSpectrumModel) -> bool:
     return len(model.equal_area_penalties) != 0
 
 
 def apply_spectral_penalties(
-    model: T_KineticSpectrumModel,
+    model: KineticSpectrumModel,
     parameter: ParameterGroup,
     clp_labels: Union[List[str], List[List[str]]],
     clps: np.ndarray,

--- a/glotaran/builtin/models/kinetic_spectrum/spectral_relations.py
+++ b/glotaran/builtin/models/kinetic_spectrum/spectral_relations.py
@@ -1,16 +1,21 @@
 """ Glotaran Spectral Relation """
+from __future__ import annotations
 
-import typing
+from typing import TYPE_CHECKING
+from typing import List
+from typing import Tuple
 
 import numpy as np
 
 from glotaran.model import model_attribute
 from glotaran.parameter import Parameter
-from glotaran.parameter import ParameterGroup
 
-T_KineticSpectrumModel = typing.TypeVar(
-    "glotaran.builtin.models.kinetic_spectrum.KineticSpectrumModel"
-)
+if TYPE_CHECKING:
+    from typing import Any
+
+    from glotaran.parameter import ParameterGroup
+
+    from .kinetic_spectrum_model import KineticSpectrumModel
 
 
 @model_attribute(
@@ -18,18 +23,18 @@ T_KineticSpectrumModel = typing.TypeVar(
         "compartment": str,
         "target": str,
         "parameter": Parameter,
-        "interval": typing.List[typing.Tuple[float, float]],
+        "interval": List[Tuple[float, float]],
     },
     no_label=True,
 )
 class SpectralRelation:
-    def applies(self, index: any) -> bool:
+    def applies(self, index: Any) -> bool:
         """
         Returns true if the index is in one of the intervals.
 
         Parameters
         ----------
-        index : any
+        index :
 
         Returns
         -------
@@ -40,12 +45,12 @@ class SpectralRelation:
 
 
 def create_spectral_relation_matrix(
-    model: T_KineticSpectrumModel,
+    model: KineticSpectrumModel,
     parameter: ParameterGroup,
-    clp_labels: typing.List[str],
+    clp_labels: List[str],
     matrix: np.ndarray,
     index: float,
-) -> typing.Tuple[typing.List[str], np.ndarray]:
+) -> Tuple[List[str], np.ndarray]:
     relation_matrix = np.diagflat([1.0 for _ in clp_labels])
 
     idx_to_delete = []
@@ -63,12 +68,12 @@ def create_spectral_relation_matrix(
 
 
 def apply_spectral_relations(
-    model: T_KineticSpectrumModel,
+    model: KineticSpectrumModel,
     parameter: ParameterGroup,
-    clp_labels: typing.List[str],
+    clp_labels: List[str],
     matrix: np.ndarray,
     index: float,
-) -> typing.Tuple[typing.List[str], np.ndarray]:
+) -> Tuple[List[str], np.ndarray]:
 
     if not model.spectral_relations:
         return (clp_labels, matrix)
@@ -83,12 +88,12 @@ def apply_spectral_relations(
 
 
 def retrieve_related_clps(
-    model: T_KineticSpectrumModel,
+    model: KineticSpectrumModel,
     parameter: ParameterGroup,
-    clp_labels: typing.List[str],
+    clp_labels: List[str],
     clps: np.ndarray,
     index: float,
-) -> typing.Tuple[typing.List[str], np.ndarray]:
+) -> Tuple[List[str], np.ndarray]:
 
     for relation in model.spectral_relations:
         if relation.compartment in clp_labels and relation.applies(index):

--- a/glotaran/model/attribute.py
+++ b/glotaran/model/attribute.py
@@ -1,21 +1,32 @@
 """The model attribute decorator."""
+from __future__ import annotations
 
 import copy
-import typing
+from typing import TYPE_CHECKING
 
-import glotaran
 from glotaran.parameter import Parameter
-from glotaran.parameter import ParameterGroup
 
 from .property import ModelProperty
 from .util import wrap_func_as_method
 
+if TYPE_CHECKING:
+    from typing import Any
+    from typing import Callable
+    from typing import Dict
+    from typing import List
+    from typing import Type
+    from typing import Union
+
+    from glotaran.parameter import ParameterGroup
+
+    from .base_model import Model
+
 
 def model_attribute(
-    properties: typing.Union[typing.Any, typing.Dict[str, typing.Dict[str, typing.Any]]] = {},
+    properties: Union[Any, Dict[str, Dict[str, Any]]] = {},
     has_type: bool = False,
     no_label: bool = False,
-) -> typing.Callable:
+) -> Callable:
     """The `@model_attribute` decorator adds the given properties to the class. Further it adds
     classmethods for deserialization, validation and printing.
 
@@ -112,7 +123,7 @@ def model_attribute(
     return decorator
 
 
-def model_attribute_typed(types: typing.Dict[str, any] = {}, no_label=False):
+def model_attribute_typed(types: Dict[str, Any] = {}, no_label=False):
     """The model_attribute_typed decorator adds attributes to the class to enable
     the glotaran model parser to infer the correct class for an item when there
     are multiple variants.
@@ -144,7 +155,7 @@ def model_attribute_typed(types: typing.Dict[str, any] = {}, no_label=False):
 def _create_add_type_func(cls):
     @classmethod
     @wrap_func_as_method(cls)
-    def add_type(cls, type_name: str, type: typing.Type):
+    def add_type(cls, type_name: str, type: Type):
         getattr(cls, "_glotaran_model_attribute_types")[type_name] = type
 
     return add_type
@@ -163,7 +174,7 @@ def _create_init_func(cls):
 def _create_from_dict_func(cls):
     @classmethod
     @wrap_func_as_method(cls)
-    def from_dict(ncls, values: typing.Dict) -> cls:
+    def from_dict(ncls, values: Dict) -> cls:
         f"""Creates an instance of {cls.__name__} from a dictionary of values.
 
         Intended only for internal use.
@@ -190,7 +201,7 @@ def _create_from_dict_func(cls):
 def _create_from_list_func(cls):
     @classmethod
     @wrap_func_as_method(cls)
-    def from_list(ncls, values: typing.List) -> cls:
+    def from_list(ncls, values: List) -> cls:
         f"""Creates an instance of {cls.__name__} from a list of values. Intended only for internal use.
 
         Parameters
@@ -215,7 +226,7 @@ def _create_from_list_func(cls):
 
 def _create_validation_func(cls):
     @wrap_func_as_method(cls)
-    def validate(self, model, parameter=None) -> typing.List[str]:
+    def validate(self, model: Model, parameter=None) -> List[str]:
         f"""Creates a list of parameters needed by this instance of {cls.__name__} not present in a
         set of parameters.
 
@@ -240,7 +251,7 @@ def _create_validation_func(cls):
 
 def _create_fill_func(cls):
     @wrap_func_as_method(cls)
-    def fill(self, model: "glotaran.model.BaseModel", parameter: ParameterGroup) -> cls:
+    def fill(self, model: Model, parameter: ParameterGroup) -> cls:
         """Returns a copy of the {cls._name} instance with all members which are Parameters are
         replaced by the value of the corresponding parameter in the parameter group.
 


### PR DESCRIPTION
This PR fixes all 'not valid as a type' type errors mypy trows and makes some module member exports more pythonic.

It reduces the type checking errors from [199](https://github.com/glotaran/pyglotaran/pull/444/checks?check_run_id=1458384107) to [183](https://github.com/s-weigand/pyglotaran/runs/1459302847?check_suite_focus=true).

In some cases `any` (builtin function) was used as type of index so I replaced them with of `typing.Any`.
But I think it should be `int` or `Union[int, float]`.
Also since the implementation of the interval checking is always the same it can be refactored to a helper function.

And
```python
def applies(interval):
    return interval[0] <= index <= interval[1]
```
should be 
```python
def applies(interval):
    return min(interval) <= index <= max(interval)
```
or there should be some validation e.g.
```python
if not math.isclose(interval[0], min(interval)):
    raise ValueError(f"Interval needs to be ordered. Got {interval}")
```
