### PR TITLE
✨ Add Folder plugin for save result

### DIFF
--- a/glotaran/builtin/io/folder/__init__.py
+++ b/glotaran/builtin/io/folder/__init__.py
@@ -1,0 +1,1 @@
+"""Plugin to dump pyglotaran object as files in a folder."""

--- a/glotaran/builtin/io/folder/folder_plugin.py
+++ b/glotaran/builtin/io/folder/folder_plugin.py
@@ -1,0 +1,74 @@
+"""Implementation of the folder Io plugin.
+
+The current implementation is an exact copy of how ``Result.save(path)``
+worked in glotaran 0.3.x and meant as an compatibility function.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from glotaran.io.interface import ProjectIoInterface
+from glotaran.plugin_system.project_io_registration import register_project_io
+
+if TYPE_CHECKING:
+    from glotaran.project import Result
+
+
+@register_project_io(["folder", "legacy"])
+class FolderProjectIo(ProjectIoInterface):
+    """Project Io plugin to save result data to a folder.
+
+    There won't be a serialization of the Result object, but simply
+    a markdown summary output and the important data saved to files.
+    """
+
+    def save_result(self, result_path: str, result: Result) -> list[str]:
+        """Save the result to a given folder.
+
+        Returns a list with paths of all saved items.
+        The following files are saved:
+        * `result.md`: The result with the model formatted as markdown text.
+        * `optimized_parameters.csv`: The optimized parameter as csv file.
+        * `{dataset_label}.nc`: The result data for each dataset as NetCDF file.
+
+        Parameters
+        ----------
+        result_path : str
+            The path to the folder in which to save the result.
+        result : Result
+            Result instance to be saved.
+
+        Returns
+        -------
+        list[str]
+            List of file paths which were created.
+
+        Raises
+        ------
+        OSError
+            If the folder to save the result in doesn't exist or couldn't be created.
+        """
+        if not os.path.exists(result_path):
+            os.makedirs(result_path)
+        elif not os.path.isdir(result_path):
+            raise OSError(f"The path '{result_path}' is not a directory.")
+
+        paths = []
+
+        md_path = os.path.join(result_path, "result.md")
+        with open(md_path, "w") as f:
+            f.write(result.markdown())
+        paths.append(md_path)
+
+        csv_path = os.path.join(result_path, "optimized_parameters.csv")
+        result.optimized_parameters.to_csv(csv_path)
+        paths.append(csv_path)
+
+        for label, data in result.data.items():
+            nc_path = os.path.join(result_path, f"{label}.nc")
+            data.to_netcdf(nc_path, engine="netcdf4")
+            paths.append(nc_path)
+
+        return paths

--- a/glotaran/builtin/io/folder/folder_plugin.py
+++ b/glotaran/builtin/io/folder/folder_plugin.py
@@ -47,13 +47,13 @@ class FolderProjectIo(ProjectIoInterface):
 
         Raises
         ------
-        OSError
-            If the folder to save the result in doesn't exist or couldn't be created.
+        ValueError
+            If ``result_path`` is a file.
         """
         if not os.path.exists(result_path):
             os.makedirs(result_path)
-        elif not os.path.isdir(result_path):
-            raise OSError(f"The path '{result_path}' is not a directory.")
+        if not os.path.isdir(result_path):
+            raise ValueError(f"The path '{result_path}' is not a directory.")
 
         paths = []
 

