### PR TITLE
Fix typo in Levenberg-Marquardt

### DIFF
--- a/glotaran/analysis/optimize.py
+++ b/glotaran/analysis/optimize.py
@@ -11,7 +11,8 @@ from .scheme import Scheme
 SUPPORTED_METHODS = {
     "TrustRegionReflection": "trf",
     "Dogbox": "dogbox",
-    "LevenbergMarquart": "lm",
+    "LevenbergMarquardt": "lm",
+    "Levenberg-Marquardt": "lm",
 }
 
 

--- a/glotaran/analysis/optimize.py
+++ b/glotaran/analysis/optimize.py
@@ -11,7 +11,6 @@ from .scheme import Scheme
 SUPPORTED_METHODS = {
     "TrustRegionReflection": "trf",
     "Dogbox": "dogbox",
-    "LevenbergMarquardt": "lm",
     "Levenberg-Marquardt": "lm",
 }
 

--- a/glotaran/analysis/scheme.py
+++ b/glotaran/analysis/scheme.py
@@ -37,7 +37,6 @@ class Scheme:
         optimization_method: Literal[
             "TrustRegionReflection",
             "Dogbox",
-            "LevenbergMarquardt",
             "Levenberg-Marquardt",
         ] = "TrustRegionReflection",
     ):

--- a/glotaran/analysis/scheme.py
+++ b/glotaran/analysis/scheme.py
@@ -37,7 +37,8 @@ class Scheme:
         optimization_method: Literal[
             "TrustRegionReflection",
             "Dogbox",
-            "LevenbergMarquart",
+            "LevenbergMarquardt",
+            "Levenberg-Marquardt",
         ] = "TrustRegionReflection",
     ):
 

--- a/glotaran/analysis/test/test_optimization.py
+++ b/glotaran/analysis/test/test_optimization.py
@@ -20,7 +20,7 @@ from glotaran.analysis.test.models import TwoCompartmentDecay
     [
         "TrustRegionReflection",
         "Dogbox",
-        "LevenbergMarquart",
+        "Levenberg-Marquardt",
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Support for both Levenberg-Marquardt and LevenbergMarquardt but the correctly spelled Levenberg-Marquardt is preferred.

**Closing issues**

Closes #544 
