### PR TITLE
Improve specification parsing

### DIFF
--- a/glotaran/analysis/scheme.py
+++ b/glotaran/analysis/scheme.py
@@ -57,7 +57,7 @@ class Scheme:
         try:
             with open(filename) as f:
                 try:
-                    scheme = yaml.load(f, Loader=yaml.FullLoader)
+                    scheme = yaml.safe_load(f)
                 except Exception as e:
                     raise ValueError(f"Error parsing scheme: {e}")
         except Exception as e:

--- a/glotaran/analysis/test/test_scheme.py
+++ b/glotaran/analysis/test/test_scheme.py
@@ -3,9 +3,8 @@ import pytest
 import xarray as xr
 
 from glotaran.analysis.scheme import Scheme
+from glotaran.analysis.test.mock import MockModel
 from glotaran.parameter import ParameterGroup
-
-from .mock import MockModel
 
 
 @pytest.fixture(scope="session")

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -137,7 +137,7 @@ class ParameterGroup(dict):
         yaml_string :
             The YAML string with the parameters.
         """
-        items = yaml.load(yaml_string, Loader=yaml.FullLoader)
+        items = yaml.safe_load(yaml_string)
         if isinstance(items, list):
             return cls.from_list(items)
         else:

--- a/glotaran/parse/parser.py
+++ b/glotaran/parse/parser.py
@@ -1,51 +1,22 @@
 """Functions for reading and parsing models from serialized representations."""
 
-import re
 from typing import Dict
 
 import yaml
+
+from glotaran.parse.util import sanitize_yaml
 
 from .register import get_model
 from .register import known_model
 
 
-# shamelessly taken from
-# https://stackoverflow.com/questions/39553008/how-to-read-a-python-tuple-using-pyyaml#39553138
-# this is to convert the string written as a tuple into a python tuple
-def _yml_tuple_constructor(loader, node):
-    # this little parse is really just for what I needed, feel free to change it!
-    def parse_tup_el(el):
-        # try to convert into int or float else keep the string
-        if el.isdigit():
-            return int(el)
-        try:
-            return float(el)
-        except ValueError:
-            return el
-
-    value = loader.construct_scalar(node)
-    # remove the ( ) from the string
-    tup_elements = [ele.strip() for ele in value[1:-1].split(",")]
-    # remove the last element if the tuple was written as (x,b,)
-    if tup_elements[-1] == "":
-        tup_elements.pop(-1)
-    tup = tuple(map(parse_tup_el, tup_elements))
-    return tup
-
-
-# !tuple is my own tag name, I think you could choose anything you want
-yaml.FullLoader.add_constructor("!tuple", _yml_tuple_constructor)
-# this is to spot the strings written as tuple in the yaml
-yaml.FullLoader.add_implicit_resolver("!tuple", re.compile(r"\((.*?,.*?)\)"), None)
-
-
-def parse_yml_file(fname: str) -> Dict:
+def parse_yml_file(filename: str) -> Dict:
     """parse_yml_file reads the given file and parses its content as YML.
 
     Parameters
     ----------
-    fname : str
-        fname is the of the file to parse.
+    filename : str
+        filename is the of the file to parse.
 
     Returns
     -------
