### PR TITLE
Replace lmfit with scipy.optimize

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -22,7 +22,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/PyCQA/isort
-    rev: 5.6.4
+    rev: 5.7.0
     hooks:
       - id: isort
         types: [file]

--- a/glotaran/analysis/optimize.py
+++ b/glotaran/analysis/optimize.py
@@ -35,6 +35,9 @@ def optimize_problem(problem: Problem, verbose: bool = True) -> Result:
     ) = problem.scheme.parameter.get_label_value_and_bounds_arrays(exclude_non_vary=True)
     method = SUPPORTED_METHODS[problem.scheme.optimization_method]
     nfev = problem.scheme.nfev
+    ftol = problem.scheme.ftol
+    gtol = problem.scheme.gtol
+    xtol = problem.scheme.xtol
     verbose = 2 if verbose else 0
 
     ls_result = least_squares(
@@ -44,8 +47,9 @@ def optimize_problem(problem: Problem, verbose: bool = True) -> Result:
         method=method,
         max_nfev=nfev,
         verbose=verbose,
-        #  ftol=1.e-7,
-        #  gtol=1.e-7,
+        ftol=ftol,
+        gtol=gtol,
+        xtol=xtol,
         kwargs={"labels": labels, "problem": problem},
     )
 

--- a/glotaran/analysis/problem.py
+++ b/glotaran/analysis/problem.py
@@ -137,6 +137,11 @@ class Problem:
     def parameter(self) -> ParameterGroup:
         return self._parameter
 
+    @parameter.setter
+    def parameter(self, parameter: ParameterGroup):
+        self._parameter = parameter
+        self.reset()
+
     @property
     def grouped(self) -> bool:
         return self._grouped
@@ -247,9 +252,8 @@ class Problem:
             self._full_penalty = np.concatenate(residuals + additional_penalty)
         return self._full_penalty
 
-    @parameter.setter
-    def parameter(self, parameter: ParameterGroup):
-        self._parameter = parameter
+    def reset(self):
+        """Resets all results and `DatasetDescriptors`. Use after updating parameters."""
         self._filled_dataset_descriptors = {
             label: descriptor.fill(self._model, self._parameter)
             for label, descriptor in self._model.dataset.items()

--- a/glotaran/analysis/scheme.py
+++ b/glotaran/analysis/scheme.py
@@ -30,6 +30,9 @@ class Scheme:
         group_tolerance: float = 0.0,
         nnls: bool = False,
         nfev: int = None,
+        ftol: float = 1e-8,
+        gtol: float = 1e-8,
+        xtol: float = 1e-8,
         optimization_method: Literal[
             "TrustRegionReflection",
             "Dogbox",
@@ -41,9 +44,12 @@ class Scheme:
         self.parameter = parameter
         self.data = data
         self.group_tolerance = group_tolerance
-        self.optimization_method = optimization_method
         self.nnls = nnls
         self.nfev = nfev
+        self.ftol = ftol
+        self.gtol = gtol
+        self.xtol = xtol
+        self.optimization_method = optimization_method
 
     @classmethod
     def from_yml_file(cls, filename: str) -> "Scheme":
@@ -94,6 +100,9 @@ class Scheme:
         optimization_method = scheme.get("optimization_method", "TrustRegionReflection")
         nnls = scheme.get("nnls", False)
         nfev = scheme.get("nfev", None)
+        ftol = scheme.get("ftol", 1e-8)
+        gtol = scheme.get("gtol", 1e-8)
+        xtol = scheme.get("xtol", 1e-8)
         group_tolerance = scheme.get("group_tolerance", 0.0)
         return cls(
             model=model,
@@ -101,6 +110,9 @@ class Scheme:
             data=data,
             nnls=nnls,
             nfev=nfev,
+            ftol=ftol,
+            gtol=gtol,
+            xtol=xtol,
             group_tolerance=group_tolerance,
             optimization_method=optimization_method,
         )

--- a/glotaran/analysis/scheme.py
+++ b/glotaran/analysis/scheme.py
@@ -2,6 +2,7 @@ import functools
 import pathlib
 import typing
 import warnings
+from typing import Literal
 
 import numpy as np
 import xarray as xr
@@ -29,12 +30,18 @@ class Scheme:
         group_tolerance: float = 0.0,
         nnls: bool = False,
         nfev: int = None,
+        optimization_method: Literal[
+            "TrustRegionReflection",
+            "Dogbox",
+            "LevenbergMarquart",
+        ] = "TrustRegionReflection",
     ):
 
         self.model = model
         self.parameter = parameter
         self.data = data
         self.group_tolerance = group_tolerance
+        self.optimization_method = optimization_method
         self.nnls = nnls
         self.nfev = nfev
 
@@ -84,6 +91,7 @@ class Scheme:
             except Exception as e:
                 raise ValueError(f"Error loading dataset '{label}': {e}")
 
+        optimization_method = scheme.get("optimization_method", "TrustRegionReflection")
         nnls = scheme.get("nnls", False)
         nfev = scheme.get("nfev", None)
         group_tolerance = scheme.get("group_tolerance", 0.0)
@@ -94,6 +102,7 @@ class Scheme:
             nnls=nnls,
             nfev=nfev,
             group_tolerance=group_tolerance,
+            optimization_method=optimization_method,
         )
 
     @property

--- a/glotaran/analysis/test/test_optimization.py
+++ b/glotaran/analysis/test/test_optimization.py
@@ -60,9 +60,9 @@ def test_optimization(suite, index_dependent, grouped, weight):
     print(result.optimized_parameter)
     print(result.data["dataset1"])
 
