### PR TITLE
Refactor io plugins

### DIFF
--- a/glotaran/__init__.py
+++ b/glotaran/__init__.py
@@ -2,8 +2,10 @@
 
 from importlib import metadata
 
-for entry_point in metadata.entry_points()["glotaran.plugins"]:
-    entry_point.load()
+for entry_point_name, entry_points in metadata.entry_points().items():
+    if entry_point_name.startswith("glotaran.plugins"):
+        for entry_point in entry_points:
+            entry_point.load()
 
 __version__ = "0.3.2"
 # TODO: add git SHA1 information

--- a/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
+++ b/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
@@ -9,8 +9,8 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from glotaran.io import Io
-from glotaran.io import register_io
+from glotaran.io import DataIoInterface
+from glotaran.io import register_data_io
 from glotaran.io.prepare_dataset import prepare_time_trace_dataset
 from glotaran.project import SavingOptions
 
@@ -244,8 +244,8 @@ def get_data_file_format(line):
 
 
 #  @file_reader(extension="ascii", name="Wavelength-/Time-Explicit ASCII")
-@register_io("ascii")
-class AsciiIo(Io):
+@register_data_io("ascii")
+class AsciiIo(DataIoInterface):
     def read_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
         """Reads an ascii file in wavelength- or time-explicit format.
 

--- a/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
+++ b/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
@@ -245,7 +245,7 @@ def get_data_file_format(line):
 
 #  @file_reader(extension="ascii", name="Wavelength-/Time-Explicit ASCII")
 @register_data_io("ascii")
-class AsciiIo(DataIoInterface):
+class AsciiDataIo(DataIoInterface):
     def read_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
         """Reads an ascii file in wavelength- or time-explicit format.
 

--- a/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
+++ b/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
@@ -246,7 +246,7 @@ def get_data_file_format(line):
 #  @file_reader(extension="ascii", name="Wavelength-/Time-Explicit ASCII")
 @register_io("ascii")
 class AsciiIo(Io):