@@ -53,7 +24,7 @@ def parse_yml_file(fname: str) -> Dict:
         The content of the file as dictionary.
     """
 
-    with open(fname) as f:
+    with open(filename) as f:
         spec = parse_yml(f)
 
     return spec
@@ -61,12 +32,14 @@ def parse_yml_file(fname: str) -> Dict:
 
 def parse_yml(data: str):
     try:
-        return yaml.load(data, Loader=yaml.FullLoader)
+        return yaml.safe_load(data)
     except Exception as e:
         raise e
 
 
 def parse_spec(spec: Dict):
+
+    spec = sanitize_yaml(spec)
 
     if "type" not in spec:
         raise Exception("Model type not defined")
@@ -84,8 +57,8 @@ def parse_spec(spec: Dict):
         raise e
 
 
-def load_yml_file(fname: str):
-    spec = parse_yml_file(fname)
+def load_yml_file(filename: str):
+    spec = parse_yml_file(filename)
     return parse_spec(spec)
 
 

--- a/glotaran/parse/test/test_model_parser_kinetic.py
+++ b/glotaran/parse/test/test_model_parser_kinetic.py
@@ -64,7 +64,7 @@ def test_spectral_constraints(model):
     assert len(zcs) == 2
     for zc in zcs:
         assert zc.compartment == "s1"
-        assert zc.interval == [(1, 100), (2, 200)]
+        assert zc.interval == [[1, 100], [2, 200]]
 
 
 def test_spectral_penalties(model):
@@ -72,9 +72,9 @@ def test_spectral_penalties(model):
     assert all(isinstance(c, EqualAreaPenalty) for c in model.equal_area_penalties)
     eac = model.equal_area_penalties[0]
     assert eac.source == "s3"
-    assert eac.source_intervals == [(670, 810)]
+    assert eac.source_intervals == [[670, 810]]
     assert eac.target == "s2"
-    assert eac.target_intervals == [(670, 810)]
+    assert eac.target_intervals == [[670, 810]]
     assert eac.parameter == 55
     assert eac.weight == 0.0016
 
@@ -87,7 +87,7 @@ def test_spectral_relations(model):
 
     assert rel.compartment == "s1"
     assert rel.target == "s2"
-    assert rel.interval == [(1, 100), (2, 200)]
+    assert rel.interval == [[1, 100], [2, 200]]
 
 
 def test_initial_concentration(model):
@@ -147,8 +147,8 @@ def test_weight(model):
     weight = model.weights[0]
     assert isinstance(weight, Weight)
     assert weight.datasets == ["d1", "d2"]
-    assert weight.global_interval == (100, 102)
-    assert weight.model_interval == (301, 502)
+    assert weight.global_interval == [100, 102]
+    assert weight.model_interval == [301, 502]
     assert weight.value == 42
 
 

--- a/glotaran/parse/test/test_model_spec_kinetic.yml
+++ b/glotaran/parse/test/test_model_spec_kinetic.yml
@@ -64,14 +64,14 @@ spectral_constraints:
     interval:
       - (1, 100)
       - (2, 200)
-  - [zero, s1, [!tuple '(1, 100)', !tuple '(2, 200)']]
+  - [zero, s1, [(1, 100), (2, 200)]]
 
 equal_area_penalties:
   - type: equal_area
     source: s3
-    source_intervals: [!tuple '(670, 810)']
+    source_intervals: [(670, 810)]
     target: s2
-    target_intervals: [!tuple '(670, 810)']
+    target_intervals: [(670, 810)]
     parameter: 55
     weight: 0.0016
 
@@ -79,7 +79,7 @@ spectral_relations:
   - compartment: s1
     target: s2
     parameter: 8
-    interval: [!tuple '(1,100)', !tuple '(2,200)']
+    interval: [(1,100), (2,200)]
 
 weights:
   - datasets: [d1, d2]

--- a/glotaran/parse/test/test_model_spec_kinetic.yml
+++ b/glotaran/parse/test/test_model_spec_kinetic.yml
@@ -62,16 +62,16 @@ spectral_constraints:
   - type: zero
     compartment: s1
     interval:
-      - (1, 100)
-      - (2, 200)
-  - [zero, s1, [(1, 100), (2, 200)]]
+      - [1, 100]
+      - [2, 200]
+  - [zero, s1, [[1, 100], [2, 200]]]
 
 equal_area_penalties:
   - type: equal_area
     source: s3
-    source_intervals: [(670, 810)]
+    source_intervals: [[670, 810]]
     target: s2
-    target_intervals: [(670, 810)]
+    target_intervals: [[670, 810]]
     parameter: 55
     weight: 0.0016
 
@@ -79,10 +79,10 @@ spectral_relations:
   - compartment: s1
     target: s2
     parameter: 8
-    interval: [(1,100), (2,200)]
+    interval: [[1,100], [2,200]]
 
 weights:
   - datasets: [d1, d2]
-    global_interval: (100, 102)
-    model_interval: (301, 502)
+    global_interval: [100, 102]
+    model_interval: [301, 502]
     value: 42

--- a/glotaran/parse/test/test_util.py
+++ b/glotaran/parse/test/test_util.py
@@ -1,0 +1,59 @@
+from typing import Any
+from typing import List
+from typing import NamedTuple
+
+import pytest
+
+from glotaran.parse.util import sanitize_list_with_broken_tuples
+
+
+class MangledListTestData(NamedTuple):
+    input: List[Any]
+    input_sanitized: List[str]
+    output: List[str]
+
+
+test_data_list = [
+    MangledListTestData(
+        ["(3", 100, "13)", "(4.0", "-200)"],
+        "[(3, 100, 13), (4.0, -200)]",
+        ["(3, 100, 13)", "(4.0, -200)"],
+    ),
+    MangledListTestData(
+        [(3, 100, 13), 5.5, (4.0, -200), 5.6],
+        "[(3, 100, 13), 5.5, (4.0, -200), 5.6]",
+        ["(3, 100, 13)", "5.5", "(4.0, -200)", "5.6"],
+    ),
+    MangledListTestData(
+        [(3, 100, 13), -5.5, (4.0, -200), +5.6],
+        "[(3, 100, 13), -5.5, (4.0, -200), 5.6]",
+        ["(3, 100, 13)", "-5.5", "(4.0, -200)", "5.6"],
+    ),
+    MangledListTestData(
+        ["(3", -100, "13)", "(4.0", "-200)"],
+        "[(3, -100, 13), (4.0, -200)]",
+        ["(3, -100, 13)", "(4.0, -200)"],
+    ),
+    MangledListTestData(
+        ["(3", 100, "13)", "(4.0", "+200)"],
+        "[(3, 100, 13), (4.0, +200)]",
+        ["(3, 100, 13)", "(4.0, +200)"],
+    ),
+]
+
+
+@pytest.mark.parametrize("test_data", test_data_list)
+def test_mangled_list_sanitization(test_data: "MangledListTestData"):
+    assert test_data.input_sanitized == str(test_data.input).replace("'", "")
+
+
+@pytest.mark.parametrize("test_data", test_data_list)
+def test_fix_tuple_string_list(test_data: "MangledListTestData"):
+    actual = sanitize_list_with_broken_tuples(test_data.input)
+    assert all(a in b for a, b in zip(actual, test_data.output))
+
+
+if __name__ == "__main__":
+    for test_data in test_data_list:
+        test_mangled_list_sanitization(test_data)
+        test_fix_tuple_string_list(test_data)

--- a/glotaran/parse/util.py
+++ b/glotaran/parse/util.py
@@ -1,0 +1,95 @@
+import re
+from typing import Any
+from typing import List
+
+# tuple_pattern = re.compile(r"(\(.*?,.*?\))")
+tuple_number_pattern = re.compile(r"(\([\s\d.+-]+?[,\s\d.+-]*?\))")
+number_pattern = re.compile(r"[\d.+-]+")
+tuple_name_pattern = re.compile(r"(\([.\s\w\d]+?[,.\s\w\d]*?\))")
+name_pattern = re.compile(r"[\w]+")
+group_pattern = re.compile(r"(\(.+?\))")
+match_list_with_tuples = re.compile(r"(\[.+\(.+\).+\])")
+match_elements_in_string_of_list = re.compile(r"(\(.+?\)|[-+.\d]+)")
+
+
+def sanitize_list_with_broken_tuples(mangled_list: List[Any]) -> List[str]:
+    """Sanitize a list with 'broken' tuples
+
+    A list of broken tuples as returned by yaml when parsing tuples.
+    e.g parsing the list of tuples [(3,100), (4,200)] results in
+    a list of str ['(3', '100)', '(4', '200)'] which can be restored to
+    a list with the tuples restored as strings ['(3, 100)', '(4, 200)']
+
+    Args:
+        mangled_list (List[str,float]): [description]
+
+    Returns:
+        List[str]: [description]
+    """
+    sanitized_string = str(mangled_list).replace("'", "")
+    return list(match_elements_in_string_of_list.findall(sanitized_string))
+
+
+def sanitize_dict_keys(d):
+    if not isinstance(d, (dict, list)):
+        return
+    d_new = {}
+    for k, v in d.items() if isinstance(d, dict) else enumerate(d):
+        if isinstance(d, dict) and isinstance(k, str) and tuple_name_pattern.match(k):
+            k_new = tuple(map(str, name_pattern.findall(k)))
+            d_new.update({k_new: v})
+        elif isinstance(d, (dict, list)):
+            new_v = sanitize_dict_keys(v)
+            if new_v:
+                d[k] = new_v
+    return d_new
+
+
+def sanitize_dict_values(d):
+    if not isinstance(d, (dict, list)):
+        return
+    for k, v in d.items() if isinstance(d, dict) else enumerate(d):
+        if isinstance(v, list):
+            leaf = all(isinstance(el, (str, tuple, float)) for el in v)
+            if leaf:
+                # print(f"is_leaf: {v}")
+                if "(" in str(v):
+                    d[k] = list_to_tuple(sanitize_list_with_broken_tuples(v))
+                # print(d)
+            else:
+                sanitize_dict_values(v)
+        if isinstance(v, dict):
+            sanitize_dict_values(v)
+        if isinstance(v, str):
+            d[k] = str_to_tuple(v)
+
+
+def str_to_tuple(v, from_list=False):
+    if tuple_number_pattern.match(v):
+        return tuple(map(float, number_pattern.findall(v)))
+    elif tuple_name_pattern.match(v):
+        return tuple(map(str, name_pattern.findall(v)))
+    elif from_list and number_pattern.match(v):
+        return float(v)
+    else:
+        return v
+
+
+def list_to_tuple(a_list):
+    for i, v in enumerate(a_list):
+        a_list[i] = str_to_tuple(v, from_list=True)
+    return a_list
+
+
+def sanitize_yaml(d):
+    """Sanitize a yaml-returned dict for key or (list) values containing tuples
+
+    Args:
+        d (dict): a dict resulting from parsing a pyglotaran model spec yml file
+
+    Returns:
+        dict: a sanitized dict with (broken) string tuples restored as proper tuples
+    """
+    sanitize_dict_keys(d)
+    sanitize_dict_values(d)
+    return d

--- a/glotaran/parse/util.py
+++ b/glotaran/parse/util.py
@@ -1,6 +1,7 @@
 import re
-from typing import Any
 from typing import List
+from typing import Tuple
+from typing import Union
 
 # tuple_pattern = re.compile(r"(\(.*?,.*?\))")
 tuple_number_pattern = re.compile(r"(\([\s\d.+-]+?[,\s\d.+-]*?\))")
@@ -12,7 +13,7 @@ match_list_with_tuples = re.compile(r"(\[.+\(.+\).+\])")
 match_elements_in_string_of_list = re.compile(r"(\(.+?\)|[-+.\d]+)")
 
 
-def sanitize_list_with_broken_tuples(mangled_list: List[Any]) -> List[str]:
+def sanitize_list_with_broken_tuples(mangled_list: List[Union[str, float]]) -> List[str]:
     """Sanitize a list with 'broken' tuples
 
     A list of broken tuples as returned by yaml when parsing tuples.
