### PR TITLE
Prepare v0.3.3 release

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,18 @@
 History
 =======
 
-0.3.1 (2021-02-23)
+0.3.3 (2021-03-18)
+------------------
+* Force recalculation of SVD attributes in scheme._prepare_data (#597)
+* Remove unneeded check in spectral_penalties._get_area Fixes (#598)
+* Added python 3.9 support (#450)
+
+0.3.2 (2021-02-28)
+------------------
+
+* Re-release of version 0.3.1 due to packaging issue
+
+0.3.1 (2021-02-28)
 ------------------
 
 * Added compatibility for numpy 1.20 and raised minimum required numpy version to 1.20 (#555)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pyGloTarAn is a Python library for Global and Target Analysis
 
 Prerequisites:
 
-- Python 3.8 (Python 3.9+ is not supported in this release)
+- Python 3.8 (Python 3.9 is only supported as of v0.3.3)
 - On Windows only 64bit is supported
 
 Note for Windows Users: The easiest way to get python for Windows is via [Anaconda](https://www.anaconda.com/)

--- a/glotaran/__init__.py
+++ b/glotaran/__init__.py
@@ -3,7 +3,7 @@
 from . import io
 from . import parameter
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 ParameterGroup = parameter.ParameterGroup
 


### PR DESCRIPTION
Bumped version to v0.3.3 and added release notes

v0.3.3 release notes draft: 
* Force recalculation of SVD attributes in scheme._prepare_data (#597)
* Remove unneeded check in spectral_penalties._get_area Fixes (#598)
* Added python 3.9 support (#450)