### PR TITLE
Add stubs for runtime patched objects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,9 @@ repos:
     rev: 5.6.4
     hooks:
       - id: isort
+        types: [file]
+        types_or: [python, pyi]
+        minimum_pre_commit_version: 2.9.0
 
   # - repo: https://github.com/PyCQA/pydocstyle
   #   rev: 5.1.1

--- a/glotaran/builtin/models/kinetic_image/initial_concentration.pyi
+++ b/glotaran/builtin/models/kinetic_image/initial_concentration.pyi
@@ -1,0 +1,21 @@
+from typing import List
+
+from glotaran.model import DatasetDescriptor
+from glotaran.model import model_attribute
+from glotaran.parameter import Parameter
+
+class InitialConcentration:
+    @property
+    def compartments(self) -> List[str]:
+        ...
+
+    @property
+    def parameters(self) -> List[Parameter]:
+        ...
+
+    @property
+    def exclude_from_normalize(self) -> List[Parameter]:
+        ...
+
+    def normalized(self, dataset: DatasetDescriptor) -> InitialConcentration:
+        ...

--- a/glotaran/builtin/models/kinetic_image/irf.pyi
+++ b/glotaran/builtin/models/kinetic_image/irf.pyi
@@ -1,0 +1,50 @@
+from typing import Any
+from typing import List
+from typing import Type
+
+from glotaran.model import model_attribute
+from glotaran.model import model_attribute_typed
+from glotaran.parameter import Parameter
+
+class IrfMeasured:
+    ...
+
+
+class IrfMultiGaussian:
+    @property
+    def center(self) -> List[Parameter]:
+        ...
+
+    @property
+    def width(self) -> List[Parameter]:
+        ...
+
+    @property
+    def scale(self) -> List[Parameter]:
+        ...
+
+    @property
+    def backsweep_period(self) -> Parameter:
+        ...
+
+    def parameter(self, index: Any):
+        ...
+
+    def calculate(self, index: Any, axis: Any):
+        ...
+
+
+class IrfGaussian(IrfMultiGaussian):
+    @property
+    def center(self) -> Parameter:
+        ...
+
+    @property
+    def width(self) -> Parameter:
+        ...
+
+
+class Irf:
+    @classmethod
+    def add_type(cls, type_name: str, type: Type) -> None:
+        ...

--- a/glotaran/builtin/models/kinetic_image/k_matrix.pyi
+++ b/glotaran/builtin/models/kinetic_image/k_matrix.pyi
@@ -1,0 +1,56 @@
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+
+import numpy as np
+
+from glotaran.model import model_attribute
+from glotaran.parameter import Parameter
+
+from .initial_concentration import InitialConcentration
+
+class KMatrix:
+    @classmethod
+    def empty(cls: Any, label: str, compartments: List[str]) -> KMatrix:
+        ...
+
+    def involved_compartments(self) -> List[str]:
+        ...
+
+    def combine(self, k_matrix: KMatrix) -> KMatrix:
+        ...
+
+    def matrix_as_markdown(self, compartments: List[str] = ..., fill_parameter: bool = ...) -> str:
+        ...
+
+    def a_matrix_as_markdown(self, initial_concentration: InitialConcentration) -> str:
+        ...
+
+    def reduced(self, compartments: List[str]) -> np.ndarray:
+        ...
+
+    def full(self, compartments: List[str]) -> np.ndarray:
+        ...
+
+    def eigen(self, compartments: List[str]) -> Tuple[np.ndarray, np.ndarray]:
+        ...
+
+    def rates(self, initial_concentration: InitialConcentration) -> np.ndarray:
+        ...
+
+    def a_matrix(self, initial_concentration: InitialConcentration) -> np.ndarray:
+        ...
+
+    def a_matrix_non_unibranch(self, initial_concentration: InitialConcentration) -> np.ndarray:
+        ...
+
+    def a_matrix_unibranch(self, initial_concentration: InitialConcentration) -> np.array:
+        ...
+
+    def is_unibranched(self, initial_concentration: InitialConcentration) -> bool:
+        ...
+
+    @property
+    def matrix(self) -> Dict[Tuple[str, str], Parameter]:
+        ...