-    def read_dataset(self, fmt: str, file_name: str) -> xr.Dataset | xr.DataArray:
+    def read_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
         """Reads an ascii file in wavelength- or time-explicit format.
 
         See [1]_ for documentation of this format.
@@ -279,9 +279,7 @@ class AsciiIo(Io):
 
         return data_file.read(prepare=True)
 
-    def write_dataset(
-        self, fmt: str, file_name: str, saving_options: SavingOptions, dataset: xr.Dataset
-    ):
+    def write_dataset(self, file_name: str, saving_options: SavingOptions, dataset: xr.Dataset):
         file_format = "TimeExplicit"
         number_format = "%.10e"
         data_file = (

--- a/glotaran/builtin/io/csv/csv.py
+++ b/glotaran/builtin/io/csv/csv.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pandas as pd
 
 from glotaran.io import register_io

--- a/glotaran/builtin/io/csv/csv.py
+++ b/glotaran/builtin/io/csv/csv.py
@@ -1,15 +1,16 @@
 import pandas as pd
 
 from glotaran.io import register_io
+from glotaran.io.io import Io
 from glotaran.parameter import ParameterGroup
 
 
 @register_io(["csv"])
-class CsvIo:
-    def read_parameters(self, fmt: str, file_name: str) -> ParameterGroup:
+class CsvIo(Io):
+    def read_parameters(self, file_name: str) -> ParameterGroup:
         df = pd.read_csv(file_name, skipinitialspace=True, na_values=["None", "none"])
         return ParameterGroup.from_dataframe(df, source=file_name)
 
-    def write_parameters(self, fmt: str, file_name: str, parameters: ParameterGroup):
+    def write_parameters(self, file_name: str, parameters: ParameterGroup):
         """Writes a :class:`ParameterGroup` to a CSV file."""
         parameters.to_dataframe().to_csv(file_name, na_rep="None", index=False)

--- a/glotaran/builtin/io/csv/csv.py
+++ b/glotaran/builtin/io/csv/csv.py
@@ -8,7 +8,7 @@ from glotaran.parameter import ParameterGroup
 
 
 @register_project_io(["csv"])
-class CsvIo(ProjectIoInterface):
+class CsvProjectIo(ProjectIoInterface):
     def read_parameters(self, file_name: str) -> ParameterGroup:
         df = pd.read_csv(file_name, skipinitialspace=True, na_values=["None", "none"])
         return ParameterGroup.from_dataframe(df, source=file_name)

--- a/glotaran/builtin/io/csv/csv.py
+++ b/glotaran/builtin/io/csv/csv.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import pandas as pd
 
-from glotaran.io import register_io
-from glotaran.io.io import Io
+from glotaran.io import ProjectIoInterface
+from glotaran.io import register_project_io
 from glotaran.parameter import ParameterGroup
 
 
-@register_io(["csv"])
-class CsvIo(Io):
+@register_project_io(["csv"])
+class CsvIo(ProjectIoInterface):
     def read_parameters(self, file_name: str) -> ParameterGroup:
         df = pd.read_csv(file_name, skipinitialspace=True, na_values=["None", "none"])
         return ParameterGroup.from_dataframe(df, source=file_name)

--- a/glotaran/builtin/io/netCDF/netCDF.py
+++ b/glotaran/builtin/io/netCDF/netCDF.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import xarray as xr
 
-from glotaran.io import Io
-from glotaran.io import register_io
+from glotaran.io import DataIoInterface
+from glotaran.io import register_data_io
 from glotaran.project import SavingOptions
 from glotaran.project import default_data_filters
 
 
-@register_io("nc")
-class NetCDFIo(Io):
+@register_data_io("nc")
+class NetCDFIo(DataIoInterface):
     def read_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
         return xr.open_dataset(file_name)
 

--- a/glotaran/builtin/io/netCDF/netCDF.py
+++ b/glotaran/builtin/io/netCDF/netCDF.py
@@ -10,12 +10,10 @@ from glotaran.project import default_data_filters
 
 @register_io("nc")
 class NetCDFIo(Io):
-    def read_dataset(self, fmt: str, file_name: str) -> xr.Dataset | xr.DataArray:
+    def read_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
         return xr.open_dataset(file_name)
 
-    def write_dataset(
-        self, fmt: str, file_name: str, saving_options: SavingOptions, dataset: xr.Dataset
-    ):
+    def write_dataset(self, file_name: str, saving_options: SavingOptions, dataset: xr.Dataset):
 
         data_to_save = dataset
 

--- a/glotaran/builtin/io/netCDF/netCDF.py
+++ b/glotaran/builtin/io/netCDF/netCDF.py
@@ -9,7 +9,7 @@ from glotaran.project import default_data_filters
 
 
 @register_data_io("nc")
-class NetCDFIo(DataIoInterface):
+class NetCDFDataIo(DataIoInterface):
     def read_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
         return xr.open_dataset(file_name)
 

--- a/glotaran/builtin/io/sdt/sdt_file_reader.py
+++ b/glotaran/builtin/io/sdt/sdt_file_reader.py
@@ -15,7 +15,7 @@ from glotaran.io.prepare_dataset import prepare_time_trace_dataset
 
 
 @register_data_io("sdt")
-class SdtIo(DataIoInterface):
+class SdtDataIo(DataIoInterface):
     def read_dataset(
         self,
         file_name: str,

--- a/glotaran/builtin/io/sdt/sdt_file_reader.py
+++ b/glotaran/builtin/io/sdt/sdt_file_reader.py
@@ -9,13 +9,13 @@ import numpy as np
 import xarray as xr
 from sdtfile import SdtFile
 
-from glotaran.io import Io
-from glotaran.io import register_io
+from glotaran.io import DataIoInterface
+from glotaran.io import register_data_io
 from glotaran.io.prepare_dataset import prepare_time_trace_dataset
 
 
-@register_io("sdt")
-class SdtIo(Io):
+@register_data_io("sdt")
+class SdtIo(DataIoInterface):
     def read_dataset(
         self,
         file_name: str,

--- a/glotaran/builtin/io/sdt/sdt_file_reader.py
+++ b/glotaran/builtin/io/sdt/sdt_file_reader.py
@@ -16,8 +16,8 @@ from glotaran.io.prepare_dataset import prepare_time_trace_dataset
 class SdtIo(Io):
     def read_dataset(
         self,
-        fmt: str,
         file_name: str,
+        *,
         index: np.ndarray = None,
         flim: bool = False,
         dataset_index: int = None,

--- a/glotaran/builtin/io/sdt/sdt_file_reader.py
+++ b/glotaran/builtin/io/sdt/sdt_file_reader.py
@@ -1,6 +1,8 @@
 """
 Glotarans module to read files
 """
+from __future__ import annotations
+
 import warnings
 
 import numpy as np
@@ -18,9 +20,9 @@ class SdtIo(Io):
         self,
         file_name: str,
         *,
-        index: np.ndarray = None,
+        index: np.ndarray | None = None,
         flim: bool = False,
-        dataset_index: int = None,
+        dataset_index: int | None = None,
         swap_axis: bool = False,
         orig_time_axis_index: int = 2,
     ) -> xr.Dataset:

--- a/glotaran/builtin/io/sdt/test/test_file_readers.py
+++ b/glotaran/builtin/io/sdt/test/test_file_readers.py
@@ -16,8 +16,8 @@ from . import TEMPORAL_DATA
 )
 def test_read_sdt(test_file_path, result_file_path, index):
 
-    sdt_reader = SdtIo()
-    test_dataset = sdt_reader.read_dataset("sdt", test_file_path, index=index)
+    sdt_reader = SdtIo("sdt")
+    test_dataset = sdt_reader.read_dataset(test_file_path, index=index)
     result_df = pd.read_csv(
         result_file_path, skiprows=1, sep=r"\s+", dtype={"Delay": float, "Data": np.uint16}
     )

--- a/glotaran/builtin/io/sdt/test/test_file_readers.py
+++ b/glotaran/builtin/io/sdt/test/test_file_readers.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from glotaran.builtin.io.sdt.sdt_file_reader import SdtIo
+from glotaran.builtin.io.sdt.sdt_file_reader import SdtDataIo
 
 from . import TEMPORAL_DATA
 
@@ -16,7 +16,7 @@ from . import TEMPORAL_DATA
 )
 def test_read_sdt(test_file_path, result_file_path, index):
 
-    sdt_reader = SdtIo("sdt")
+    sdt_reader = SdtDataIo("sdt")
     test_dataset = sdt_reader.read_dataset(test_file_path, index=index)
     result_df = pd.read_csv(
         result_file_path, skiprows=1, sep=r"\s+", dtype={"Delay": float, "Data": np.uint16}

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import pathlib
 from dataclasses import asdict
+from typing import TYPE_CHECKING
 
 import yaml
 
@@ -8,14 +11,16 @@ from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
 from glotaran.io import register_io
-from glotaran.model import Model
 from glotaran.model import get_model
 from glotaran.parameter import ParameterGroup
-from glotaran.project import Result
 from glotaran.project import SavingOptions
 from glotaran.project import Scheme
 
 from .sanatize import sanitize_yaml
+
+if TYPE_CHECKING:
+    from glotaran.model import Model
+    from glotaran.project import Result
 
 
 @register_io(["yml", "yaml", "yml_str"])
@@ -102,7 +107,7 @@ class YmlIo(Io):
         data = {}
         for label, path in scheme["data"].items():
             fmt = scheme.get("data_format", None)
-            path = pathlib.Path(path)
+            path = str(pathlib.Path(path).resolve())
 
             try:
                 data[label] = load_dataset(path, fmt=fmt)

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -6,11 +6,11 @@ from typing import TYPE_CHECKING
 
 import yaml
 
-from glotaran.io import Io
+from glotaran.io import ProjectIoInterface
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
-from glotaran.io import register_io
+from glotaran.io import register_project_io
 from glotaran.model import get_model
 from glotaran.parameter import ParameterGroup
 from glotaran.project import SavingOptions
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
     from glotaran.project import Result
 
 
-@register_io(["yml", "yaml", "yml_str"])
-class YmlIo(Io):
+@register_project_io(["yml", "yaml", "yml_str"])
+class YmlIo(ProjectIoInterface):
     def read_model(self, file_name: str) -> Model:
         """parse_yaml_file reads the given file and parses its content as YML.
 

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -20,7 +20,7 @@ from .sanatize import sanitize_yaml
 
 @register_io(["yml", "yaml", "yml_str"])
 class YmlIo(Io):
