### PR TITLE
Remove unreliable URL from authors.rst

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,7 +18,7 @@ Special Thanks
 
 Supervision
 --------------
-* **dr. Ivo H.M. van Stokkum** <i.h.m.van.stokkum@vu.nl> (`VU University profile <https://research.vu.nl/en/persons/ihm-van-stokkum>`_, `personal homepage <http://www.nat.vu.nl/~ivo/>`_)
+* **dr. Ivo H.M. van Stokkum** <i.h.m.van.stokkum@vu.nl> (`University profile <https://research.vu.nl/en/persons/ihm-van-stokkum>`_)
 
 Original publications
 ---------------------


### PR DESCRIPTION
Address failing docs (on link testing), like e.g. here:
https://github.com/glotaran/pyglotaran/pull/617/checks?check_run_id=2248961079

**Error log**

```make
(         authors: line   21) broken    
    http://www.nat.vu.nl/~ivo/ - HTTPConnectionPool(host='www.nat.vu.nl', port=80): Max retries exceeded 
    with url: /~ivo/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f34a281cee0>: 
    Failed to establish a new connection: [Errno 110] Connection timed out'))
build finished with problems, 18 warnings.
make: *** [Makefile:42: linkcheck] Error 1
```