--- a/glotaran/builtin/models/kinetic_image/kinetic_image_dataset_descriptor.pyi
+++ b/glotaran/builtin/models/kinetic_image/kinetic_image_dataset_descriptor.pyi
@@ -1,0 +1,21 @@
+from glotaran.model import DatasetDescriptor
+from glotaran.model import model_attribute
+
+class KineticImageDatasetDescriptor(DatasetDescriptor):
+    @property
+    def initial_concentration(self) -> str:
+        ...
+
+    @property
+    def irf(self) -> str:
+        ...
+
+    @property
+    def baseline(self) -> bool:
+        ...
+
+    def get_k_matrices(self):
+        ...
+
+    def compartments(self):
+        ...

--- a/glotaran/builtin/models/kinetic_image/kinetic_image_megacomplex.pyi
+++ b/glotaran/builtin/models/kinetic_image/kinetic_image_megacomplex.pyi
@@ -1,0 +1,22 @@
+from typing import Any
+from typing import List
+from typing import Optional
+
+from glotaran.model import model_attribute
+from glotaran.parameter import Parameter
+
+class KineticImageMegacomplex:
+    @property
+    def k_matrix(self) -> List[str]:
+        ...
+
+    @property
+    def scale(self) -> Parameter:
+        ...
+
+    def full_k_matrix(self, model: Optional[Any] = ...):
+        ...
+
+    @property
+    def involved_compartments(self):
+        ...

--- a/glotaran/builtin/models/kinetic_image/kinetic_image_model.pyi
+++ b/glotaran/builtin/models/kinetic_image/kinetic_image_model.pyi
@@ -1,6 +1,6 @@
 from typing import Any
-from typing import Dict
 from typing import List
+from typing import Mapping
 from typing import Tuple
 from typing import Union
 
@@ -18,8 +18,8 @@ from .kinetic_image_megacomplex import KineticImageMegacomplex
 from .kinetic_image_result import finalize_kinetic_image_result
 
 class KineticImageModel(Model):
-    dataset: Dict[str, KineticImageDatasetDescriptor]  # type: ignore[assignment]
-    megacomplex: Dict[str, KineticImageMegacomplex]
+    dataset: Mapping[str, KineticImageDatasetDescriptor]
+    megacomplex: Mapping[str, KineticImageMegacomplex]
 
     @staticmethod
     def matrix(  # type: ignore[override]
@@ -28,13 +28,13 @@ class KineticImageModel(Model):
         ...
 
     @property
-    def initial_concentration(self) -> Dict[str, InitialConcentration]:
+    def initial_concentration(self) -> Mapping[str, InitialConcentration]:
         ...
 
     @property
-    def k_matrix(self) -> Dict[str, KMatrix]:
+    def k_matrix(self) -> Mapping[str, KMatrix]:
         ...
 
     @property
-    def irf(self) -> Dict[str, Irf]:
+    def irf(self) -> Mapping[str, Irf]:
         ...

--- a/glotaran/builtin/models/kinetic_image/kinetic_image_model.pyi
+++ b/glotaran/builtin/models/kinetic_image/kinetic_image_model.pyi
@@ -1,0 +1,40 @@
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
+
+import numpy as np
+
+from glotaran.model import Model
+from glotaran.model import model
+
+from .initial_concentration import InitialConcentration
+from .irf import Irf
+from .k_matrix import KMatrix
+from .kinetic_image_dataset_descriptor import KineticImageDatasetDescriptor
+from .kinetic_image_matrix import kinetic_image_matrix
+from .kinetic_image_megacomplex import KineticImageMegacomplex
+from .kinetic_image_result import finalize_kinetic_image_result
+
+class KineticImageModel(Model):
+    dataset: Dict[str, KineticImageDatasetDescriptor]  # type: ignore[assignment]
+    megacomplex: Dict[str, KineticImageMegacomplex]
+
+    @staticmethod
+    def matrix(  # type: ignore[override]
+        dataset_descriptor: KineticImageDatasetDescriptor = None, axis=None, index=None, irf=None
+    ) -> Union[Tuple[None, None], Tuple[List[Any], np.ndarray]]:
+        ...
+
+    @property
+    def initial_concentration(self) -> Dict[str, InitialConcentration]:
+        ...
+
+    @property
+    def k_matrix(self) -> Dict[str, KMatrix]:
+        ...
+
+    @property
+    def irf(self) -> Dict[str, Irf]:
+        ...

--- a/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_dataset_descriptor.pyi
+++ b/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_dataset_descriptor.pyi
@@ -1,0 +1,11 @@
+from typing import Dict
+
+from glotaran.builtin.models.kinetic_image.kinetic_image_dataset_descriptor import (
+    KineticImageDatasetDescriptor,
+)
+from glotaran.model import model_attribute
+
+class KineticSpectrumDatasetDescriptor(KineticImageDatasetDescriptor):
+    @property
+    def shape(self) -> Dict[str, str]:
+        ...

--- a/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_model.py
+++ b/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_model.py
@@ -25,6 +25,7 @@ from .spectral_shape import SpectralShape
 
 if TYPE_CHECKING:
     from typing import List
+    from typing import Tuple
     from typing import Union
 
     from glotaran.parameter import ParameterGroup
@@ -40,7 +41,7 @@ def apply_kinetic_model_constraints(
     clp_labels: List[str],
     matrix: np.ndarray,
     index: float,
-):
+) -> Tuple[List[str], np.ndarray]:
     clp_labels, matrix = apply_spectral_relations(model, parameter, clp_labels, matrix, index)
     clp_labels, matrix = apply_spectral_constraints(model, clp_labels, matrix, index)
     return clp_labels, matrix