-    for _, param in result.optimized_parameter.all():
+    for label, param in result.optimized_parameter.all():
         if param.vary:
-            assert np.allclose(param.value, wanted.get(param.full_label).value, rtol=1e-1)
+            assert np.allclose(param.value, wanted.get(label).value, rtol=1e-1)
 
     resultdata = result.data["dataset1"]
     print(resultdata)

--- a/glotaran/builtin/models/kinetic_spectrum/test/test_kinetic_spectrum_model.py
+++ b/glotaran/builtin/models/kinetic_spectrum/test/test_kinetic_spectrum_model.py
@@ -189,21 +189,21 @@ class ThreeComponentParallel:
             "shape": {
                 "sh1": {
                     "type": "gaussian",
-                    "amplitude": "shape.amps.1",
-                    "location": "shape.locs.1",
-                    "width": "shape.width.1",
+                    "amplitude": "shapes.amps.1",
+                    "location": "shapes.locs.1",
+                    "width": "shapes.width.1",
                 },
                 "sh2": {
                     "type": "gaussian",
-                    "amplitude": "shape.amps.2",
-                    "location": "shape.locs.2",
-                    "width": "shape.width.2",
+                    "amplitude": "shapes.amps.2",
+                    "location": "shapes.locs.2",
+                    "width": "shapes.width.2",
                 },
                 "sh3": {
                     "type": "gaussian",
-                    "amplitude": "shape.amps.3",
-                    "location": "shape.locs.3",
-                    "width": "shape.width.3",
+                    "amplitude": "shapes.amps.3",
+                    "location": "shapes.locs.3",
+                    "width": "shapes.width.3",
                 },
             },
             "irf": {
@@ -242,7 +242,7 @@ class ThreeComponentParallel:
                 ["2", 502e-4],
                 ["3", 705e-5],
             ],
-            "shape": {"amps": [7, 3, 30], "locs": [620, 670, 720], "width": [10, 30, 50]},
+            "shapes": {"amps": [7, 3, 30], "locs": [620, 670, 720], "width": [10, 30, 50]},
             "irf": [["center", 1.3], ["width", 7.8]],
             "j": [["1", 1, {"vary": False, "non-negative": False}]],
         }
@@ -307,21 +307,21 @@ class ThreeComponentSequential:
             "shape": {
                 "sh1": {
                     "type": "gaussian",
-                    "amplitude": "shape.amps.1",
-                    "location": "shape.locs.1",
-                    "width": "shape.width.1",
+                    "amplitude": "shapes.amps.1",
+                    "location": "shapes.locs.1",
+                    "width": "shapes.width.1",
                 },
                 "sh2": {
                     "type": "gaussian",
-                    "amplitude": "shape.amps.2",
-                    "location": "shape.locs.2",
-                    "width": "shape.width.2",
+                    "amplitude": "shapes.amps.2",
+                    "location": "shapes.locs.2",
+                    "width": "shapes.width.2",
                 },
                 "sh3": {
                     "type": "gaussian",
-                    "amplitude": "shape.amps.3",
-                    "location": "shape.locs.3",
-                    "width": "shape.width.3",
+                    "amplitude": "shapes.amps.3",
+                    "location": "shapes.locs.3",
+                    "width": "shapes.width.3",
                 },
             },
             "irf": {
@@ -364,7 +364,7 @@ class ThreeComponentSequential:
                 ["2", 202e-4],
                 ["3", 105e-5],
             ],
-            "shape": {"amps": [3, 1, 5], "locs": [620, 670, 720], "width": [10, 30, 50]},
+            "shapes": {"amps": [3, 1, 5], "locs": [620, 670, 720], "width": [10, 30, 50]},
             "irf": [["center", 1.3], ["width", 7.8]],
             "j": [
                 ["1", 1, {"vary": False, "non-negative": False}],

--- a/glotaran/builtin/models/kinetic_spectrum/test/test_spectral_irf.py
+++ b/glotaran/builtin/models/kinetic_spectrum/test/test_spectral_irf.py
@@ -280,7 +280,7 @@ def test_spectral_irf(suite):
     assert np.array_equal(dataset["spectral"], resultdata["spectral"])
     assert dataset.data.shape == resultdata.data.shape
     assert dataset.data.shape == resultdata.fitted_data.shape
-    assert np.allclose(dataset.data, resultdata.fitted_data, atol=1e-15)
+    assert np.allclose(dataset.data, resultdata.fitted_data, atol=1e-14)
 
     print(resultdata.fitted_data.isel(spectral=0).argmax())
     print(resultdata.fitted_data.isel(spectral=-1).argmax())

--- a/glotaran/builtin/models/kinetic_spectrum/test/test_spectral_penalties.py
+++ b/glotaran/builtin/models/kinetic_spectrum/test/test_spectral_penalties.py
@@ -16,7 +16,7 @@ from glotaran.builtin.models.kinetic_spectrum.spectral_penalties import _get_idx
 from glotaran.io import prepare_time_trace_dataset
 from glotaran.parameter import ParameterGroup
 
-ParameterSpec = namedtuple("ParameterSpec", "base equal_area shape")
+ParameterSpec = namedtuple("ParameterSpec", "base equal_area shapes")
 NoiseSpec = namedtuple("NoiseSpec", "active seed std_dev")
 SimulationSpec = namedtuple("SimulationSpec", "max_nfev noise")
 DatasetSpec = namedtuple("DatasetSpec", "times wavelengths irf shapes")
@@ -134,15 +134,15 @@ def test_equal_area_penalties(debug=False):
         "shape": {
             "sh1": {
                 "type": "gaussian",
-                "amplitude": "shape.amps.1",
-                "location": "shape.locs.1",
-                "width": "shape.width.1",
+                "amplitude": "shapes.amps.1",
+                "location": "shapes.locs.1",
+                "width": "shapes.width.1",
             },
             "sh2": {
                 "type": "gaussian",
-                "amplitude": "shape.amps.2",
-                "location": "shape.locs.2",
-                "width": "shape.width.2",
+                "amplitude": "shapes.amps.2",
+                "location": "shapes.locs.2",
+                "width": "shapes.width.2",
             },
         }
     }
