### PR TITLE
Remove 'docs' artifact from CI, in favor of RTD build on PR

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -31,11 +31,6 @@ jobs:
       - name: Build docs
         run: |
           make --directory=docs clean html
-      - name: Upload docs artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: docs
-          path: docs/build/html
 
   docs-links:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I set [RTD to build on PR's](https://docs.readthedocs.io/en/latest/pull-requests.html) so we don't need the docs artifact anymore.
This PR is also a test for RTD to build the docs.

**Testing**

Passing the tests is mandatory.