-    def read_model(self, fmt: str, file_name: str) -> Model:
+    def read_model(self, file_name: str) -> Model:
         """parse_yaml_file reads the given file and parses its content as YML.
 
         Parameters
@@ -34,7 +34,7 @@ class YmlIo(Io):
             The content of the file as dictionary.
         """
 
-        if fmt == "yml_str":
+        if self.format == "yml_str":
             spec = yaml.safe_load(file_name)
 
         else:
@@ -52,9 +52,9 @@ class YmlIo(Io):
         model = get_model(model_type)
         return model.from_dict(spec)
 
-    def read_parameters(self, fmt: str, file_name: str) -> ParameterGroup:
+    def read_parameters(self, file_name: str) -> ParameterGroup:
 
-        if fmt == "yml_str":
+        if self.format == "yml_str":
             spec = yaml.safe_load(file_name)
         else:
             with open(file_name) as f:
@@ -65,8 +65,8 @@ class YmlIo(Io):
         else:
             return ParameterGroup.from_dict(spec)
 
-    def read_scheme(self, fmt: str, file_name: str) -> Scheme:
-        if fmt == "yml_str":
+    def read_scheme(self, file_name: str) -> Scheme:
+        if self.format == "yml_str":
             yml = file_name
         else:
             try:
@@ -131,12 +131,10 @@ class YmlIo(Io):
             saving=saving,
         )
 
-    def write_scheme(self, fmt: str, file_name: str, scheme: Scheme):
+    def write_scheme(self, file_name: str, scheme: Scheme):
         _write_dict(file_name, asdict(scheme))
 