--- a/glotaran/builtin/io/folder/test/test_folder_plugin.py
+++ b/glotaran/builtin/io/folder/test/test_folder_plugin.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from glotaran.analysis.optimize import optimize
+from glotaran.analysis.simulation import simulate
+from glotaran.analysis.test.models import ThreeDatasetDecay as suite
+from glotaran.io import save_result
+from glotaran.project import Scheme
+
+if TYPE_CHECKING:
+    from py.path import local as TmpDir
+
+
+def test_save_result_folder(tmpdir: TmpDir):
+    """Check all files exist."""
+    model = suite.model
+
+    model.is_grouped = False
+    model.is_index_dependent = False
+
+    wanted_parameters = suite.wanted_parameters
+    data = {}
+    for i in range(3):
+        e_axis = getattr(suite, "e_axis" if i == 0 else f"e_axis{i+1}")
+        c_axis = getattr(suite, "c_axis" if i == 0 else f"c_axis{i+1}")
+
+        data[f"dataset{i+1}"] = simulate(
+            suite.sim_model, f"dataset{i+1}", wanted_parameters, {"e": e_axis, "c": c_axis}
+        )
+    scheme = Scheme(
+        model=suite.model,
+        parameters=suite.initial_parameters,
+        data=data,
+        maximum_number_function_evaluations=1,
+    )
+
+    result = optimize(scheme)
+
+    result_dir = Path(tmpdir / "testresult")
+    save_result(result_path=str(result_dir), format_name="folder", result=result)
+
+    assert (result_dir / "result.md").exists()
+    assert (result_dir / "optimized_parameters.csv").exists()
+    assert (result_dir / "dataset1.nc").exists()
+    assert (result_dir / "dataset2.nc").exists()
+    assert (result_dir / "dataset3.nc").exists()

--- a/glotaran/builtin/io/folder/test/test_folder_plugin.py
+++ b/glotaran/builtin/io/folder/test/test_folder_plugin.py
@@ -10,6 +10,7 @@ from glotaran.analysis.simulation import simulate
 from glotaran.analysis.test.models import ThreeDatasetDecay as suite
 from glotaran.io import save_result
 from glotaran.project import Scheme
+from glotaran.project.result import Result
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -17,9 +18,10 @@ if TYPE_CHECKING:
     from py.path import local as TmpDir
 
 
-@pytest.mark.parametrize("format_names", ("folder", "legacy"))
-def test_save_result_folder(tmpdir: TmpDir, format_name: Literal["folder", "legacy"]):
-    """Check all files exist."""
+@pytest.fixture(scope="module")
+def dummy_result():
+    """Dummy result for testing."""
+
     model = suite.model
 
     model.is_grouped = False
