### PR TITLE
Fix for excessive memory usage when creating results

### DIFF
--- a/glotaran/analysis/problem.py
+++ b/glotaran/analysis/problem.py
@@ -1029,7 +1029,7 @@ class Problem:
         )
 
     def _create_svd(self, name: str, dataset: xr.Dataset):
-        l, v, r = np.linalg.svd(dataset[name])
+        l, v, r = np.linalg.svd(dataset[name], full_matrices=False)
 
         dataset[f"{name}_left_singular_vectors"] = (
             (self._model_dimension, "left_singular_value_index"),

--- a/glotaran/io/prepare_dataset.py
+++ b/glotaran/io/prepare_dataset.py
@@ -25,7 +25,7 @@ def prepare_time_trace_dataset(
         dataset = dataset.to_dataset(name="data")
 
     if "data_singular_values" not in dataset:
-        l, s, r = np.linalg.svd(dataset.data)
+        l, s, r = np.linalg.svd(dataset.data, full_matrices=False)
         dataset["data_left_singular_vectors"] = (("time", "left_singular_value_index"), l)
         dataset["data_singular_values"] = (("singular_value_index"), s)
         dataset["data_right_singular_vectors"] = (("right_singular_value_index", "spectral"), r)


### PR DESCRIPTION
Issue explained in #574 

Change call to numpy.linalg.svd to use full_matrices=False

**Closing issues**

Closes #574 