-    def write_result(
-        self, fmt: str, file_name: str, saving_options: SavingOptions, result: Result
-    ):
+    def write_result(self, file_name: str, saving_options: SavingOptions, result: Result):
         _write_dict(file_name, asdict(result))
 
 

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 @register_project_io(["yml", "yaml", "yml_str"])
-class YmlIo(ProjectIoInterface):
+class YmlProjectIo(ProjectIoInterface):
     def read_model(self, file_name: str) -> Model:
         """parse_yaml_file reads the given file and parses its content as YML.
 

--- a/glotaran/cli/commands/optimize.py
+++ b/glotaran/cli/commands/optimize.py
@@ -5,7 +5,7 @@ import click
 
 from glotaran.analysis.optimize import optimize
 from glotaran.io import save_result
-from glotaran.io.register import known_fmts
+from glotaran.io.register import known_data_fmts
 from glotaran.project.scheme import Scheme
 
 from . import util
@@ -15,7 +15,7 @@ from . import util
     "--dataformat",
     "-dfmt",
     default=None,
-    type=click.Choice(known_fmts()),
+    type=click.Choice(known_data_fmts()),
     help="The input format of the data. Will be inferred from extension if not set.",
 )
 @click.option(

--- a/glotaran/cli/commands/pluginlist.py
+++ b/glotaran/cli/commands/pluginlist.py
@@ -1,6 +1,7 @@
 import click
 
-from glotaran.io.register import known_fmts
+from glotaran.io.register import known_data_fmts
+from glotaran.io.register import known_project_fmts
 from glotaran.model import known_model_names
 
 
@@ -17,9 +18,14 @@ def plugin_list_cmd():
     for name in known_model_names():
         output += f"    * {name}\n"
 
-    output += "\nFile Formats\n\n"
+    output += "\nData file Formats\n\n"
 
-    for reader_fmt in known_fmts():
+    for reader_fmt in known_data_fmts():
+        output += f"    * .{reader_fmt}\n"
+
+    output += "\nProject file Formats\n\n"
+
+    for reader_fmt in known_project_fmts():
         output += f"    * .{reader_fmt}\n"
 
     click.echo(output)

--- a/glotaran/io/__init__.py
+++ b/glotaran/io/__init__.py
@@ -1,7 +1,9 @@
 """Functions for data IO"""
 
-from .decorator import register_io
-from .io import Io
+from .decorator import register_data_io
+from .decorator import register_project_io
+from .interface import DataIoInterface
+from .interface import ProjectIoInterface
 from .prepare_dataset import prepare_time_trace_dataset
 from .project import save_result
 from .register import load_dataset

--- a/glotaran/io/decorator.py
+++ b/glotaran/io/decorator.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
-from .register import register_io as register
+from typing import TYPE_CHECKING
+
+from .register import _register_data_io
+from .register import _register_project_io
+
+if TYPE_CHECKING:
+    from glotaran.io.register import DataIoInterface
+    from glotaran.io.register import ProjectIoInterface
 
 
-def register_io(fmt: str | list(str)):
-    def decorator(cls):
-        register(fmt, cls)
+def register_data_io(fmt: str | list[str]):
+    def decorator(cls: type[DataIoInterface]):
+        _register_data_io(fmt, cls)
+        return cls
+
+    return decorator
+
+
+def register_project_io(fmt: str | list[str]):
+    def decorator(cls: type[ProjectIoInterface]):
+        _register_project_io(fmt, cls)
         return cls
 
     return decorator

--- a/glotaran/io/interface.py
+++ b/glotaran/io/interface.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Callable
+    from typing import Union
+
     import xarray as xr
 
     from glotaran.model import Model
@@ -11,19 +14,58 @@ if TYPE_CHECKING:
     from glotaran.project import SavingOptions
     from glotaran.project import Scheme
 
+    DataLoader = Callable[[str], Union[xr.Dataset, xr.DataArray]]
+    DataWriter = Callable[[str, SavingOptions, xr.Dataset], None]
+
 
 class DataIoInterface:
+    """Baseclass for Data IO plugins."""
+
     def __init__(self, fmt: str) -> None:
         self.format = fmt
 
     def read_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
-        raise NotImplementedError
+        """'read_dataset' isn't implemented for this format."""
+        raise NotImplementedError(
+            f"""'read_dataset' isn't implemented for the format: {self.format!r}"""
+        )
 
     def write_dataset(self, file_name: str, saving_options: SavingOptions, dataset: xr.Dataset):
