### PR TITLE
Run test_optimization in single-threaded dask mode

### DIFF
--- a/glotaran/analysis/test/test_optimization.py
+++ b/glotaran/analysis/test/test_optimization.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import dask
 import numpy as np
 import pytest
 import xarray as xr
@@ -7,6 +8,7 @@ import xarray as xr
 from glotaran.analysis.optimize import optimize
 from glotaran.analysis.scheme import Scheme
 from glotaran.analysis.simulation import simulate
+from glotaran.analysis.test.mock import MockMegacomplex
 from glotaran.model import DatasetDescriptor
 from glotaran.model import Model
 from glotaran.model import model
@@ -14,7 +16,7 @@ from glotaran.model import model_attribute
 from glotaran.parameter import Parameter
 from glotaran.parameter import ParameterGroup
 
-from .mock import MockMegacomplex
+dask.config.set(scheduler="single-threaded")
 
 
 def calculate_kinetic(dataset_descriptor=None, axis=None, index=None, extra_stuff=None):


### PR DESCRIPTION
Fix relative import to absolute import for convenience and consistency

In test_optimization run dask in single threaded mode. 
At least under Windows 10 with python 3.8.6 it's unusably slow otherwise.

**Testing**

Passed all tests, and much faster too. ^^

**Closing issues**

closes #458 