@@ -179,7 +179,7 @@ def test_equal_area_penalties(debug=False):
         "rela": [rela, {"vary": False}],
     }
     pspec_shape = {
-        "shape": {
+        "shapes": {
             "amps": [sh1.amplitude, sh2.amplitude],
             "locs": [sh1.location, sh2.location],
             "width": [sh1.width, sh2.width],
@@ -201,7 +201,7 @@ def test_equal_area_penalties(debug=False):
 
     # %% Parameter specification (pspec)
 
-    pspec_sim = dict(deepcopy(pspec.base), **pspec.shape)
+    pspec_sim = dict(deepcopy(pspec.base), **pspec.shapes)
     param_sim = ParameterGroup.from_dict(pspec_sim)
 
     # For the wp model we create two version of the parameter specification

--- a/glotaran/builtin/models/kinetic_spectrum/test/test_spectral_relations.py
+++ b/glotaran/builtin/models/kinetic_spectrum/test/test_spectral_relations.py
@@ -113,6 +113,10 @@ def test_spectral_relation():
     scheme = Scheme(model=model, parameter=parameter, data=dataset, nfev=20)
     result = optimize(scheme)
 
+    for label, param in result.optimized_parameter.all():
+        if param.vary:
+            assert np.allclose(param.value, parameter.get(label).value, rtol=1e-1)
+
     result_data = result.data["dataset1"]
     print(result_data.species_associated_spectra)
     assert result_data.species_associated_spectra.shape == (1, 4)
@@ -120,9 +124,9 @@ def test_spectral_relation():
         result_data.species_associated_spectra[0, 1]
         == rel1 * result_data.species_associated_spectra[0, 0]
     )
-    assert (
-        result_data.species_associated_spectra[0, 2]
-        == rel2 * result_data.species_associated_spectra[0, 0]
+    assert np.allclose(
+        result_data.species_associated_spectra[0, 2].values,
+        rel2 * result_data.species_associated_spectra[0, 0].values,
     )
 
 

--- a/glotaran/cli/commands/pluginlist.py
+++ b/glotaran/cli/commands/pluginlist.py
@@ -5,10 +5,10 @@ from glotaran.parse.register import known_model_names
 
 
 def plugin_list_cmd():
-    """Prints a list of intalled plugins."""
+    """Prints a list of installed plugins."""
 
     output = """
-Installed Glotaran Plugins:
+    Installed Glotaran Plugins:
 
     Models:
     """

--- a/glotaran/examples/sequential.py
+++ b/glotaran/examples/sequential.py
@@ -27,21 +27,21 @@ sim_model = gta.builtin.models.kinetic_spectrum.KineticSpectrumModel.from_dict(
         "shape": {
             "sh1": {
                 "type": "gaussian",
-                "amplitude": "shape.amps.1",
-                "location": "shape.locs.1",
-                "width": "shape.width.1",
+                "amplitude": "shapes.amps.1",
+                "location": "shapes.locs.1",
+                "width": "shapes.width.1",
             },
             "sh2": {
                 "type": "gaussian",
-                "amplitude": "shape.amps.2",
-                "location": "shape.locs.2",
-                "width": "shape.width.2",
+                "amplitude": "shapes.amps.2",
+                "location": "shapes.locs.2",
+                "width": "shapes.width.2",
             },
             "sh3": {
                 "type": "gaussian",
-                "amplitude": "shape.amps.3",
-                "location": "shape.locs.3",
-                "width": "shape.width.3",
+                "amplitude": "shapes.amps.3",
+                "location": "shapes.locs.3",
+                "width": "shapes.width.3",
             },
         },
         "irf": {
@@ -73,11 +73,7 @@ wanted_parameter = gta.ParameterGroup.from_dict(
             ["2", 0.3],
             ["3", 0.1],
         ],
-        "osc": [
-            ["freq", 25],
-            ["rate", 1],
-        ],
-        "shape": {"amps": [30, 20, 40], "locs": [620, 630, 650], "width": [40, 20, 60]},
+        "shapes": {"amps": [30, 20, 40], "locs": [620, 630, 650], "width": [40, 20, 60]},
         "irf": [["center", 0.3], ["width", 0.1]],
     }
 )

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -326,6 +326,34 @@ class Parameter:
         """Sets the value from an optimization result and reverses non-negative transormation."""
         self.value = np.exp(value) if self.non_negative else value
 
+    def __getstate__(self):
+        """Get state for pickle."""
+        return (
+            self.label,
+            self.full_label,
+            self.expression,
+            self.maximum,
+            self.minimum,
+            self.non_negative,
+            self.stderr,
+            self.value,
+            self.vary,
+        )
+
+    def __setstate__(self, state):
+        """Set state from pickle."""
+        (
+            self.label,
+            self.full_label,
+            self.expression,
+            self.maximum,
+            self.minimum,
+            self.non_negative,
+            self.stderr,
+            self.value,
+            self.vary,
+        ) = state
+
     def _getval(self) -> float:
         return self._value
 

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -1,9 +1,10 @@
 """The parameter class."""
 
-import typing
+from typing import Dict
+from typing import List
+from typing import Union
 
 import numpy as np
-from lmfit import Parameter as LmParameter
 
 import glotaran
 
@@ -11,17 +12,26 @@ import glotaran
 class Keys:
     """Keys for parameter options."""
 
-    MIN = "min"
-    MAX = "max"
-    NON_NEG = "non-negative"
     EXPR = "expr"
+    MAX = "max"
+    MIN = "min"
+    NON_NEG = "non-negative"
     VARY = "vary"
 
 
-class Parameter(LmParameter):
+class Parameter:
     """A parameter for optimization."""
 
-    def __init__(self, label: str = None, full_label: str = None):
+    def __init__(
+        self,
+        label: str = None,
+        full_label: str = None,
+        expression: str = None,
+        maximum: Union[int, float] = np.inf,
+        minimum: Union[int, float] = -np.inf,
+        non_negative: bool = False,
+        vary: bool = True,
+    ):
         """
 
         Parameters
@@ -30,43 +40,49 @@ class Parameter(LmParameter):
             The label of the parameter.
         full_label : str
             The label of the parameter with its path in a parameter group prepended.
-        """
+        """  # TODO: update docstring.
 
-        super().__init__(name=label, user_data={"non_neg": False, "full_label": full_label})
+        super().__init__(name=label, user_data={"non_negative": False, "full_label": full_label})
 
         self.label = label
         self.full_label = full_label
+        self.expression = expression
+        self.maximum = maximum
+        self.minimum = minimum
+        self.non_negative = non_negative
+        self.stderr = 0.0
+        self.vary = vary
 
-    @classmethod
-    def from_parameter(cls, label: str, parameter: LmParameter) -> "Parameter":
-        """Creates a :class:`Parameter` from a `lmfit.Parameter`
-
-        Parameters
-        ----------
-        label : str
-            The label of the parameter.
-        parameter : lmfit.Parameter
-            The `lmfit.Parameter`.
-        """
-        p = cls(label=label)
-        p.vary = parameter.vary
-        p.non_neg = parameter.user_data["non_neg"]
-        p.full_label = parameter.user_data["full_label"]
-        p.value = np.exp(parameter.value) if p.non_neg else parameter.value
-        p.min = (
-            np.exp(parameter.min) if p.non_neg and np.isfinite(parameter.min) else parameter.min
-        )
-        p.max = (
-            np.exp(parameter.max) if p.non_neg and np.isfinite(parameter.max) else parameter.max
-        )
-        p.stderr = parameter.stderr
-        return p
+    #  @classmethod
+    #  def from_parameter(cls, label: str, parameter: LmParameter) -> "Parameter":
+    #      """Creates a :class:`Parameter` from a `lmfit.Parameter`
+    #
+    #      Parameters
+    #      ----------
+    #      label : str
+    #          The label of the parameter.
+    #      parameter : lmfit.Parameter
+    #          The `lmfit.Parameter`.
+    #      """
+    #      p = cls(label=label)
+    #      p.vary = parameter.vary
+    #      p.non_neg = parameter.user_data["non_neg"]
+    #      p.full_label = parameter.user_data["full_label"]
+    #      p.value = np.exp(parameter.value) if p.non_neg else parameter.value
+    #      p.min = (
+    #          np.exp(parameter.min) if p.non_neg and np.isfinite(parameter.min) else parameter.min
+    #      )
+    #      p.max = (
+    #          np.exp(parameter.max) if p.non_neg and np.isfinite(parameter.max) else parameter.max
+    #      )
+    #      p.stderr = parameter.stderr
+    #      return p
 
     @classmethod
     def from_list_or_value(
         cls,
-        value: typing.Union[int, float, typing.List],
-        default_options: typing.Dict = None,
+        value: Union[int, float, List],
+        default_options: Dict = None,
         label: str = None,
     ) -> "Parameter":
         """Creates a parameter from a list or numeric value.
@@ -81,12 +97,9 @@ class Parameter(LmParameter):
             The label of the parameter.
         """
 
-        if not isinstance(value, list):
-            value = [value]
-
         param = cls(label=label)
 
-        if isinstance(value, (int, float)):
+        if not isinstance(value, list):
             param.value = value
             return param
 
@@ -125,74 +138,264 @@ class Parameter(LmParameter):
         """
 
         p = group.get(self.full_label)
-        self.vary = p.vary
-        self.value = p.value
-        self.min = p.min
-        self.max = p.max
-        self.expr = p.expr
+        self.expression = p.expression
+        self.maximum = p.maximum
+        self.minimum = p.minimum
+        self.non_negative = p.non_negative
         self.stderr = p.stderr
-        self.non_neg = p.non_neg
+        self.value = p.value
+        self.vary = p.vary
 
-    def _set_options_from_dict(self, options: typing.Dict):
-        if Keys.NON_NEG in options:
-            self.non_neg = options[Keys.NON_NEG]
-        if Keys.MAX in options:
-            self.max = float(options[Keys.MAX])
-        if Keys.MIN in options:
-            self.min = float(options[Keys.MIN])
-        if Keys.EXPR in options:
-            self.expr = options[Keys.EXPR]
-        if Keys.VARY in options:
-            self.vary = options[Keys.VARY]
+    def _set_options_from_dict(self, options: Dict):
+        self.expr = options.get(Keys.EXPR, None)
+        self.non_negative = options.get(Keys.NON_NEG, False)
+        self.maximum = options.get(Keys.MAX, np.inf)
+        self.minimum = options.get(Keys.MIN, -np.inf)
+        self.vary = options.get(Keys.VARY, True)
 
     @property
     def label(self) -> str:
         """Label of the parameter"""
-        return self.user_data["label"]
+        return self._label
 
     @label.setter
     def label(self, label: str):
-        self.user_data["label"] = label
+        self._label = label
 
     @property
     def full_label(self) -> str:
         """The label of the parameter with its path in a parameter group prepended."""
-        return self.user_data["full_label"]
+        return self._full_label
 
     @full_label.setter
     def full_label(self, full_label: str):
-        self.user_data["full_label"] = full_label
+        self._full_label = full_label
 
     @property
-    def non_neg(self) -> bool:
+    def non_negative(self) -> bool:
         r"""Indicates if the parameter is non-negativ.
 
         If true, the parameter will be transformed with :math:`p' = \log{p}` and
         :math:`p = \exp{p'}`.
         """  # w605
-        return self.user_data["non_neg"]
+        return self._non_negative
 
-    @non_neg.setter
-    def non_neg(self, non_neg: bool):
-        self.user_data["non_neg"] = non_neg
+    @non_negative.setter
+    def non_negative(self, non_negative: bool):
+        self._non_negative = non_negative
 
-    @LmParameter.value.setter
-    def value(self, val):
-        if not isinstance(val, (int, float)):
+    @property
+    def vary(self) -> bool:
+        """Indicates if the parameter should be optimized."""
+        return self._vary
+
+    @vary.setter
+    def vary(self, vary: bool):
+        self._vary = vary
+
+    @property
+    def maximum(self) -> float:
+        """The upper bound of the parameter."""
+        return self._maximum
+
+    @maximum.setter
+    def maximum(self, maximum: Union[int, float]):
+        if not isinstance(maximum, float):
             try:
-                val = float(val)
+                maximum = float(maximum)
             except Exception:
-                raise TypeError(f"Parameter Error: value must be numeric:{val} Type: {type(val)}")
+                raise TypeError(
+                    "Parameter maximum must be numeric."
+                    + f"'{self.full_label}' has maximum '{maximum}' of type '{type(maximum)}'"
+                )
 
-        if isinstance(val, int):
-            val = float(val)
+        self._maximum = maximum
 
-        LmParameter.value.fset(self, val)
+    @property
+    def minimum(self) -> float:
+        """The lower bound of the parameter."""
+        return self._minimum
 
-    def __str__(self):
-        """ """
+    @minimum.setter
+    def minimum(self, minimum: Union[int, float]):
+        if not isinstance(minimum, float):
+            try:
+                minimum = float(minimum)
+            except Exception:
+                raise TypeError(
+                    "Parameter minimum must be numeric."
+                    + f"'{self.full_label}' has minimum '{minimum}' of type '{type(minimum)}'"
+                )
+
+        self._minimum = minimum
+
+    @property
+    def expression(self) -> str:
+        """The expression of the parameter."""  # TODO: Formulate better docstring.
+        return self._expression
+
+    @expression.setter
+    def expression(self, expression: str):
+        self._expression = expression
+
+    @property
+    def stderr(self) -> float:
+        """The standard error of the optimized parameter."""
+        return self._stderr
+
+    @stderr.setter
+    def stderr(self, stderr: float):
+        self._stderr = stderr
+
+    @property
+    def value(self) -> float:
+        """The value of the parameter"""
+        return self._getval()
+
+    @value.setter
+    def value(self, value: Union[int, float]):
+        if not isinstance(value, float):
+            try:
+                value = float(value)
+            except Exception:
+                raise TypeError(
+                    "Parameter value must be numeric."
+                    + f"'{self.full_label}' has value '{value}' of type '{type(value)}'"
+                )
+
+        self._value = value
+
+    def _getval(self) -> float:
+        return self._value
+
+    def __repr__(self):
+        """String representation """
         return (
             f"__{self.label}__: _Value_: {self.value}, _StdErr_: {self.stderr}, _Min_:"
             + f" {self.min}, _Max_: {self.max}, _Vary_: {self.vary},"
-            + f" _Non-Negative_: {self.non_neg}"
+            + f" _Non-Negative_: {self.non_negative}"
         )
+
+    def __array__(self):
+        """array"""
+        return [float(self._getval())]
+
+    def __str__(self):
+        """string"""
+        return self.__repr__()
+
+    def __abs__(self):
+        """abs"""
+        return abs(self._getval())
+
+    def __neg__(self):
+        """neg"""
+        return -self._getval()
+
+    def __pos__(self):
+        """positive"""
+        return +self._getval()
+
+    def __bool__(self):
+        """bool"""
+        return self._getval() != 0
+
+    def __int__(self):
+        """int"""
+        return int(self._getval())
+
+    def __float__(self):
+        """float"""
+        return float(self._getval())
+
+    def __trunc__(self):
+        """trunc"""
+        return self._getval().__trunc__()
+
+    def __add__(self, other):
+        """+"""
+        return self._getval() + other
+
+    def __sub__(self, other):
+        """-"""
+        return self._getval() - other
+
+    def __truediv__(self, other):
+        """/"""
+        return self._getval() / other
+
+    def __floordiv__(self, other):
+        """//"""
+        return self._getval() // other
+
+    def __divmod__(self, other):
+        """divmod"""
+        return divmod(self._getval(), other)
+
+    def __mod__(self, other):
+        """%"""
+        return self._getval() % other
+
+    def __mul__(self, other):
+        """*"""
+        return self._getval() * other
+
+    def __pow__(self, other):
+        """**"""
+        return self._getval() ** other
+
+    def __gt__(self, other):
+        """>"""
+        return self._getval() > other
+
+    def __ge__(self, other):
+        """>="""
+        return self._getval() >= other
+
+    def __le__(self, other):
+        """<="""
+        return self._getval() <= other
+
+    def __lt__(self, other):
+        """<"""
+        return self._getval() < other
+
+    def __eq__(self, other):
+        """=="""
+        return self._getval() == other
+
+    def __ne__(self, other):
+        """!="""
+        return self._getval() != other
+
+    def __radd__(self, other):
+        """+ (right)"""
+        return other + self._getval()
+
+    def __rtruediv__(self, other):
+        """/ (right)"""
+        return other / self._getval()
+
+    def __rdivmod__(self, other):
+        """divmod (right)"""
+        return divmod(other, self._getval())
+
+    def __rfloordiv__(self, other):
+        """// (right)"""
+        return other // self._getval()
+
+    def __rmod__(self, other):
+        """% (right)"""
+        return other % self._getval()
+
+    def __rmul__(self, other):
+        """* (right)"""
+        return other * self._getval()
+
+    def __rpow__(self, other):
+        """** (right)"""
+        return other ** self._getval()
+
+    def __rsub__(self, other):
+        """- (right)"""
+        return other - self._getval()

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -378,7 +378,7 @@ class ParameterGroup(dict):
     def set_from_label_and_value_arrays(self, labels: List[str], values: np.ndarray):
         """Updates the parameter values from a list of labels and values."""
 
-        if not len(labels) == len(values):
+        if len(labels) != len(values):
             raise ValueError(
                 f"Length of labels({len(labels)}) not equal to length of values({len(values)})."
             )
@@ -402,7 +402,7 @@ class ParameterGroup(dict):
 
     def markdown(self) -> str:
         """Formats the :class:`ParameterGroup` as markdown string."""
-        t = "".join(["  " for _ in range(self.get_nr_roots())])
+        t = "".join("  " for _ in range(self.get_nr_roots()))
         s = ""
         if self.label != "p":
             s += f"{t}* __{self.label}__:\n"

--- a/glotaran/parameter/test/test_parameter.py
+++ b/glotaran/parameter/test/test_parameter.py
@@ -168,9 +168,9 @@ def test_parameter_group_to_array():
     assert len(upper_bounds) == 3
 
     assert labels == ["1", "2", "3"]
-    assert values == [1, np.log(4e2), 2e4]
-    assert lower_bounds == [-1, np.log(10), -np.inf]
-    assert upper_bounds == [1, np.log(8e2), np.inf]
+    assert np.allclose(values, [1, np.log(4e2), 2e4])
+    assert np.allclose(lower_bounds, [-1, np.log(10), -np.inf])
+    assert np.allclose(upper_bounds, [1, np.log(8e2), np.inf])
 
     (
         labels_only_vary,

--- a/glotaran/parameter/test/test_parameter.py
+++ b/glotaran/parameter/test/test_parameter.py
@@ -182,7 +182,7 @@ def test_parameter_group_to_array():
     assert len(labels_only_vary) == 2
     assert len(values_only_vary) == 2
     assert len(lower_bounds_only_vary) == 2
-    assert len(lower_bounds_only_vary) == 2
+    assert len(upper_bounds_only_vary) == 2
 
     assert labels_only_vary == ["2", "3"]
 

--- a/glotaran/parameter/test/test_parameter.py
+++ b/glotaran/parameter/test/test_parameter.py
@@ -282,11 +282,11 @@ def test_parameter_expressions():
     assert params.get("3").value == params.get("1") * np.exp(params.get("2"))
     assert params.get("4").value == 2
 
-    params_bad_expr = """
+    with pytest.raises(ValueError):
+        params_bad_expr = """
     - ["3", {expr: 'None'}]
     """
 
-    with pytest.raises(ValueError):
         ParameterGroup.from_yaml(params_bad_expr)
 
 

--- a/glotaran/parameter/test/test_parameter.py
+++ b/glotaran/parameter/test/test_parameter.py
@@ -1,3 +1,5 @@
+import pickle
+
 import numpy as np
 import pytest
 
@@ -286,3 +288,15 @@ def test_parameter_expressions():
 
     with pytest.raises(ValueError):
         ParameterGroup.from_yaml(params_bad_expr)
+
+
+def test_parameter_pickle(tmpdir):
+
+    parameter = Parameter("testlabel", "testlabelfull", "testexpression", 1, 2, True, 42, False)
+
+    with open(tmpdir.join("test_param_pickle"), "wb") as f:
+        pickle.dump(parameter, f)
+    with open(tmpdir.join("test_param_pickle"), "rb") as f:
+        pickled_parameter = pickle.load(f)
+
+    assert parameter == pickled_parameter

--- a/glotaran/parameter/test/test_parameter.py
+++ b/glotaran/parameter/test/test_parameter.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from glotaran.parameter import Parameter
 from glotaran.parameter import ParameterGroup
@@ -46,20 +47,20 @@ def test_param_options():
 
     assert params.get("5").value == 1.0
     assert not params.get("5").non_negative
-    assert params.get("5").min == -1
-    assert params.get("5").max == 1
+    assert params.get("5").minimum == -1
+    assert params.get("5").maximum == 1
     assert not params.get("5").vary
 
     assert params.get("6").value == 4e2
     assert params.get("6").non_negative
-    assert params.get("6").min == -7e2
-    assert params.get("6").max == 8e2
+    assert params.get("6").minimum == -7e2
+    assert params.get("6").maximum == 8e2
     assert params.get("6").vary
 
     assert params.get("7").value == 2e4
     assert not params.get("7").non_negative
-    assert params.get("7").min == float("-inf")
-    assert params.get("7").max == float("inf")
+    assert params.get("7").minimum == float("-inf")
+    assert params.get("7").maximum == float("inf")
     assert params.get("7").vary
 
 
@@ -140,7 +141,7 @@ def test_non_negative():
     assert np.allclose(2, nonneg2.value)
 
     nonnegminmax = Parameter(value=5, minimum=3, maximum=6, non_negative=True)
-    value5, minimum, maximum = nonnegminmax
+    value5, minimum, maximum = nonnegminmax.get_value_and_bounds_for_optimization()
     assert not np.allclose(5, value5)
     assert not np.allclose(3, minimum)
     assert not np.allclose(6, maximum)
@@ -155,26 +156,31 @@ def test_parameter_group_to_array():
 
     params = ParameterGroup.from_yaml(params)
 
-    labels, values, bounds = params.get_label_value_and_bounds_arrays(exclude_non_vary=False)
+    labels, values, lower_bounds, upper_bounds = params.get_label_value_and_bounds_arrays(
+        exclude_non_vary=False
+    )
 
     assert len(labels) == 3
     assert len(values) == 3
-    assert len(bounds) == 3
+    assert len(lower_bounds) == 3
+    assert len(upper_bounds) == 3
 
     assert labels == ["1", "2", "3"]
     assert values == [1, np.log(4e2), 2e4]
-    assert all([len(bound) == 2 for bound in bounds])
-    assert bounds == [(-1, 1), (np.log(10), np.log(8e2), (-np.inf, np.inf))]
+    assert lower_bounds == [-1, np.log(10), -np.inf]
+    assert upper_bounds == [1, np.log(8e2), np.inf]
 
     (
         labels_only_vary,
         values_only_vary,
-        bounds_only_vary,
+        lower_bounds_only_vary,
+        upper_bounds_only_vary,
     ) = params.get_label_value_and_bounds_arrays(exclude_non_vary=True)
 
     assert len(labels_only_vary) == 2
     assert len(values_only_vary) == 2
-    assert len(bounds_only_vary) == 2
+    assert len(lower_bounds_only_vary) == 2
+    assert len(lower_bounds_only_vary) == 2
 
     assert labels_only_vary == ["2", "3"]
 
@@ -197,3 +203,86 @@ def test_update_parameter_group_from_array():
 
     for i in range(3):
         assert params.get(f"{i+1}").value == values[i]
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        ("$1", "group.get('1').value"),
+        (
+            "1 - $kinetic.1 * exp($kinetic.2) + $kinetic.3",
+            "1 - group.get('kinetic.1').value * exp(group.get('kinetic.2').value) "
+            "+ group.get('kinetic.3').value",
+        ),
+        ("2", "2"),
+        (
+            "1 - sum([$kinetic.1, $kinetic.2])",
+            "1 - sum([group.get('kinetic.1').value, group.get('kinetic.2').value])",
+        ),
+        ("exp($kinetic.4)", "exp(group.get('kinetic.4').value)"),
+        ("$kinetic.5", "group.get('kinetic.5').value"),
+        (
+            "$group.sub_group.param1 + $kinetic6",
+            "group.get('group.sub_group.param1').value + group.get('kinetic6').value",
+        ),
+        ("$foo.7.bar + $kinetic6", "group.get('foo.7.bar').value + group.get('kinetic6').value"),
+        ("$1", "group.get('1').value"),
+        ("$1-$2", "group.get('1').value-group.get('2').value"),
+        ("$1-$5", "group.get('1').value-group.get('5').value"),
+    ],
+)
+def test_transform_expression(case):
+    expression, wanted = case
+    parameter = Parameter(expression=expression)
+    assert parameter.transformed_expression == wanted
+
+
+def test_label_validator():
+    valid_names = [
+        "1",
+        "valid1",
+        "_valid2",
+        "extra_valid3",
+    ]
+
+    assert all(list(map(Parameter.valid_label, valid_names)))
+
+    invalid_names = [
+        "testé",
+        "kinetic.1",
+        "kinetic_red.3",
+        "foo.7.bar",
+        "_ilikeunderscoresatbegeninngin.justbecause",
+        "42istheanswer.42",
+        "kinetic::red",
+        "kinetic_blue+kinetic_red",
+        "makesthissense=trueandfalse",
+        "what/about\\slashes",
+        "$invalid",
+        "round",
+        "group",
+    ]
+    assert not any(list(map(Parameter.valid_label, invalid_names)))
+
+
+def test_parameter_expressions():
+    params = """
+    - ["1", 2]
+    - ["2", 5]
+    - ["3", {expr: '$1 * exp($2)'}]
+    - ["4", {expr: '2'}]
+    """
+
+    params = ParameterGroup.from_yaml(params)
+
+    assert params.get("3").expression is not None
+    assert not params.get("3").vary
+    assert params.get("3").value == params.get("1") * np.exp(params.get("2"))
+    assert params.get("4").value == 2
+
+    params_bad_expr = """
+    - ["3", {expr: 'None'}]
+    """
+
+    with pytest.raises(ValueError):
+        ParameterGroup.from_yaml(params_bad_expr)

--- a/glotaran/parameter/test/test_parameter.py
+++ b/glotaran/parameter/test/test_parameter.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from glotaran.parameter import Parameter
 from glotaran.parameter import ParameterGroup
 
 
@@ -44,19 +45,19 @@ def test_param_options():
     params = ParameterGroup.from_yaml(params)
 
     assert params.get("5").value == 1.0
-    assert not params.get("5").non_neg
+    assert not params.get("5").non_negative
     assert params.get("5").min == -1
     assert params.get("5").max == 1
     assert not params.get("5").vary
 
     assert params.get("6").value == 4e2
-    assert params.get("6").non_neg
+    assert params.get("6").non_negative
     assert params.get("6").min == -7e2
     assert params.get("6").max == 8e2
     assert params.get("6").vary
 
     assert params.get("7").value == 2e4
-    assert not params.get("7").non_neg
+    assert not params.get("7").non_negative
     assert params.get("7").min == float("-inf")
     assert params.get("7").max == float("inf")
     assert params.get("7").vary
@@ -120,23 +121,79 @@ def test_nested_param_group():
 
 def test_non_negative():
 
-    params = """
-    - ["neg", -1]
-    - ["negmax", -1, {max=0}]
-    - ["nonneg1", 1, {non-negative: True}]
-    - ["nonneg2", 2, {non-negative: True}]
-    - ["nonnegmin", 6, {non-negative: True, min: 2}]
-    """
-    params = ParameterGroup.from_yaml(params)
-    result = ParameterGroup.from_parameter_dict(params.as_parameter_dict())
-    print(params)
-    params.as_parameter_dict().pretty_print()
-    print(result)
+    notnonneg = Parameter(value=1, non_negative=False)
+    valuenotnoneg, _, _ = notnonneg.get_value_and_bounds_for_optimization()
+    assert np.allclose(1, valuenotnoneg)
+    notnonneg.set_value_from_optimization(valuenotnoneg)
+    assert np.allclose(1, notnonneg.value)
 
-    for label, p in params.all():
-        print(label)
-        r = result.get(label)
-        assert r.non_neg == p.non_neg
-        assert np.allclose(r.value, p.value)
-        assert np.allclose(r.min, p.min)
-        assert np.allclose(r.max, p.max)
+    nonneg1 = Parameter(value=1, non_negative=True)
+    value1, _, _ = nonneg1.get_value_and_bounds_for_optimization()
+    assert not np.allclose(1, value1)
+    nonneg1.set_value_from_optimization(value1)
+    assert np.allclose(1, nonneg1.value)
+
+    nonneg2 = Parameter(value=2, non_negative=True)
+    value2, _, _ = nonneg2.get_value_and_bounds_for_optimization()
+    assert not np.allclose(2, value2)
+    nonneg2.set_value_from_optimization(value2)
+    assert np.allclose(2, nonneg2.value)
+
+    nonnegminmax = Parameter(value=5, minimum=3, maximum=6, non_negative=True)
+    value5, minimum, maximum = nonnegminmax
+    assert not np.allclose(5, value5)
+    assert not np.allclose(3, minimum)
+    assert not np.allclose(6, maximum)
+
+
+def test_parameter_group_to_array():
+    params = """
+    - ["1", 1, {non-negative: false, min: -1, max: 1, vary: false}]
+    - ["2", 4e2, {non-negative: true, min: 10, max: 8e2, vary: true}]
+    - ["3", 2e4]
+    """
+
+    params = ParameterGroup.from_yaml(params)
+
+    labels, values, bounds = params.get_label_value_and_bounds_arrays(exclude_non_vary=False)
+
+    assert len(labels) == 3
+    assert len(values) == 3
+    assert len(bounds) == 3
+
+    assert labels == ["1", "2", "3"]
+    assert values == [1, np.log(4e2), 2e4]
+    assert all([len(bound) == 2 for bound in bounds])
+    assert bounds == [(-1, 1), (np.log(10), np.log(8e2), (-np.inf, np.inf))]
+
+    (
+        labels_only_vary,
+        values_only_vary,
+        bounds_only_vary,
+    ) = params.get_label_value_and_bounds_arrays(exclude_non_vary=True)
+
+    assert len(labels_only_vary) == 2
+    assert len(values_only_vary) == 2
+    assert len(bounds_only_vary) == 2
+
+    assert labels_only_vary == ["2", "3"]
+
+
+def test_update_parameter_group_from_array():
+    params = """
+    - ["1", 1, {non-negative: false, min: -1, max: 1, vary: false}]
+    - ["2", 4e2, {non-negative: true, min: 10, max: 8e2, vary: true}]
+    - ["3", 2e4]
+    """
+
+    params = ParameterGroup.from_yaml(params)
+
+    labels = ["1", "2", "3"]
+    values = [0, np.log(6e2), 42]
+
+    params.set_from_label_and_value_arrays(labels, values)
+
+    values[1] = np.exp(values[1])
+
+    for i in range(3):
+        assert params.get(f"{i+1}").value == values[i]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,11 +6,11 @@ wheel>=0.30.0
 bump2version>=0.5.11
 
 # glotaran setup dependencies
+asteval==0.9.21
 numpy==1.19.4; sys_platform != "win32"
 numpy==1.19.3; sys_platform == "win32"
 scipy==1.5.4
 click==7.1.2
-lmfit==1.0.1
 numba==0.52.0
 pandas==1.1.4
 pyyaml==5.3.1

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import find_packages
 from setuptools import setup
 
 install_requires = [
+    "asteval>=0.9.21",
     "click>=7.0",
-    "lmfit>=0.9.13",
     "netCDF4>=1.5.3",
     "numba>=0.48",
     'numpy>=1.17.3; sys_platform != "win32"',


### PR DESCRIPTION
This PR removes all dependencies to the `lmfit` package.

The optimization is now done by directly calling `scipy.optimize.least_squares`.

Changes
=======

* The `Parameter` class is no longer a child of `lmfit.Parameter`.
* `asteval` is used to evaluate parameter expressions.
* `optimize` now calls `scipy.optimize.least_quares` instead of using `lmfit.Minimizer`
* Few adaptions to tests due to small numeric differences
* Parameter and group labels now have restrictions to work with the new parameter expression scheme

Known Issues
===========

* The covariance matrix is no longer calculated
* The standart error of the optimized parameters is not calculated

This PR closes #491, closes #489 and closes #481.