@@ -41,13 +43,38 @@ def test_save_result_folder(tmpdir: TmpDir, format_name: Literal["folder", "lega
         maximum_number_function_evaluations=1,
     )
 
-    result = optimize(scheme)
+    yield optimize(scheme)
+
+
+@pytest.mark.parametrize("format_name", ("folder", "legacy"))
+def test_save_result_folder(
+    tmpdir: TmpDir, dummy_result: Result, format_name: Literal["folder", "legacy"]
+):
+    """Check all files exist."""
 
     result_dir = Path(tmpdir / "testresult")
-    save_result(result_path=str(result_dir), format_name=format_name, result=result)
+    save_result(result_path=str(result_dir), format_name=format_name, result=dummy_result)
 
     assert (result_dir / "result.md").exists()
     assert (result_dir / "optimized_parameters.csv").exists()
     assert (result_dir / "dataset1.nc").exists()
     assert (result_dir / "dataset2.nc").exists()
     assert (result_dir / "dataset3.nc").exists()
+
+
+@pytest.mark.parametrize("format_name", ("folder", "legacy"))
+def test_save_result_folder_error_path_is_file(
+    tmpdir: TmpDir, dummy_result: Result, format_name: Literal["folder", "legacy"]
+):
+    """Raise error if result_path is a file without extension and overwrite is true."""
+
+    result_dir = Path(tmpdir / "testresult")
+    result_dir.touch()
+
+    with pytest.raises(ValueError, match="The path '.+?' is not a directory."):
+        save_result(
+            result_path=str(result_dir),
+            format_name=format_name,
+            result=dummy_result,
+            allow_overwrite=True,
+        )

--- a/glotaran/builtin/io/folder/test/test_folder_plugin.py
+++ b/glotaran/builtin/io/folder/test/test_folder_plugin.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
+
 from glotaran.analysis.optimize import optimize
 from glotaran.analysis.simulation import simulate
 from glotaran.analysis.test.models import ThreeDatasetDecay as suite
@@ -10,10 +12,13 @@ from glotaran.io import save_result
 from glotaran.project import Scheme
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from py.path import local as TmpDir
 
 
-def test_save_result_folder(tmpdir: TmpDir):
+@pytest.mark.parametrize("format_names", ("folder", "legacy"))
+def test_save_result_folder(tmpdir: TmpDir, format_name: Literal["folder", "legacy"]):
     """Check all files exist."""
     model = suite.model
 
@@ -39,7 +44,7 @@ def test_save_result_folder(tmpdir: TmpDir):
     result = optimize(scheme)
 
     result_dir = Path(tmpdir / "testresult")
-    save_result(result_path=str(result_dir), format_name="folder", result=result)
+    save_result(result_path=str(result_dir), format_name=format_name, result=result)
 
     assert (result_dir / "result.md").exists()
     assert (result_dir / "optimized_parameters.csv").exists()

--- a/glotaran/builtin/io/folder/test/test_folder_plugin.py
+++ b/glotaran/builtin/io/folder/test/test_folder_plugin.py
@@ -5,50 +5,22 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from glotaran.analysis.optimize import optimize
-from glotaran.analysis.simulation import simulate
-from glotaran.analysis.test.models import ThreeDatasetDecay as suite
 from glotaran.io import save_result
-from glotaran.project import Scheme
-from glotaran.project.result import Result
+from glotaran.project.test.test_result import dummy_result  # noqa: F401
 
 if TYPE_CHECKING:
     from typing import Literal
 
     from py.path import local as TmpDir
 
-
-@pytest.fixture(scope="module")
-def dummy_result():
-    """Dummy result for testing."""
-
-    model = suite.model
-
-    model.is_grouped = False
-    model.is_index_dependent = False
-
-    wanted_parameters = suite.wanted_parameters
-    data = {}
-    for i in range(3):
-        e_axis = getattr(suite, "e_axis" if i == 0 else f"e_axis{i+1}")
-        c_axis = getattr(suite, "c_axis" if i == 0 else f"c_axis{i+1}")
-
-        data[f"dataset{i+1}"] = simulate(
-            suite.sim_model, f"dataset{i+1}", wanted_parameters, {"e": e_axis, "c": c_axis}
-        )
-    scheme = Scheme(
-        model=suite.model,
-        parameters=suite.initial_parameters,
-        data=data,
-        maximum_number_function_evaluations=1,
-    )
-
-    yield optimize(scheme)
+    from glotaran.project.result import Result
 
 
 @pytest.mark.parametrize("format_name", ("folder", "legacy"))
 def test_save_result_folder(
-    tmpdir: TmpDir, dummy_result: Result, format_name: Literal["folder", "legacy"]
+    tmpdir: TmpDir,
+    dummy_result: Result,  # noqa: F811
+    format_name: Literal["folder", "legacy"],
 ):
     """Check all files exist."""
 
@@ -64,7 +36,9 @@ def test_save_result_folder(
 
 @pytest.mark.parametrize("format_name", ("folder", "legacy"))
 def test_save_result_folder_error_path_is_file(
-    tmpdir: TmpDir, dummy_result: Result, format_name: Literal["folder", "legacy"]
+    tmpdir: TmpDir,
+    dummy_result: Result,  # noqa: F811
+    format_name: Literal["folder", "legacy"],
 ):
     """Raise error if result_path is a file without extension and overwrite is true."""
 

--- a/glotaran/builtin/io/yml/test/test_save_result.py
+++ b/glotaran/builtin/io/yml/test/test_save_result.py
@@ -1,44 +1,31 @@
-import os
+from __future__ import annotations
 
-from glotaran.analysis.optimize import optimize
-from glotaran.analysis.simulation import simulate
-from glotaran.analysis.test.models import ThreeDatasetDecay as suite
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 from glotaran.io import save_result
-from glotaran.project import Scheme
+from glotaran.project.test.test_result import dummy_result  # noqa: F401
+
+if TYPE_CHECKING:
+    from py.path import local as TmpDir
+
+    from glotaran.project.result import Result
 
 
-def test_optimization(tmpdir):
-    model = suite.model
+def test_save_result_yml(
+    tmpdir: TmpDir,
+    dummy_result: Result,  # noqa: F811
+):
+    """Check all files exist."""
 
-    model.is_grouped = False
-    model.is_index_dependent = False
+    result_dir = Path(tmpdir / "testresult")
+    save_result(result_path=str(result_dir), format_name="yml", result=dummy_result)
 
-    wanted_parameters = suite.wanted_parameters
-    data = {}
-    for i in range(3):
-        e_axis = getattr(suite, "e_axis" if i == 0 else f"e_axis{i+1}")
-        c_axis = getattr(suite, "c_axis" if i == 0 else f"c_axis{i+1}")
-
-        data[f"dataset{i+1}"] = simulate(
-            suite.sim_model, f"dataset{i+1}", wanted_parameters, {"e": e_axis, "c": c_axis}
-        )
-    scheme = Scheme(
-        model=suite.model,
-        parameters=suite.initial_parameters,
-        data=data,
-        maximum_number_function_evaluations=1,
-    )
-
-    result = optimize(scheme)
-
-    result_dir = os.path.join(tmpdir, "testresult")
-    save_result(result_path=result_dir, format_name="yml", result=result)
-
-    assert os.path.exists(os.path.join(result_dir, "result.md"))
-    assert os.path.exists(os.path.join(result_dir, "scheme.yml"))
-    assert os.path.exists(os.path.join(result_dir, "result.yml"))
-    assert os.path.exists(os.path.join(result_dir, "initial_parameters.csv"))
-    assert os.path.exists(os.path.join(result_dir, "optimized_parameters.csv"))
-    assert os.path.exists(os.path.join(result_dir, "dataset1.nc"))
-    assert os.path.exists(os.path.join(result_dir, "dataset2.nc"))
-    assert os.path.exists(os.path.join(result_dir, "dataset3.nc"))
+    assert (result_dir / "result.md").exists()
+    assert (result_dir / "scheme.yml").exists()
+    assert (result_dir / "result.yml").exists()
+    assert (result_dir / "initial_parameters.csv").exists()
+    assert (result_dir / "optimized_parameters.csv").exists()
+    assert (result_dir / "dataset1.nc").exists()
+    assert (result_dir / "dataset2.nc").exists()
+    assert (result_dir / "dataset3.nc").exists()

--- a/glotaran/plugin_system/io_plugin_utils.py
+++ b/glotaran/plugin_system/io_plugin_utils.py
@@ -15,7 +15,9 @@ from typing import cast
 DecoratedFunc = TypeVar("DecoratedFunc", bound=Callable[..., Any])  # decorated function
 
 
-def inferr_file_format(file_path: str | os.PathLike[str], *, needs_to_exist: bool = True) -> str:
+def inferr_file_format(
+    file_path: str | os.PathLike[str], *, needs_to_exist: bool = True, allow_folder=False
+) -> str:
     """Inferr format of a file if it exists.
 
     Parameters
@@ -25,6 +27,9 @@ def inferr_file_format(file_path: str | os.PathLike[str], *, needs_to_exist: boo
     needs_to_exist : bool
         Whether or not a file need to exists for an successful format inferring.
         While write functions don't need the file to exists, load functions do.
+    allow_folder: bool
+        Whether or not to allow the format to be ``folder``.
+        This is only used in ``save_result``.
 
     Returns
     -------
@@ -38,14 +43,18 @@ def inferr_file_format(file_path: str | os.PathLike[str], *, needs_to_exist: boo
     ValueError
         If file has no extension.
     """
-    if not os.path.isfile(file_path) and needs_to_exist:
+    if not os.path.isfile(file_path) and needs_to_exist and not allow_folder:
         raise ValueError(f"There is no file {file_path!r}.")
 
     _, file_format = os.path.splitext(file_path)
     if file_format == "":
-        raise ValueError(
-            f"Cannot determine format of file {file_path!r}, please provide an explicit format."
-        )
+        if allow_folder:
+            return "folder"
+        else:
+            raise ValueError(
+                f"Cannot determine format of file {file_path!r}, "
+                "please provide an explicit format."
+            )
     else:
         return file_format.lstrip(".")
 

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -368,7 +368,9 @@ def save_result(
         of the project io plugin.
     """
     protect_from_overwrite(result_path, allow_overwrite=allow_overwrite)
-    io = get_project_io(format_name or inferr_file_format(result_path, needs_to_exist=False))
+    io = get_project_io(
+        format_name or inferr_file_format(result_path, needs_to_exist=False, allow_folder=True)
+    )
     io.save_result(  # type: ignore[call-arg]
         result_path=result_path,
         result=result,

--- a/glotaran/plugin_system/test/test_io_plugin_utils.py
+++ b/glotaran/plugin_system/test/test_io_plugin_utils.py
@@ -52,6 +52,16 @@ def test_inferr_file_format_no_extension(tmp_path: Path):
         inferr_file_format(file_path)
 
 
+@pytest.mark.parametrize("is_file", (True, False))
+def test_inferr_file_format_allow_folder(tmp_path: Path, is_file: bool):
+    """If there is no extension, return folder."""
+    file_path = tmp_path / "dummy"
+    if is_file:
+        file_path.touch()
+
+    assert inferr_file_format(file_path, allow_folder=True) == "folder"
+
+
 def test_inferr_file_format_none_existing_file():
     """Raise error if file does not exists."""
     with pytest.raises(ValueError, match="There is no file "):

--- a/glotaran/project/test/test_result.py
+++ b/glotaran/project/test/test_result.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from glotaran.analysis.optimize import optimize
+from glotaran.analysis.simulation import simulate
+from glotaran.analysis.test.models import ThreeDatasetDecay as suite
+from glotaran.project import Scheme
+
+
+@pytest.fixture(scope="session")
+def dummy_result():
+    """Dummy result for testing."""
+
+    model = suite.model
+
+    model.is_grouped = False
+    model.is_index_dependent = False
+
+    wanted_parameters = suite.wanted_parameters
+    data = {}
+    for i in range(3):
+        e_axis = getattr(suite, "e_axis" if i == 0 else f"e_axis{i+1}")
+        c_axis = getattr(suite, "c_axis" if i == 0 else f"c_axis{i+1}")
+
+        data[f"dataset{i+1}"] = simulate(
+            suite.sim_model, f"dataset{i+1}", wanted_parameters, {"e": e_axis, "c": c_axis}
+        )
+    scheme = Scheme(
+        model=suite.model,
+        parameters=suite.initial_parameters,
+        data=data,
+        maximum_number_function_evaluations=1,
+    )
+
+    yield optimize(scheme)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ remove_redundant_aliases = true
 [tool.interrogate]
 exclude = ["setup.py", "docs", "*test/*"]
 ignore-init-module = true
-fail-under = 38
+fail-under = 47
 
 [tool.nbqa.addopts]
 flake8 = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ glotaran.plugins.model =
 glotaran.plugins.project_io =
     yml = glotaran.builtin.io.yml.yml
     csv = glotaran.builtin.io.csv.csv
+    folder = glotaran.builtin.io.folder.folder_plugin
 
 [aliases]
 test = pytest


### PR DESCRIPTION
This plugin adds back the functionality from `glotaran.analysis.result.Result.save(result_path)` of pyglotaran `0.3.x`.
For `glotaran.io.save_result` it also adds inferring of `format_name=="folder"` if the provided `result_path` doesn't have an extension.
If `result_path` is a file it will raise a `ValueError`.

Usage equivalent to `result.save(result_path)`
```python
save_result(result_path=str(output_folder), result=result, allow_overwrite=True)
# or if format must be given:
save_result(result_path=str(output_folder), result=result, format_name="folder", allow_overwrite=True)
save_result(result_path=str(output_folder), result=result, format_name="pyglotaran-legacy", allow_overwrite=True)
```

Also, the plugin is registered under the names `folder` and `pyglotaran-legacy`, thus if we want to fundamentally change the `folder`-plugin we can keep the old implementation around as `pyglotaran-legacy` for backward compatibility.

**Testing**

Passing the tests is mandatory.

**Closing issues**

closes #619
