### PR TITLE
Make Models py310 ready

### DIFF
--- a/glotaran/model/decorator.py
+++ b/glotaran/model/decorator.py
@@ -6,7 +6,6 @@ from typing import Dict
 from typing import List
 from typing import Tuple
 from typing import Type
-from typing import TypeVar
 from typing import Union
 
 import numpy as np
@@ -54,9 +53,7 @@ RetrieveClpFunction = Callable[
 ]
 """A `RetrieveClpFunction` retrieves the full set of clp from a reduced set."""
 
-FinalizeFunction = Callable[
-    [TypeVar("glotaran.analysis.problem.Problem"), Dict[str, xr.Dataset]], None
-]
+FinalizeFunction = Callable[["glotaran.analysis.problem.Problem", Dict[str, xr.Dataset]], None]
 """A `FinalizeFunction` gets called after optimization."""
 
 PenaltyFunction = Callable[
@@ -91,7 +88,7 @@ def model(
     finalize_data_function: FinalizeFunction = None,
     grouped: Union[bool, Callable[[Type[Model]], bool]] = False,
     index_dependent: Union[bool, Callable[[Type[Model]], bool]] = False,
-) -> Callable:
+) -> Callable[[Type[Model]], Type[Model]]:
     """The `@model` decorator is intended to be used on subclasses of :class:`glotaran.model.Model`.
     It creates properties for the given attributes as well as functions to add access them. Also it
     adds the functions (e.g. for `matrix`) to the model ensures they are added wrapped in a correct

--- a/glotaran/model/decorator.py
+++ b/glotaran/model/decorator.py
@@ -1,75 +1,78 @@
 """The model decorator."""
 from __future__ import annotations
 
-from typing import Any
-from typing import Callable
+from typing import TYPE_CHECKING
 from typing import Dict
 from typing import List
-from typing import Tuple
-from typing import Type
-from typing import Union
 
-import numpy as np
-import xarray as xr
-
-import glotaran  # TODO: refactor to postponed type annotation
-from glotaran.parameter import ParameterGroup
+from glotaran.model.dataset_descriptor import DatasetDescriptor
+from glotaran.model.util import wrap_func_as_method
+from glotaran.model.weight import Weight
 from glotaran.plugin_system.model_registration import register_model
 
-from .base_model import Model
-from .dataset_descriptor import DatasetDescriptor
-from .util import wrap_func_as_method
-from .weight import Weight
+if TYPE_CHECKING:
+    from typing import Any
+    from typing import Callable
+    from typing import Tuple
+    from typing import Type
+    from typing import Union
 
-MatrixFunction = Callable[[Type[DatasetDescriptor], xr.Dataset], Tuple[List[str], np.ndarray]]
-"""A `MatrixFunction` calculates the matrix for a model."""
+    import numpy as np
+    import xarray as xr
 
-IndexDependentMatrixFunction = Callable[
-    [Type[DatasetDescriptor], xr.Dataset, Any],
-    Tuple[List[str], np.ndarray],
-]
-"""A `MatrixFunction` calculates the matrix for a model."""
+    from glotaran.analysis.problem import Problem
+    from glotaran.model.base_model import Model
+    from glotaran.parameter import ParameterGroup
 
-GlobalMatrixFunction = Callable[
-    [Type[DatasetDescriptor], np.ndarray], Tuple[List[str], np.ndarray]
-]
-"""A `GlobalMatrixFunction` calculates the global matrix for a model."""
+    MatrixFunction = Callable[[Type[DatasetDescriptor], xr.Dataset], Tuple[List[str], np.ndarray]]
+    """A `MatrixFunction` calculates the matrix for a model."""
 
-ConstrainMatrixFunction = Callable[
-    [Type[Model], ParameterGroup, List[str], np.ndarray, float],
-    Tuple[List[str], np.ndarray],
-]
-"""A `ConstrainMatrixFunction` applies constraints on a matrix."""
+    IndexDependentMatrixFunction = Callable[
+        [Type[DatasetDescriptor], xr.Dataset, Any],
+        Tuple[List[str], np.ndarray],
+    ]
+    """A `MatrixFunction` calculates the matrix for a model."""
 
-RetrieveClpFunction = Callable[
-    [
-        Type[Model],
-        ParameterGroup,
-        Dict[str, Union[List[str], List[List[str]]]],
-        Dict[str, Union[List[str], List[List[str]]]],
+    GlobalMatrixFunction = Callable[
+        [Type[DatasetDescriptor], np.ndarray], Tuple[List[str], np.ndarray]
+    ]
+    """A `GlobalMatrixFunction` calculates the global matrix for a model."""
+
+    ConstrainMatrixFunction = Callable[
+        [Type[Model], ParameterGroup, List[str], np.ndarray, float],
+        Tuple[List[str], np.ndarray],
+    ]
+    """A `ConstrainMatrixFunction` applies constraints on a matrix."""
+
+    RetrieveClpFunction = Callable[
+        [
+            Type[Model],
+            ParameterGroup,
+            Dict[str, Union[List[str], List[List[str]]]],
+            Dict[str, Union[List[str], List[List[str]]]],
+            Dict[str, List[np.ndarray]],
+            Dict[str, xr.Dataset],
+        ],
         Dict[str, List[np.ndarray]],
-        Dict[str, xr.Dataset],
-    ],
-    Dict[str, List[np.ndarray]],
-]
-"""A `RetrieveClpFunction` retrieves the full set of clp from a reduced set."""
+    ]
+    """A `RetrieveClpFunction` retrieves the full set of clp from a reduced set."""
 
-FinalizeFunction = Callable[["glotaran.analysis.problem.Problem", Dict[str, xr.Dataset]], None]
-"""A `FinalizeFunction` gets called after optimization."""
+    FinalizeFunction = Callable[[Problem, Dict[str, xr.Dataset]], None]
+    """A `FinalizeFunction` gets called after optimization."""
 
-PenaltyFunction = Callable[
-    [
-        Type[Model],
-        ParameterGroup,
-        Dict[str, Union[List[str], List[List[str]]]],
-        Dict[str, List[np.ndarray]],
-        Dict[str, Union[np.ndarray, List[np.ndarray]]],
-        Dict[str, xr.Dataset],
-        float,
-    ],
-    np.ndarray,
-]
-"""A `PenaltyFunction` calculates additional penalties for the optimization."""
+    PenaltyFunction = Callable[
+        [
+            Type[Model],
+            ParameterGroup,
+            Dict[str, Union[List[str], List[List[str]]]],
+            Dict[str, List[np.ndarray]],
+            Dict[str, Union[np.ndarray, List[np.ndarray]]],
+            Dict[str, xr.Dataset],
+            float,
+        ],
+        np.ndarray,
+    ]
+    """A `PenaltyFunction` calculates additional penalties for the optimization."""
 
 
 def model(

--- a/glotaran/model/util.py
+++ b/glotaran/model/util.py
@@ -1,11 +1,17 @@
 """Helper functions."""
+from __future__ import annotations
 
-import typing
+from typing import Any
+from typing import Callable
+from typing import TypeVar
+from typing import cast
+
+DecoratedFunc = TypeVar("DecoratedFunc", bound=Callable[..., Any])  # decorated function
 
 
 def wrap_func_as_method(
-    cls: typing.Any, name: str = None, annotations: str = None, doc: str = None
-) -> typing.Callable:
+    cls: Any, name: str = None, annotations: dict[str, type] = None, doc: str = None
+) -> DecoratedFunc:
     """A decorator to wrap a function as class method.
 
     Notes
@@ -25,7 +31,7 @@ def wrap_func_as_method(
         The documentation of the method. If `None`, the original function's documentation is used.
     """
 
-    def decorator(func):
+    def decorator(func: DecoratedFunc) -> DecoratedFunc:
         if name:
             func.__name__ = name
         if annotations:
@@ -37,4 +43,4 @@ def wrap_func_as_method(
 
         return func
 
-    return decorator
+    return cast(DecoratedFunc, decorator)


### PR DESCRIPTION
Instead of relying on the `__annotations__` property to be the old style (python < 3.10), `wrap_func_as_method` needs to set `__annotations__` explicitly where needed.

Since only `Model` accesses `__annotations__` directly to use them, I don't think we need the same precautions for `ModelProperty` and `model.attributes`, since they use `_glotaran_model_attribute_typed` and `_glotaran_properties` internally, which then is used by `Model`.

**Testing**

Passing the tests is mandatory.

**Closing issues**

closes #610
