### PR TITLE
Refactor/531 address deprecation warnings

### DIFF
--- a/glotaran/builtin/models/kinetic_spectrum/test/test_coherent_artifact.py
+++ b/glotaran/builtin/models/kinetic_spectrum/test/test_coherent_artifact.py
@@ -63,7 +63,8 @@ def test_coherent_artifact():
     irf = model.irf["irf1"].fill(model, parameters)
     irf_diff_width = irf.calculate_coherent_artifact(time)
 
-    assert not np.array_equal(irf_same_width, irf_diff_width)
+    assert np.array_equal(irf_same_width[0], irf_diff_width[0])  # labels the same
+    assert not np.array_equal(irf_same_width[1], irf_diff_width[1])  # but content is not
 
     data = model.dataset["dataset1"].fill(model, parameters)
     compartments, matrix = kinetic_spectrum_matrix(data, time, 0)

--- a/glotaran/builtin/models/kinetic_spectrum/test/test_spectral_irf.py
+++ b/glotaran/builtin/models/kinetic_spectrum/test/test_spectral_irf.py
@@ -93,9 +93,7 @@ class SimpleIrfDispersion:
 
 class MultiIrfDispersion:
     model = read_model_from_yaml(MODEL_MULTI_IRF_DISPERSION)
-    print(model)
     parameters = read_parameters_from_yaml(PARAMETERS_MULTI_IRF_DISPERSION)
-    print(parameters)
     time = np.arange(-1, 5, 0.2)
     spectral = np.arange(300, 500, 100)
     axis = {"time": time, "spectral": spectral}
@@ -138,7 +136,7 @@ def test_spectral_irf(suite):
 
     resultdata = result.data["dataset1"]
 
-    print(resultdata)
+    # print(resultdata)
 
     assert np.array_equal(dataset["time"], resultdata["time"])
     assert np.array_equal(dataset["spectral"], resultdata["spectral"])
@@ -146,12 +144,11 @@ def test_spectral_irf(suite):
     assert dataset.data.shape == resultdata.fitted_data.shape
     assert np.allclose(dataset.data, resultdata.fitted_data, atol=1e-14)
 
-    print(resultdata.fitted_data.isel(spectral=0).argmax())
-    print(resultdata.fitted_data.isel(spectral=-1).argmax())
-    assert (
-        resultdata.fitted_data.isel(spectral=0).argmax()
-        != resultdata.fitted_data.isel(spectral=-1).argmax()
-    )
+    irf_max_at_start = resultdata.fitted_data.isel(spectral=0).argmax(axis=0)
+    irf_max_at_end = resultdata.fitted_data.isel(spectral=-1).argmax(axis=0)
+    print(f" irf_max_at_start: {irf_max_at_start}\n irf_max_at_end: {irf_max_at_end}")
+    # These should not be equal due to dispersion:
+    assert irf_max_at_start != irf_max_at_end
 
     assert "species_associated_spectra" in resultdata
     assert "decay_associated_spectra" in resultdata


### PR DESCRIPTION
Refactored test_spectral_irf.py and test_coherent_artifact.py to address (visible) deprecation warnings, especially noticeable when running pytest.

**Closing issues**

Closes: #531 