-        raise NotImplementedError
+        """'write_dataset' isn't implemented for this format."""
+        raise NotImplementedError(
+            f"""'write_dataset' isn't implemented for the format: {self.format!r}"""
+        )
+
+    def get_dataloader(self) -> DataLoader:
+        """Retrieve implementation of the read_dataset functionality.
+
+        This allows to get the proper help and autocomplete for the function,
+        which is especially valuable if the function provides additional options.
+
+        Returns
+        -------
+        DataLoader
+            Function to load data a given format as :xarraydoc:`Dataset` or :xarraydoc:`DataArray`.
+        """
+        return self.read_dataset
+
+    def get_datawriter(self) -> DataWriter:
+        """Retrieve implementation of the write_dataset functionality.
+
+        This allows to get the proper help and autocomplete for the function,
+        which is especially valuable if the function provides additional options.
+
+        Returns
+        -------
+        DataWriter
+            Function to write :xarraydoc:`Dataset` to a given format.
+        """
+        return self.write_dataset
 
 
 class ProjectIoInterface:
+    """Baseclass for Project IO plugins."""
+
     def __init__(self, fmt: str) -> None:
         self.format = fmt
 

--- a/glotaran/io/interface.py
+++ b/glotaran/io/interface.py
@@ -12,7 +12,18 @@ if TYPE_CHECKING:
     from glotaran.project import Scheme
 
 
-class Io:
+class DataIoInterface:
+    def __init__(self, fmt: str) -> None:
+        self.format = fmt
+
+    def read_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
+        raise NotImplementedError
+
+    def write_dataset(self, file_name: str, saving_options: SavingOptions, dataset: xr.Dataset):
+        raise NotImplementedError
+
+
+class ProjectIoInterface:
     def __init__(self, fmt: str) -> None:
         self.format = fmt
 
@@ -32,12 +43,6 @@ class Io:
         raise NotImplementedError
 
     def write_scheme(self, file_name: str, scheme: Scheme):
-        raise NotImplementedError
-
-    def read_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
-        raise NotImplementedError
-
-    def write_dataset(self, file_name: str, saving_options: SavingOptions, dataset: xr.Dataset):
         raise NotImplementedError
 
     def read_result(self, file_name: str) -> Result:

--- a/glotaran/io/io.py
+++ b/glotaran/io/io.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-import xarray as xr
+from typing import TYPE_CHECKING
 
-from glotaran.model import Model
-from glotaran.parameter import ParameterGroup
-from glotaran.project import Result
-from glotaran.project import SavingOptions
-from glotaran.project import Scheme
+if TYPE_CHECKING:
+    import xarray as xr
+
+    from glotaran.model import Model
+    from glotaran.parameter import ParameterGroup
+    from glotaran.project import Result
+    from glotaran.project import SavingOptions
+    from glotaran.project import Scheme
 
 
 class Io:
@@ -31,10 +34,10 @@ class Io:
     def write_scheme(self, file_name: str, scheme: Scheme):
         raise NotImplementedError
 
-    def read_dataset(self, file_name: str) -> xr.DataSet | xr.DataArray:
+    def read_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
         raise NotImplementedError
 
-    def write_dataset(self, file_name: str, saving_options: SavingOptions, dataset: xr.DataSet):
+    def write_dataset(self, file_name: str, saving_options: SavingOptions, dataset: xr.Dataset):
         raise NotImplementedError
 
     def read_result(self, file_name: str) -> Result:

--- a/glotaran/io/io.py
+++ b/glotaran/io/io.py
@@ -10,36 +10,35 @@ from glotaran.project import Scheme
 
 
 class Io:
-    def read_model(self, fmt: str, file_name: str) -> Model:
+    def __init__(self, fmt: str) -> None:
+        self.format = fmt
+
+    def read_model(self, file_name: str) -> Model:
         raise NotImplementedError
 
-    def write_model(self, fmt: str, file_name: str, model: Model):
+    def write_model(self, file_name: str, model: Model):
         raise NotImplementedError
 
-    def read_parameters(self, fmt: str, file_name: str) -> ParameterGroup:
+    def read_parameters(self, file_name: str) -> ParameterGroup:
         raise NotImplementedError
 
-    def write_parameters(self, fmt: str, file_name: str, parameters: ParameterGroup):
+    def write_parameters(self, file_name: str, parameters: ParameterGroup):
         raise NotImplementedError
 
-    def read_scheme(self, fmt: str, file_name: str) -> Scheme:
+    def read_scheme(self, file_name: str) -> Scheme:
         raise NotImplementedError
 
-    def write_scheme(self, fmt: str, file_name: str, scheme: Scheme):
+    def write_scheme(self, file_name: str, scheme: Scheme):
         raise NotImplementedError
 
-    def read_dataset(self, fmt: str, file_name: str) -> xr.DataSet | xr.DataArray:
+    def read_dataset(self, file_name: str) -> xr.DataSet | xr.DataArray:
         raise NotImplementedError
 
-    def write_dataset(
-        self, fmt: str, file_name: str, saving_options: SavingOptions, dataset: xr.DataSet
-    ):
+    def write_dataset(self, file_name: str, saving_options: SavingOptions, dataset: xr.DataSet):
         raise NotImplementedError
 