@@ -20,19 +21,40 @@ def sanitize_list_with_broken_tuples(mangled_list: List[Any]) -> List[str]:
     a list of str ['(3', '100)', '(4', '200)'] which can be restored to
     a list with the tuples restored as strings ['(3, 100)', '(4, 200)']
 
-    Args:
-        mangled_list (List[str,float]): [description]
+    Parameters
+    ----------
+    mangled_list : List[Union[str,float]]
+        A list with strings representing tuples broken up by round brackets.
 
-    Returns:
-        List[str]: [description]
+    Returns
+    -------
+    List[str]
+        A list containing the restores tuples (in string form) which can be
+        converted back to numbered tuples using `list_string_to_tuple`
     """
+
     sanitized_string = str(mangled_list).replace("'", "")
     return list(match_elements_in_string_of_list.findall(sanitized_string))
 
 
-def sanitize_dict_keys(d):
+def sanitize_dict_keys(d: dict) -> dict:
+    """Sanitize the stringified tuple dict keys in a yaml parsed dict
+
+    Keys representing a tuple, e.g. '(s1, s2)' are converted to a tuple of strings
+        e.g. ('s1', 's2')
+
+    Parameters
+    ----------
+    d : dict
+        A dict containing tuple-like string keys
+
+    Returns
+    -------
+    dict
+        A dict with tuple-like string keys converted to tuple keys
+    """
     if not isinstance(d, (dict, list)):
-        return
+        return {}
     d_new = {}
     for k, v in d.items() if isinstance(d, dict) else enumerate(d):
         if isinstance(d, dict) and isinstance(k, str) and tuple_name_pattern.match(k):
@@ -45,51 +67,96 @@ def sanitize_dict_keys(d):
     return d_new
 
 
-def sanitize_dict_values(d):
+def sanitize_dict_values(d: dict):
+    """Sanitizes a dict with broken tuples inside modifying it in-place
+    Broken tuples are tuples that are turned into strings by the yaml parser.
+    This functions calls `sanitize_list_with_broken_tuples` to glue the broken strings together
+    and then calls list_to_tuple to turn the list with tuple strings back to number tuples.
+
+    Args:
+        d (dict): A (complex) dict containing (possibly nested) values of broken tuple strings
+    """
     if not isinstance(d, (dict, list)):
         return
     for k, v in d.items() if isinstance(d, dict) else enumerate(d):
         if isinstance(v, list):
             leaf = all(isinstance(el, (str, tuple, float)) for el in v)
             if leaf:
-                # print(f"is_leaf: {v}")
                 if "(" in str(v):
-                    d[k] = list_to_tuple(sanitize_list_with_broken_tuples(v))
-                # print(d)
+                    d[k] = list_string_to_tuple(sanitize_list_with_broken_tuples(v))
             else:
                 sanitize_dict_values(v)
         if isinstance(v, dict):
             sanitize_dict_values(v)
         if isinstance(v, str):
-            d[k] = str_to_tuple(v)
+            d[k] = string_to_tuple(v)
 
 
-def str_to_tuple(v, from_list=False):
-    if tuple_number_pattern.match(v):
-        return tuple(map(float, number_pattern.findall(v)))
-    elif tuple_name_pattern.match(v):
-        return tuple(map(str, name_pattern.findall(v)))
-    elif from_list and number_pattern.match(v):
-        return float(v)
+def string_to_tuple(
+    tuple_str: str, from_list=False
+) -> Union[Tuple[float], Tuple[str], float, str]:
+    """[summary]
+
+    Parameters
+    ----------
+    tuple_str : str
+        A string representing some tuple to convert
+        the numbers inside the string tuple are mapped to float
+    from_list : bool, optional
+        only if true will a single number string be converted to float,
+        otherwise returned as-is since it may represent a label,
+        by default False
+
+    Returns
+    -------
+    Union[Tuple[float], Tuple[str], float, str]
+        Returns the tuple intended by the string
+    """
+
+    if tuple_number_pattern.match(tuple_str):
+        return tuple(map(float, number_pattern.findall(tuple_str)))
+    elif tuple_name_pattern.match(tuple_str):
+        return tuple(map(str, name_pattern.findall(tuple_str)))
+    elif from_list and number_pattern.match(tuple_str):
+        return float(tuple_str)
     else:
-        return v
+        return tuple_str
 
 
-def list_to_tuple(a_list):
+def list_string_to_tuple(a_list: List[str]) -> List[Union[float, str]]:
+    """Converts a list of strings (representing tuples) to a list of tuples
+
+    Parameters
+    ----------
+    a_list : List[str]
+        A list of strings, some of them representing (numbered) tuples
+
+    Returns
+    -------
+    List[Union[float, str]]
+        A list of the (numbered) tuples represted by the incoming a_list
+    """
     for i, v in enumerate(a_list):
-        a_list[i] = str_to_tuple(v, from_list=True)
+        a_list[i] = string_to_tuple(v, from_list=True)
     return a_list
 
 
-def sanitize_yaml(d):
+def sanitize_yaml(d: dict, do_keys: bool = True, do_values: bool = False) -> dict:
     """Sanitize a yaml-returned dict for key or (list) values containing tuples
 
