### PR TITLE
Use tabulate for table markdown formatting

### DIFF
--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -379,9 +379,12 @@ class ParameterGroup(dict):
                 parameter.value = value
 
     def markdown(self) -> str:
-        """Formats the :class:`ParameterGroup` as markdown string."""
-        t = "  " * self.get_nr_roots()
-        s = ""
+        """Formats the :class:`ParameterGroup` as markdown string.
+
+        This is done by recursing the nested :class:`ParameterGroup` tree.
+        """
+        node_indentation = "  " * self.get_nr_roots()
+        return_string = ""
         parameter_rows = []
         table_header = [
             "_Label_",
@@ -394,7 +397,7 @@ class ParameterGroup(dict):
             "_Expr_",
         ]
         if self.label != "p":
-            s += f"{t}* __{self.label}__:\n"
+            return_string += f"{node_indentation}* __{self.label}__:\n"
         if len(self._parameters):
             for _, parameter in self._parameters.items():
                 parameter_rows.append(
@@ -413,12 +416,12 @@ class ParameterGroup(dict):
                 tabulate(
                     parameter_rows, headers=table_header, tablefmt="github", missingval="None"
                 ),
-                f"  {t}",
+                f"  {node_indentation}",
             )
-            s += f"{parameter_table}\n\n"
-        for _, g in self.items():
-            s += f"{g.__str__()}"
-        return s
+            return_string += f"{parameter_table}\n\n"
+        for _, child_group in self.items():
+            return_string += f"{child_group.__str__()}"
+        return return_string
 
     def __repr__(self):
         return self.markdown()

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -395,7 +395,7 @@ class ParameterGroup(dict):
             "_Non-Negative_",
             "_Expr_",
         ]
-        if self.label != "p":
+        if self.label is not None:
             return_string += f"{node_indentation}* __{self.label}__:\n"
         if len(self._parameters):
             parameter_rows = [

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -385,7 +385,6 @@ class ParameterGroup(dict):
         """
         node_indentation = "  " * self.get_nr_roots()
         return_string = ""
-        parameter_rows = []
         table_header = [
             "_Label_",
             "_Value_",
@@ -399,19 +398,19 @@ class ParameterGroup(dict):
         if self.label != "p":
             return_string += f"{node_indentation}* __{self.label}__:\n"
         if len(self._parameters):
-            for _, parameter in self._parameters.items():
-                parameter_rows.append(
-                    [
-                        parameter.label,
-                        parameter.value,
-                        parameter.standard_error,
-                        parameter.minimum,
-                        parameter.maximum,
-                        parameter.vary,
-                        parameter.non_negative,
-                        parameter.expression,
-                    ]
-                )
+            parameter_rows = [
+                [
+                    parameter.label,
+                    parameter.value,
+                    parameter.standard_error,
+                    parameter.minimum,
+                    parameter.maximum,
+                    parameter.vary,
+                    parameter.non_negative,
+                    parameter.expression,
+                ]
+                for _, parameter in self._parameters.items()
+            ]
             parameter_table = indent(
                 tabulate(
                     parameter_rows, headers=table_header, tablefmt="github", missingval="None"

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from copy import copy
+from textwrap import indent
 from typing import Generator
 
 import asteval
 import numpy as np
 import pandas as pd
+from tabulate import tabulate
 
 from .parameter import Parameter
 
@@ -378,12 +380,42 @@ class ParameterGroup(dict):
 
     def markdown(self) -> str:
         """Formats the :class:`ParameterGroup` as markdown string."""
-        t = "".join("  " for _ in range(self.get_nr_roots()))
+        t = "  " * self.get_nr_roots()
         s = ""
+        parameter_rows = []
+        table_header = [
+            "_Label_",
+            "_Value_",
+            "_StdErr_",
+            "_Min_",
+            "_Max_",
+            "_Vary_",
+            "_Non-Negative_",
+            "_Expr_",
+        ]
         if self.label != "p":
             s += f"{t}* __{self.label}__:\n"
-        for _, p in self._parameters.items():
-            s += f"{t}  * {p}\n"
+        if len(self._parameters):
+            for _, parameter in self._parameters.items():
+                parameter_rows.append(
+                    [
+                        parameter.label,
+                        parameter.value,
+                        parameter.standard_error,
+                        parameter.minimum,
+                        parameter.maximum,
+                        parameter.vary,
+                        parameter.non_negative,
+                        parameter.expression,
+                    ]
+                )
+            parameter_table = indent(
+                tabulate(
+                    parameter_rows, headers=table_header, tablefmt="github", missingval="None"
+                ),
+                f"  {t}",
+            )
+            s += f"{parameter_table}\n\n"
         for _, g in self.items():
             s += f"{g.__str__()}"
         return s

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -139,16 +139,14 @@ class Result:
         )
         if len(self.data) > 1:
 
-            RMSE_rows = []
-            for index, (label, dataset) in enumerate(self.data.items(), start=1):
-
-                RMSE_rows.append(
-                    [
-                        f"{index}.{label}:",
-                        dataset.weighted_root_mean_square_error,
-                        dataset.root_mean_square_error,
-                    ]
-                )
+            RMSE_rows = [
+                [
+                    f"{index}.{label}:",
+                    dataset.weighted_root_mean_square_error,
+                    dataset.root_mean_square_error,
+                ]
+                for index, (label, dataset) in enumerate(self.data.items(), start=1)
+            ]
 
             RMSE_table = tabulate(
                 RMSE_rows,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,6 +14,7 @@ xarray==0.17.0
 netCDF4==1.5.6
 setuptools==41.2
 sdtfile==2020.12.10
+tabulate==0.8.8
 
 # documentation dependencies
 Sphinx>=3.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     scipy>=1.3.2
     sdtfile>=2020.8.3
     setuptools>=41.2
+    tabulate>=0.8.8
     xarray>=0.16.2
 python_requires = >=3.8, <3.9
 setup_requires =


### PR DESCRIPTION
Changes:
- Adds tabulate as a dependency
- `Result.markdown` now renders properly
- `ParameterGroup.markdown` is easier to read (both code and output)


A demo of how it looks [can be found at binder](https://mybinder.org/v2/gh/s-weigand/pyglotaran/tabulate?urlpath=lab%2Ftree%2Fdocs%2Fsource%2Fnotebooks%2Fquickstart.ipynb).

Compared it to [the current version](https://mybinder.org/v2/gh/glotaran/pyglotaran/main?urlpath=lab%2Ftree%2Fdocs%2Fsource%2Fnotebooks%2Fquickstart.ipynb), where the output of cell 16 showcases all changes.
To see the difference in plaintext (e.g. what a CLI user would see) use `print` instead of `print_md`.

**Testing**

Passing the tests is mandatory.

**Closing issues**

closes #587 
