### PR TITLE
Add configs for tools planned to use

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,3 +70,8 @@ ignore_directives = autoattribute,autoclass,autoexception,autofunction,autometho
 
 [darglint]
 docstring_style = numpy
+
+[mypy]
+ignore_missing_imports = True
+scripts_are_modules = True
+show_error_codes = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,9 @@ ignore_directives = autoattribute,autoclass,autoexception,autofunction,autometho
 [darglint]
 docstring_style = numpy
 
+[pydocstyle]
+convention = numpy
+
 [mypy]
 ignore_missing_imports = True
 scripts_are_modules = True


### PR DESCRIPTION
Just some tool configs for QA tools we plan to use but can't for the whole project because then the CI would fail.
When I write code for PR's I check that my code passes tests with `mypy`, `pydocstyle` and `darglint`, which we also plan to use.
So it would be nice to already have the configs in place, so I don't need to pass all the CLI flags each time