-    def read_result(self, fmt: str, file_name: str) -> Result:
+    def read_result(self, file_name: str) -> Result:
         raise NotImplementedError
 
-    def write_result(
-        self, fmt: str, file_name: str, saving_options: SavingOptions, result: Result
-    ):
+    def write_result(self, file_name: str, saving_options: SavingOptions, result: Result):
         raise NotImplementedError

--- a/glotaran/io/register.py
+++ b/glotaran/io/register.py
@@ -9,6 +9,8 @@ from glotaran.project import SavingOptions
 
 if TYPE_CHECKING:
     from glotaran.io.interface import DataIoInterface
+    from glotaran.io.interface import DataLoader
+    from glotaran.io.interface import DataWriter
     from glotaran.io.interface import ProjectIoInterface
     from glotaran.model import Model
     from glotaran.parameter import ParameterGroup
@@ -120,6 +122,36 @@ def write_dataset(
         return io.write_dataset(file_name, saving_options, dataset)
     except NotImplementedError:
         raise ValueError(f"Cannot write dataset with format '{fmt}'")
+
+
+def get_dataloader(fmt: str) -> DataLoader:
+    """Retrieve implementation of the read_dataset functionalityfor the format 'fmt'.
+
+    This allows to get the proper help and autocomplete for the function,
+    which is especially valuable if the function provides additional options.
+
+    Returns
+    -------
+    DataLoader
+        Function to load data of format 'fmt' as :xarraydoc:`Dataset` or :xarraydoc:`DataArray`.
+    """
+    io = get_data_io(fmt)
+    return io.get_dataloader()
+
+
+def get_datawriter(fmt: str) -> DataWriter:
+    """Retrieve implementation of the write_dataset functionality for the format 'fmt'.
+
+    This allows to get the proper help and autocomplete for the function,
+    which is especially valuable if the function provides additional options.
+
+    Returns
+    -------
+    DataWriter
+        Function to write :xarraydoc:`Dataset` to the format 'fmt' .
+    """
+    io = get_data_io(fmt)
+    return io.get_datawriter()
 
 
 def write_result(

--- a/glotaran/io/register.py
+++ b/glotaran/io/register.py
@@ -8,38 +8,61 @@ import xarray as xr
 from glotaran.project import SavingOptions
 
 if TYPE_CHECKING:
-    from glotaran.io.io import Io
+    from glotaran.io.interface import DataIoInterface
+    from glotaran.io.interface import ProjectIoInterface
     from glotaran.model import Model
     from glotaran.parameter import ParameterGroup
     from glotaran.project import Result
     from glotaran.project import Scheme
 
-_io_register: dict[str, Io] = {}
+__data_io_register: dict[str, DataIoInterface] = {}
+
+__project_io_register: dict[str, ProjectIoInterface] = {}
 
 
-def register_io(fmt: str | list[str], io: type[Io]):
+def _register_data_io(fmt: str | list[str], io: type[DataIoInterface]):
     fmt = fmt if isinstance(fmt, list) else [fmt]
     for fmt_name in fmt:
-        _io_register[fmt_name] = io(fmt_name)
+        __data_io_register[fmt_name] = io(fmt_name)
 
 
-def known_fmt(fmt: str) -> bool:
-    return fmt in _io_register
+def known_data_fmt(fmt: str) -> bool:
+    return fmt in __data_io_register
 
 
-def get_io(fmt: str) -> Io:
-    if not known_fmt(fmt):
-        raise ValueError(f"Unknown format '{fmt}'. Known formats are: {known_fmts()}")
-    return _io_register[fmt]
+def get_data_io(fmt: str) -> DataIoInterface:
+    if not known_data_fmt(fmt):
+        raise ValueError(f"Unknown format '{fmt}'. Known formats are: {known_data_fmts()}")
+    return __data_io_register[fmt]
 
 
-def known_fmts() -> list[str]:
-    return [fmt for fmt in _io_register]
+def known_data_fmts() -> list[str]:
+    return [fmt for fmt in __data_io_register]
+
+
+def _register_project_io(fmt: str | list[str], io: type[ProjectIoInterface]):
+    fmt = fmt if isinstance(fmt, list) else [fmt]
+    for fmt_name in fmt:
+        __project_io_register[fmt_name] = io(fmt_name)
+
+
+def known_project_fmt(fmt: str) -> bool:
+    return fmt in __project_io_register
+
+
+def get_project_io(fmt: str) -> ProjectIoInterface:
+    if not known_project_fmt(fmt):
+        raise ValueError(f"Unknown format '{fmt}'. Known formats are: {known_data_fmts()}")
+    return __project_io_register[fmt]
+
+
+def known_project_fmts() -> list[str]:
+    return [fmt for fmt in __project_io_register]
 
 
 def load_model(file_name: str, fmt: str = None) -> Model:
     fmt = _get_fmt_from_file_name(file_name) if fmt is None else fmt
-    io = get_io(fmt)
+    io = get_project_io(fmt)
     try:
         return io.read_model(file_name)
     except NotImplementedError:
@@ -48,7 +71,7 @@ def load_model(file_name: str, fmt: str = None) -> Model:
 
 def load_scheme(file_name: str, fmt: str = None) -> Scheme:
     fmt = _get_fmt_from_file_name(file_name) if fmt is None else fmt
-    io = get_io(fmt)
+    io = get_project_io(fmt)
     try:
         return io.read_scheme(file_name)
     except NotImplementedError:
@@ -56,7 +79,7 @@ def load_scheme(file_name: str, fmt: str = None) -> Scheme:
 
 
 def write_scheme(file_name: str, fmt: str, scheme: Scheme):
-    io = get_io(fmt)
+    io = get_project_io(fmt)
     try:
         return io.write_scheme(file_name, scheme)
     except NotImplementedError:
@@ -65,7 +88,7 @@ def write_scheme(file_name: str, fmt: str, scheme: Scheme):
 
 def load_parameters(file_name: str, fmt: str = None) -> ParameterGroup:
     fmt = _get_fmt_from_file_name(file_name) if fmt is None else fmt
-    io = get_io(fmt)
+    io = get_project_io(fmt)
     try:
         return io.read_parameters(file_name)
     except NotImplementedError:
@@ -73,7 +96,7 @@ def load_parameters(file_name: str, fmt: str = None) -> ParameterGroup:
 
 
 def write_parameters(file_name: str, fmt: str, parameters: ParameterGroup):
-    io = get_io(fmt)
+    io = get_project_io(fmt)
     try:
         return io.write_parameters(file_name, parameters)
     except NotImplementedError:
@@ -82,7 +105,7 @@ def write_parameters(file_name: str, fmt: str, parameters: ParameterGroup):
 
 def load_dataset(file_name: str, fmt: str = None) -> xr.Dataset | xr.DataArray:
     fmt = _get_fmt_from_file_name(file_name) if fmt is None else fmt
-    io = get_io(fmt)
+    io = get_data_io(fmt)
     try:
         return io.read_dataset(file_name)
     except NotImplementedError:
@@ -92,7 +115,7 @@ def load_dataset(file_name: str, fmt: str = None) -> xr.Dataset | xr.DataArray:
 def write_dataset(
     file_name: str, fmt: str, dataset: xr.Dataset, saving_options: SavingOptions = SavingOptions()
 ):
-    io = get_io(fmt)
+    io = get_data_io(fmt)
     try:
         return io.write_dataset(file_name, saving_options, dataset)
     except NotImplementedError:
@@ -102,7 +125,7 @@ def write_dataset(
 def write_result(
     file_name: str, fmt: str, result: Result, saving_options: SavingOptions = SavingOptions()
 ):
-    io = get_io(fmt)
+    io = get_project_io(fmt)
     try:
         return io.write_result(file_name, saving_options, result)
     except NotImplementedError:

--- a/glotaran/io/register.py
+++ b/glotaran/io/register.py
@@ -1,24 +1,26 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 import xarray as xr
 
-from glotaran.model import Model
-from glotaran.parameter import ParameterGroup
-from glotaran.project import Result
 from glotaran.project import SavingOptions
-from glotaran.project import Scheme
 
-from .io import Io
+if TYPE_CHECKING:
+    from glotaran.io.io import Io
+    from glotaran.model import Model
+    from glotaran.parameter import ParameterGroup
+    from glotaran.project import Result
+    from glotaran.project import Scheme
 
-_io_register = {}
+_io_register: dict[str, Io] = {}
 
 
-def register_io(fmt: str | list[str], io: Io):
+def register_io(fmt: str | list[str], io: type[Io]):
     fmt = fmt if isinstance(fmt, list) else [fmt]
     for fmt_name in fmt:
-        _io_register[fmt_name] = io()
+        _io_register[fmt_name] = io(fmt_name)
 
 
 def known_fmt(fmt: str) -> bool:
@@ -39,7 +41,7 @@ def load_model(file_name: str, fmt: str = None) -> Model:
     fmt = _get_fmt_from_file_name(file_name) if fmt is None else fmt
     io = get_io(fmt)
     try:
-        return io.read_model(fmt, file_name)
+        return io.read_model(file_name)
     except NotImplementedError:
         raise ValueError(f"Cannot read models with format '{fmt}'")
 
@@ -48,7 +50,7 @@ def load_scheme(file_name: str, fmt: str = None) -> Scheme:
     fmt = _get_fmt_from_file_name(file_name) if fmt is None else fmt
     io = get_io(fmt)
     try:
-        return io.read_scheme(fmt, file_name)
+        return io.read_scheme(file_name)
     except NotImplementedError:
         raise ValueError(f"Cannot read scheme with format '{fmt}'")
 
@@ -56,7 +58,7 @@ def load_scheme(file_name: str, fmt: str = None) -> Scheme:
 def write_scheme(file_name: str, fmt: str, scheme: Scheme):
     io = get_io(fmt)
     try:
-        return io.write_scheme(fmt, file_name, scheme)
+        return io.write_scheme(file_name, scheme)
     except NotImplementedError:
         raise ValueError(f"Cannot write scheme with format '{fmt}'")
 
@@ -65,7 +67,7 @@ def load_parameters(file_name: str, fmt: str = None) -> ParameterGroup:
     fmt = _get_fmt_from_file_name(file_name) if fmt is None else fmt
     io = get_io(fmt)
     try:
-        return io.read_parameters(fmt, file_name)
+        return io.read_parameters(file_name)
     except NotImplementedError:
         raise ValueError(f"Cannot read parameters with format '{fmt}'")
 
@@ -73,7 +75,7 @@ def load_parameters(file_name: str, fmt: str = None) -> ParameterGroup:
 def write_parameters(file_name: str, fmt: str, parameters: ParameterGroup):
     io = get_io(fmt)
     try:
-        return io.write_parameters(fmt, file_name, parameters)
+        return io.write_parameters(file_name, parameters)
     except NotImplementedError:
         raise ValueError(f"Cannot write parameters with format '{fmt}'")
 
@@ -82,7 +84,7 @@ def load_dataset(file_name: str, fmt: str = None) -> xr.Dataset | xr.DataArray:
     fmt = _get_fmt_from_file_name(file_name) if fmt is None else fmt
     io = get_io(fmt)
     try:
-        return io.read_dataset(fmt, file_name)
+        return io.read_dataset(file_name)
     except NotImplementedError:
         raise ValueError(f"Cannot read dataset with format '{fmt}'")
 
@@ -92,7 +94,7 @@ def write_dataset(
 ):
     io = get_io(fmt)
     try:
-        return io.write_dataset(fmt, file_name, saving_options, dataset)
+        return io.write_dataset(file_name, saving_options, dataset)
     except NotImplementedError:
         raise ValueError(f"Cannot write dataset with format '{fmt}'")
 
@@ -102,7 +104,7 @@ def write_result(
 ):
     io = get_io(fmt)
     try:
-        return io.write_result(fmt, file_name, saving_options, result)
+        return io.write_result(file_name, saving_options, result)
     except NotImplementedError:
         raise ValueError(f"Cannot write dataset with format '{fmt}'")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ remove_redundant_aliases = true
 [tool.interrogate]
 exclude = ["setup.py", "docs", "*test/*"]
 ignore-init-module = true
-fail-under = 35
+fail-under = 38
 
 [tool.nbqa.addopts]
 flake8 = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,14 +49,16 @@ zip_safe = True
 [options.entry_points]
 console_scripts =
     glotaran=glotaran.cli.main:glotaran
-glotaran.plugins =
-    kinetic_image_model = glotaran.builtin.models.kinetic_image
-    kinetic_spectrum_model = glotaran.builtin.models.kinetic_spectrum
-    ascii_file = glotaran.builtin.io.ascii.wavelength_time_explicit_file
-    sdt_file = glotaran.builtin.io.sdt.sdt_file_reader
-    csv_io = glotaran.builtin.io.csv.csv
-    nc_io = glotaran.builtin.io.netCDF.netCDF
-    yml_io = glotaran.builtin.io.yml.yml
+glotaran.plugins.data_io =
+    ascii = glotaran.builtin.io.ascii.wavelength_time_explicit_file
+    sdt = glotaran.builtin.io.sdt.sdt_file_reader
+    nc = glotaran.builtin.io.netCDF.netCDF
+glotaran.plugins.model =
+    kinetic_image = glotaran.builtin.models.kinetic_image
+    kinetic_spectrum = glotaran.builtin.models.kinetic_spectrum
+glotaran.plugins.project_io =
+    yml = glotaran.builtin.io.yml.yml
+    csv = glotaran.builtin.io.csv.csv
 
 [aliases]
 test = pytest


### PR DESCRIPTION
This PR address  some of the changes proposed in #586 

- [x] Splitup entry points to be more granular
- [x] Rename Io and possibly split it up
- [x] Make use of the `Io` instances and remove the fmt arg
- [x] Add a `get_dataloader` (maybe even `get_datawriter`) method and convenience function for `DataIoInterfaces`

Since each commit has a district purpose, it might be easiest to review this PR commit by commit.

The other changes will be done in a separate PR since this will simplify the review.
- [ ] Move all the plugin registration code in one module/package
- [ ] Add warning when a plugin replaces an existing one

**Testing**

Passing the tests is mandatory.

**Closing issues**

not yet