-    Args:
-        d (dict): a dict resulting from parsing a pyglotaran model spec yml file
+    Parameters
+    ----------
+    d : dict
+        a dict resulting from parsing a pyglotaran model spec yml file
 
-    Returns:
-        dict: a sanitized dict with (broken) string tuples restored as proper tuples
+    Returns
+    -------
+    dict
+        a sanitized dict with (broken) string tuples restored as proper tuples
     """
-    sanitize_dict_keys(d)
-    # sanitize_dict_values(d)
+    if do_keys:
+        sanitize_dict_keys(d)
+    if do_values:
+        # this is only needed to allow for tuple parsing in specification
+        sanitize_dict_values(d)
     return d

--- a/glotaran/parse/util.py
+++ b/glotaran/parse/util.py
@@ -91,5 +91,5 @@ def sanitize_yaml(d):
         dict: a sanitized dict with (broken) string tuples restored as proper tuples
     """
     sanitize_dict_keys(d)
-    sanitize_dict_values(d)
+    # sanitize_dict_values(d)
     return d


### PR DESCRIPTION
As a result of removing the need for !tuple parsing the yaml loading could be changed from yaml.load using the FullLoader to the safer yaml.safe_load (to all the security bot's delight).

A story in 2 parts

- [x] 1. Fixed tuple parsing in model spec to not require !tuple hack, also switching to yaml.safe_load
- [x] 2. Change values (not keys) in model spec to (nested) lists instead of (nested) tuples (for better syntax highlighting and simplified parsing, only k-matrix to from key label spec will still be parsed as tuples. 

**Closing issues**

closes #503 