@@ -64,7 +65,7 @@ def retrieve_spectral_clps(
     return full_clps
 
 
-def index_dependent(model: KineticSpectrumModel):
+def index_dependent(model: KineticSpectrumModel) -> bool:
     if any(
         isinstance(irf, IrfSpectralMultiGaussian) and irf.dispersion_center is not None
         for irf in model.irf.values()

--- a/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_model.pyi
+++ b/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_model.pyi
@@ -1,0 +1,123 @@
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
+
+import numpy as np
+
+from glotaran.model import model
+from glotaran.parameter import ParameterGroup
+
+from ..kinetic_image.kinetic_image_megacomplex import KineticImageMegacomplex
+from ..kinetic_image.kinetic_image_model import KineticImageModel
+from .kinetic_spectrum_dataset_descriptor import KineticSpectrumDatasetDescriptor
+from .kinetic_spectrum_matrix import kinetic_spectrum_matrix
+from .kinetic_spectrum_result import finalize_kinetic_spectrum_result
+from .spectral_constraints import SpectralConstraint
+from .spectral_constraints import apply_spectral_constraints
+from .spectral_irf import IrfSpectralMultiGaussian
+from .spectral_matrix import spectral_matrix
+from .spectral_penalties import EqualAreaPenalty
+from .spectral_penalties import apply_spectral_penalties
+from .spectral_penalties import has_spectral_penalties
+from .spectral_relations import SpectralRelation
+from .spectral_relations import apply_spectral_relations
+from .spectral_relations import retrieve_related_clps
+from .spectral_shape import SpectralShape
+
+def has_kinetic_model_constraints(model: KineticSpectrumModel) -> bool:
+    ...
+
+
+def apply_kinetic_model_constraints(
+    model: KineticSpectrumModel,
+    parameter: ParameterGroup,
+    clp_labels: List[str],
+    matrix: np.ndarray,
+    index: float,
+) -> Any:
+    ...
+
+
+def retrieve_spectral_clps(
+    model: KineticSpectrumModel,
+    parameter: ParameterGroup,
+    clp_labels: List[str],
+    reduced_clp_labels: List[str],
+    reduced_clps: Union[np.ndarray, List[np.ndarray]],
+    global_axis: np.ndarray,
+) -> Any:
+    ...
+
+
+def index_dependent(model: KineticSpectrumModel) -> Any:
+    ...
+
+
+def grouped(model: KineticSpectrumModel) -> bool:
+    ...
+
+
+class KineticSpectrumModel(KineticImageModel):
+    dataset: Dict[str, KineticSpectrumDatasetDescriptor]  # type: ignore[assignment]
+    megacomplex: Dict[str, KineticImageMegacomplex]
+
+    @property
+    def equal_area_penalties(self) -> List[EqualAreaPenalty]:
+        ...
+
+    @property
+    def shape(self) -> Dict[str, SpectralShape]:
+        ...
+
+    @property
+    def spectral_constraints(self) -> List[SpectralConstraint]:
+        ...
+
+    @property
+    def spectral_relations(self) -> List[SpectralRelation]:
+        ...
+
+    def has_matrix_constraints_function(self) -> bool:
+        ...
+
+    def constrain_matrix_function(
+        self, parameter: ParameterGroup, clp_labels: List[str], matrix: np.ndarray, index: float
+    ) -> Tuple[List[str], np.ndarray]:
+        ...
+
+    def retrieve_clp_function(
+        self,
+        parameter: ParameterGroup,
+        clp_labels: List[str],
+        reduced_clp_labels: List[str],
+        reduced_clps: Union[np.ndarray, List[np.ndarray]],
+        global_axis: np.ndarray,
+    ) -> Union[np.ndarray, List[np.ndarray]]:
+        ...
+
+    def has_additional_penalty_function(self) -> bool:
+        ...
+
+    def additional_penalty_function(
+        self,
+        parameter: ParameterGroup,
+        clp_labels: Union[List[str], List[List[str]]],
+        clps: np.ndarray,
+        global_axis: np.ndarray,
+    ) -> np.ndarray:
+        ...
+
+    @staticmethod
+    def global_matrix(dataset, axis) -> Union[Tuple[None, None], Tuple[List[str], np.ndarray]]:  # type: ignore[override]
+        ...
+
+    @staticmethod
+    def matrix(  # type: ignore[override]
+        dataset_descriptor: KineticSpectrumDatasetDescriptor = None,
+        axis=None,
+        index=None,
+        irf=None,
+    ) -> Union[Tuple[None, None], Tuple[List[Any], np.ndarray]]:
+        ...

--- a/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_model.pyi
+++ b/glotaran/builtin/models/kinetic_spectrum/kinetic_spectrum_model.pyi
@@ -1,6 +1,6 @@
 from typing import Any
-from typing import Dict
 from typing import List
+from typing import Mapping
 from typing import Tuple
 from typing import Union
 
@@ -60,15 +60,15 @@ def grouped(model: KineticSpectrumModel) -> bool:
 
 
 class KineticSpectrumModel(KineticImageModel):
-    dataset: Dict[str, KineticSpectrumDatasetDescriptor]  # type: ignore[assignment]
-    megacomplex: Dict[str, KineticImageMegacomplex]
+    dataset: Mapping[str, KineticSpectrumDatasetDescriptor]
+    megacomplex: Mapping[str, KineticImageMegacomplex]
 
     @property
     def equal_area_penalties(self) -> List[EqualAreaPenalty]:
         ...
 
     @property
-    def shape(self) -> Dict[str, SpectralShape]:
+    def shape(self) -> Mapping[str, SpectralShape]:
         ...
 
     @property

--- a/glotaran/builtin/models/kinetic_spectrum/spectral_constraints.pyi
+++ b/glotaran/builtin/models/kinetic_spectrum/spectral_constraints.pyi
@@ -1,0 +1,45 @@
+from typing import Any
+from typing import List
+from typing import Tuple
+
+import numpy as np
+
+from glotaran.model import model_attribute
+from glotaran.model import model_attribute_typed
+
+from .kinetic_spectrum_model import KineticSpectrumModel
+
+class OnlyConstraint:
+    @property
+    def compartment(self) -> str:
+        ...
+
+    @property
+    def interval(self) -> List[Tuple[float, float]]:
+        ...
+
+    def applies(self, index: Any) -> bool:
+        ...
+
+
+class ZeroConstraint:
+    @property
+    def compartment(self) -> str:
+        ...
+
+    @property
+    def interval(self) -> List[Tuple[float, float]]:
+        ...
+
+    def applies(self, index: Any) -> bool:
+        ...
+
+
+class SpectralConstraint:
+    ...
+
+
+def apply_spectral_constraints(
+    model: KineticSpectrumModel, clp_labels: List[str], matrix: np.ndarray, index: float
+) -> Tuple[List[str], np.ndarray]:
+    ...

--- a/glotaran/builtin/models/kinetic_spectrum/spectral_irf.pyi
+++ b/glotaran/builtin/models/kinetic_spectrum/spectral_irf.pyi
@@ -1,0 +1,58 @@
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+
+from glotaran.builtin.models.kinetic_image.irf import Irf
+from glotaran.builtin.models.kinetic_image.irf import IrfMultiGaussian
+from glotaran.model import model_attribute
+from glotaran.parameter import Parameter
+
+class IrfSpectralMultiGaussian(IrfMultiGaussian):
+    @property
+    def dispersion_center(self) -> Parameter:
+        ...
+
+    @property
+    def center_dispersion(self) -> List[Parameter]:
+        ...
+
+    @property
+    def width_dispersion(self) -> List[Parameter]:
+        ...
+
+    @property
+    def model_dispersion_with_wavenumber(self) -> bool:
+        ...
+
+    def parameter(self, index: Any):
+        ...
+
+    def calculate_dispersion(self, axis: Any):
+        ...
+
+
+class IrfSpectralGaussian(IrfSpectralMultiGaussian):
+    @property
+    def center(self) -> Parameter:
+        ...
+
+    @property
+    def width(self) -> Parameter:
+        ...
+
+
+class IrfGaussianCoherentArtifact(IrfSpectralGaussian):
+    @property
+    def coherent_artifact_order(self) -> int:
+        ...
+
+    @property
+    def coherent_artifact_width(self) -> Parameter:
+        ...
+
+    def clp_labels(self):
+        ...
+
+    def calculate_coherent_artifact(self, axis: Any):
+        ...

--- a/glotaran/builtin/models/kinetic_spectrum/spectral_penalties.pyi
+++ b/glotaran/builtin/models/kinetic_spectrum/spectral_penalties.pyi
@@ -1,0 +1,50 @@
+from typing import Any
+from typing import List
+from typing import Tuple
+from typing import Union
+
+import numpy as np
+
+from glotaran.model import model_attribute
+from glotaran.parameter import Parameter
+from glotaran.parameter import ParameterGroup
+
+from .kinetic_spectrum_model import KineticSpectrumModel
+
+class EqualAreaPenalty:
+    @property
+    def compartment(self) -> str:
+        ...
+
+    @property
+    def interval(self) -> List[Tuple[float, float]]:
+        ...
+
+    @property
+    def target(self) -> str:
+        ...
+
+    @property
+    def parameter(self) -> Parameter:
+        ...
+
+    @property
+    def weight(self) -> str:
+        ...
+
+    def applies(self, index: Any) -> bool:
+        ...
+
+
+def has_spectral_penalties(model: KineticSpectrumModel) -> bool:
+    ...
+
+
+def apply_spectral_penalties(
+    model: KineticSpectrumModel,
+    parameter: ParameterGroup,
+    clp_labels: Union[List[str], List[List[str]]],
+    clps: np.ndarray,
+    global_axis: np.ndarray,
+) -> np.ndarray:
+    ...

--- a/glotaran/builtin/models/kinetic_spectrum/spectral_relations.pyi
+++ b/glotaran/builtin/models/kinetic_spectrum/spectral_relations.pyi
@@ -1,0 +1,61 @@
+from typing import Any
+from typing import List
+from typing import Tuple
+
+import numpy as np
+
+from glotaran.model import model_attribute
+from glotaran.parameter import Parameter
+from glotaran.parameter import ParameterGroup
+
+from .kinetic_spectrum_model import KineticSpectrumModel
+
+class SpectralRelation:
+    @property
+    def compartment(self) -> str:
+        ...
+
+    @property
+    def target(self) -> str:
+        ...
+
+    @property
+    def parameter(self) -> Parameter:
+        ...
+
+    @property
+    def interval(self) -> List[Tuple[float, float]]:
+        ...
+
+    def applies(self, index: Any) -> bool:
+        ...
+
+
+def create_spectral_relation_matrix(
+    model: KineticSpectrumModel,
+    parameter: ParameterGroup,
+    clp_labels: List[str],
+    matrix: np.ndarray,
+    index: float,
+) -> Tuple[List[str], np.ndarray]:
+    ...
+
+
+def apply_spectral_relations(
+    model: KineticSpectrumModel,
+    parameter: ParameterGroup,
+    clp_labels: List[str],
+    matrix: np.ndarray,
+    index: float,
+) -> Tuple[List[str], np.ndarray]:
+    ...
+
+
+def retrieve_related_clps(
+    model: KineticSpectrumModel,
+    parameter: ParameterGroup,
+    clp_labels: List[str],
+    clps: np.ndarray,
+    index: float,
+) -> Tuple[List[str], np.ndarray]:
+    ...

--- a/glotaran/builtin/models/kinetic_spectrum/spectral_shape.pyi
+++ b/glotaran/builtin/models/kinetic_spectrum/spectral_shape.pyi
@@ -1,0 +1,26 @@
+from typing import Type
+
+import numpy as np
+
+from glotaran.model import model_attribute
+from glotaran.model import model_attribute_typed
+from glotaran.parameter import Parameter
+
+class SpectralShapeGaussian:
+    @property
+    def amplitude(self) -> Parameter: ...
+    @property
+    def location(self) -> Parameter: ...
+    @property
+    def width(self) -> Parameter: ...
+    def calculate(self, axis: np.ndarray) -> np.ndarray: ...
+
+class SpectralShapeOne:
+    def calculate(self, axis: np.ndarray) -> np.ndarray: ...
+
+class SpectralShapeZero:
+    def calculate(self, axis: np.ndarray) -> np.ndarray: ...
+
+class SpectralShape:
+    @classmethod
+    def add_type(cls, type_name: str, type: Type) -> None: ...

--- a/glotaran/model/base_model.pyi
+++ b/glotaran/model/base_model.pyi
@@ -76,18 +76,6 @@ class Model:
     ) -> xr.Dataset:
         ...
 
-    def optimize(
-        self,
-        parameter: ParameterGroup,
-        data: Dict[str, Union[xr.Dataset, xr.DataArray]],
-        nnls: bool = ...,
-        verbose: bool = ...,
-        max_nfev: int = ...,
-        group_tolerance: int = ...,
-        client: Any = ...,
-    ) -> Result:
-        ...
-
     def result_from_parameter(
         self,
         parameter: ParameterGroup,

--- a/glotaran/model/base_model.pyi
+++ b/glotaran/model/base_model.pyi
@@ -2,6 +2,8 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import List
+from typing import Mapping
+from typing import Optional
 from typing import Tuple
 from typing import Type
 from typing import TypeVar
@@ -25,13 +27,13 @@ Cls = TypeVar("Cls")
 
 class Model:
     _model_type: str
-    dataset: Dict[str, DatasetDescriptor]
+    dataset: Mapping[str, DatasetDescriptor]
     megacomplex: Any
     weights: Weight
     model_dimension: str
     global_dimension: str
     global_matrix = None
-    finalize_data = FinalizeFunction
+    finalize_data: Optional[FinalizeFunction] = None
     grouped: Callable[[Type[Model]], bool]
     index_dependent: Callable[[Type[Model]], bool]
 
@@ -39,6 +41,15 @@ class Model:
     def matrix(
         dataset_descriptor: DatasetDescriptor = None, axis=None, index=None
     ) -> Union[Tuple[None, None], Tuple[List[Any], np.ndarray]]:
+        ...
+
+    def add_megacomplex(self, item: Any):
+        ...
+
+    def add_weights(self, item: Weight):
+        ...
+
+    def get_dataset(self, label: str) -> DatasetDescriptor:
         ...
 
     @classmethod

--- a/glotaran/model/base_model.pyi
+++ b/glotaran/model/base_model.pyi
@@ -1,0 +1,99 @@
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
+from typing import Union
+
+import numpy as np
+import xarray as xr
+
+from glotaran.analysis.optimize import optimize
+from glotaran.analysis.result import Result
+from glotaran.analysis.scheme import Scheme
+from glotaran.analysis.simulation import simulate
+from glotaran.parameter import ParameterGroup
+
+from .dataset_descriptor import DatasetDescriptor
+from .decorator import FinalizeFunction
+from .weight import Weight
+
+Cls = TypeVar("Cls")
+
+
+class Model:
+    _model_type: str
+    dataset: Dict[str, DatasetDescriptor]
+    megacomplex: Any
+    weights: Weight
+    model_dimension: str
+    global_dimension: str
+    global_matrix = None
+    finalize_data = FinalizeFunction
+    grouped: Callable[[Type[Model]], bool]
+    index_dependent: Callable[[Type[Model]], bool]
+
+    @staticmethod
+    def matrix(
+        dataset_descriptor: DatasetDescriptor = None, axis=None, index=None
+    ) -> Union[Tuple[None, None], Tuple[List[Any], np.ndarray]]:
+        ...
+
+    @classmethod
+    def from_dict(cls: Type[Cls], model_dict_ref: Dict) -> Cls:
+        ...
+
+    @property
+    def index_depended_matrix(self):
+        ...
+
+    @property
+    def model_type(self) -> str:
+        ...
+
+    def simulate(
+        self,
+        dataset: str,
+        parameter: ParameterGroup,
+        axes: Dict[str, np.ndarray] = ...,
+        clp: Union[np.ndarray, xr.DataArray] = ...,
+        noise: bool = ...,
+        noise_std_dev: float = ...,
+        noise_seed: int = ...,
+    ) -> xr.Dataset:
+        ...
+
+    def optimize(
+        self,
+        parameter: ParameterGroup,
+        data: Dict[str, Union[xr.Dataset, xr.DataArray]],
+        nnls: bool = ...,
+        verbose: bool = ...,
+        max_nfev: int = ...,
+        group_tolerance: int = ...,
+        client: Any = ...,
+    ) -> Result:
+        ...
+
+    def result_from_parameter(
+        self,
+        parameter: ParameterGroup,
+        data: Dict[str, Union[xr.DataArray, xr.Dataset]],
+        nnls: bool = ...,
+        group_atol: float = ...,
+    ) -> Result:
+        ...
+
+    def problem_list(self, parameter: ParameterGroup = ...) -> List[str]:
+        ...
+
+    def validate(self, parameter: ParameterGroup = ...) -> str:
+        ...
+
+    def valid(self, parameter: ParameterGroup = None) -> bool:
+        ...
+
+    def markdown(self, parameter: ParameterGroup = ..., initial: ParameterGroup = ...) -> str:
+        ...

--- a/glotaran/model/dataset_descriptor.pyi
+++ b/glotaran/model/dataset_descriptor.pyi
@@ -1,0 +1,36 @@
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Type
+from typing import TypeVar
+
+from glotaran.model.base_model import Model
+from glotaran.parameter import Parameter
+from glotaran.parameter import ParameterGroup
+
+from .attribute import model_attribute
+
+T_Model = TypeVar("T_Model", bound=Model)
+T_DatasetDescriptor = TypeVar("T_DatasetDescriptor", bound=DatasetDescriptor)
+
+
+class DatasetDescriptor:
+    megacomplex: List[str]
+    scale: Optional[Parameter] = None
+
+    def fill(self, model: T_Model, parameter: ParameterGroup) -> T_DatasetDescriptor:
+        ...
+
+    @classmethod
+    def from_dict(cls: Type[T_DatasetDescriptor], values: Dict) -> T_DatasetDescriptor:
+        ...
+
+    @classmethod
+    def from_list(cls: Type[T_DatasetDescriptor], values: List) -> T_DatasetDescriptor:
+        ...
+
+    def validate(self, model: T_Model, parameter=None) -> List[str]:
+        ...
+
+    def mprint_item(self, parameter: ParameterGroup = None, initial: ParameterGroup = None) -> str:
+        ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,12 @@ exclude = '''
 
 [tool.isort]
 profile = "hug"
-src_paths = ["flake8_nb", "test"]
+src_paths = ["glotaran"]
 include_trailing_comma = true
 line_length = 99
-multi_line_output = 3
 known_first_party = ["glotaran"]
 force_single_line = true
+remove_redundant_aliases = true
 
 [tool.interrogate]
 exclude = ["setup.py", "docs", "*test/*"]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -38,4 +38,4 @@ pytest-benchmark>=3.1.1
 
 # code quality asurence
 flake8>=3.8.3
-pre-commit>=2.6.0
+pre-commit>=2.9.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -36,6 +36,6 @@ pytest-cov>=2.5.1
 pytest-runner>=2.11.1
 pytest-benchmark>=3.1.1
 
-# code quality asurence
+# code quality assurance
 flake8>=3.8.3
 pre-commit>=2.9.0


### PR DESCRIPTION
Due to the [known limitations of mypy](https://github.com/python/mypy/wiki/Unsupported-Python-Features) we need type stub files for the runtime patched objects (Models and Modelattributes) so we get proper type checking.
Those files get ignored by the python runtime and are only evaluated when type checking.

This PR reduces the current typing errors from [183](https://github.com/glotaran/pyglotaran/pull/444/checks?check_run_id=1462988697) to [76](https://github.com/s-weigand/pyglotaran/runs/1476219358?check_suite_focus=true).