### PR TITLE
Make ParameterGroup.markdown() indepedent of order parametergroups were added

### DIFF
--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -418,7 +418,7 @@ class ParameterGroup(dict):
                 f"  {node_indentation}",
             )
             return_string += f"{parameter_table}\n\n"
-        for _, child_group in self.items():
+        for _, child_group in sorted(self.items()):
             return_string += f"{child_group.__str__()}"
         return return_string
 

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -417,7 +417,7 @@ class ParameterGroup(dict):
                 ),
                 f"  {node_indentation}",
             )
-            return_string += f"{parameter_table}\n\n"
+            return_string += f"\n{parameter_table}\n\n"
         for _, child_group in sorted(self.items()):
             return_string += f"{child_group.__str__()}"
         return return_string

--- a/glotaran/parameter/test/test_parameter_group.py
+++ b/glotaran/parameter/test/test_parameter_group.py
@@ -1,0 +1,41 @@
+from glotaran.io import load_parameters
+from glotaran.parameter.parameter_group import ParameterGroup
+
+PARAMETERS_3C_BASE = """\
+irf:
+    - ["center", 1.3]
+    - ["width", 7.8]
+j:
+    - ["1", 1, {"vary": False, "non-negative": False}]
+"""
+
+PARAMETERS_3C_KINETIC = """\
+kinetic:
+    - ["1", 300e-3]
+    - ["2", 500e-4]
+    - ["3", 700e-5]
+"""
+
+
+def test_markdown_is_order_idependent():
+    """Markdown output of ParameterGroup.markdown() is independent of initial order"""
+    PARAMETERS_3C_INITIAL1 = f"""{PARAMETERS_3C_BASE}\n{PARAMETERS_3C_KINETIC}"""
+    PARAMETERS_3C_INITIAL2 = f"""{PARAMETERS_3C_KINETIC}\n{PARAMETERS_3C_BASE}"""
+
+    initial_parameters_ref = ParameterGroup.from_dict(
+        {
+            "j": [["1", 1, {"vary": False, "non-negative": False}]],
+            "kinetic": [
+                ["1", 300e-3],
+                ["2", 500e-4],
+                ["3", 700e-5],
+            ],
+            "irf": [["center", 1.3], ["width", 7.8]],
+        }
+    )
+
+    initial_parameters1 = load_parameters(PARAMETERS_3C_INITIAL1, fmt="yml_str")
+    initial_parameters2 = load_parameters(PARAMETERS_3C_INITIAL2, fmt="yml_str")
+
+    assert initial_parameters1.markdown() == initial_parameters_ref.markdown()
+    assert initial_parameters2.markdown() == initial_parameters_ref.markdown()

--- a/glotaran/parameter/test/test_parameter_group.py
+++ b/glotaran/parameter/test/test_parameter_group.py
@@ -16,8 +16,32 @@ kinetic:
     - ["3", 700e-5]
 """
 
+RENDERED_MARKDOWN = """\
+  * __irf__:
 
-def test_markdown_is_order_idependent():
+    | _Label_   |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
+    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
+    | center    |       1.3 |          0 |    -inf |     inf | True     | False            | None     |
+    | width     |       7.8 |          0 |    -inf |     inf | True     | False            | None     |
+
+  * __j__:
+
+    |   _Label_ |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
+    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
+    |         1 |         1 |          0 |    -inf |     inf | False    | False            | None     |
+
+  * __kinetic__:
+
+    |   _Label_ |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
+    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
+    |         1 |     0.3   |          0 |    -inf |     inf | True     | False            | None     |
+    |         2 |     0.05  |          0 |    -inf |     inf | True     | False            | None     |
+    |         3 |     0.007 |          0 |    -inf |     inf | True     | False            | None     |
+
+"""  # noqa: E501
+
+
+def test_markdown_is_order_independent():
     """Markdown output of ParameterGroup.markdown() is independent of initial order"""
     PARAMETERS_3C_INITIAL1 = f"""{PARAMETERS_3C_BASE}\n{PARAMETERS_3C_KINETIC}"""
     PARAMETERS_3C_INITIAL2 = f"""{PARAMETERS_3C_KINETIC}\n{PARAMETERS_3C_BASE}"""
@@ -37,5 +61,6 @@ def test_markdown_is_order_idependent():
     initial_parameters1 = load_parameters(PARAMETERS_3C_INITIAL1, fmt="yml_str")
     initial_parameters2 = load_parameters(PARAMETERS_3C_INITIAL2, fmt="yml_str")
 
-    assert initial_parameters1.markdown() == initial_parameters_ref.markdown()
-    assert initial_parameters2.markdown() == initial_parameters_ref.markdown()
+    assert initial_parameters1.markdown() == RENDERED_MARKDOWN
+    assert initial_parameters2.markdown() == RENDERED_MARKDOWN
+    assert initial_parameters_ref.markdown() == RENDERED_MARKDOWN


### PR DESCRIPTION
I just added your example from #538 as a test case and sorted the `child_group`s by the dict key before recursing them.

That way the markdown will always be sorted by the keys, but at least it will be the same no matter the order in the specs.

The test example looks like this:

  * __irf__:
    | _Label_   |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
    | center    |       1.3 |          0 |    -inf |     inf | True     | False            | None     |
    | width     |       7.8 |          0 |    -inf |     inf | True     | False            | None     |

  * __j__:
    |   _Label_ |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
    |         1 |         1 |          0 |    -inf |     inf | False    | False            | None     |

  * __kinetic__:
    |   _Label_ |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
    |         1 |     0.3   |          0 |    -inf |     inf | True     | False            | None     |
    |         2 |     0.05  |          0 |    -inf |     inf | True     | False            | None     |
    |         3 |     0.007 |          0 |    -inf |     inf | True     | False            | None     |

**Testing**

Passing the tests is mandatory.

**Closing issues**

closes #538 
