### PR TITLE
🩹 Add deprecation framework and readd 0.3.x API as deprecated

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -155,7 +155,7 @@ Deprecations
 ------------
 
 Only maintainers are allowed to decide about deprecations, thus you should first open an
-issue and check back with them if they are ok with deprecation something.
+issue and check back with them if they are ok with deprecating something.
 
 To make deprecations as robust as possible and give users all needed information
 to adjust their code, we provide helper functions inside the module

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,9 +19,9 @@ Report bugs at https://github.com/glotaran/pyglotaran/issues.
 
 If you are reporting a bug, please include:
 
-* Your operating system name and version.
-* Any details about your local setup that might be helpful in troubleshooting.
-* Detailed steps to reproduce the bug.
+*   Your operating system name and version.
+*   Any details about your local setup that might be helpful in troubleshooting.
+*   Detailed steps to reproduce the bug.
 
 Fix Bugs
 ~~~~~~~~
@@ -52,70 +52,70 @@ The best way to send feedback is to file an issue at https://github.com/glotaran
 
 If you are proposing a feature:
 
-* Explain in detail how it would work.
-* Keep the scope as narrow as possible, to make it easier to implement.
-* Remember that this is a volunteer-driven project, and that contributions
-  are welcome :)
+*   Explain in detail how it would work.
+*   Keep the scope as narrow as possible, to make it easier to implement.
+*   Remember that this is a volunteer-driven project, and that contributions
+    are welcome :)
 
 Get Started!
 ------------
 
 Ready to contribute? Here's how to set up ``pyglotaran`` for local development.
 
-1. Fork the ``pyglotaran`` repo on GitHub.
-2. Clone your fork locally::
+1.  Fork the ``pyglotaran`` repo on GitHub.
+2.  Clone your fork locally::
 
-    $ git clone https://github.com/<your_name_here>/pyglotaran.git
+        $ git clone https://github.com/<your_name_here>/pyglotaran.git
 
-3. Install your local copy into a virtualenv. Assuming you have
-   `virtualenvwrapper <https://virtualenvwrapper.readthedocs.io/en/latest/>`_
-   installed, this is how you set up your fork for local development::
+3.  Install your local copy into a virtualenv. Assuming you have
+    `virtualenvwrapper <https://virtualenvwrapper.readthedocs.io/en/latest/>`_
+    installed, this is how you set up your fork for local development::
 
-    $ mkvirtualenv pyglotaran
-    (pyglotaran)$ cd pyglotaran
-    (pyglotaran)$ python -m pip install -r requirements_dev.txt
-    (pyglotaran)$ pip install -e . --process-dependency-links
+        $ mkvirtualenv pyglotaran
+        (pyglotaran)$ cd pyglotaran
+        (pyglotaran)$ python -m pip install -r requirements_dev.txt
+        (pyglotaran)$ pip install -e . --process-dependency-links
 
-4. Install the ``pre-commit`` hooks, to automatically format and check your code::
+4.  Install the ``pre-commit`` hooks, to automatically format and check your code::
 
     $ pre-commit install
 
-5. Create a branch for local development::
+5.  Create a branch for local development::
 
-    $ git checkout -b name-of-your-bugfix-or-feature
+        $ git checkout -b name-of-your-bugfix-or-feature
 
-   Now you can make your changes locally.
+    Now you can make your changes locally.
 
-6. When you're done making changes, check that your changes pass flake8 and the
-   tests, including testing other Python versions with tox::
+6.  When you're done making changes, check that your changes pass flake8 and the
+    tests, including testing other Python versions with tox::
 
-    $ pre-commit run -a
-    $ py.test
+        $ pre-commit run -a
+        $ py.test
 
-   Or to run all at once::
+    Or to run all at once::
 
-    $ tox
+        $ tox
 
 
-7. Commit your changes and push your branch to GitHub::
+7.  Commit your changes and push your branch to GitHub::
 
-    $ git add .
-    $ git commit -m "Your detailed description of your changes."
-    $ git push origin name-of-your-bugfix-or-feature
+        $ git add .
+        $ git commit -m "Your detailed description of your changes."
+        $ git push origin name-of-your-bugfix-or-feature
 
-8. Submit a pull request through the GitHub website.
+8.  Submit a pull request through the GitHub website.
 
 Pull Request Guidelines
 -----------------------
 
 Before you submit a pull request, check that it meets these guidelines:
 
-1. The pull request should include tests.
-2. If the pull request adds functionality, the docs should be updated. Put
-   your new functionality into a function with a `docstring`_.
-3. The pull request should work for Python 3.8 and 3.9
-   Check your Github Actions ``https://github.com/<your_name_here>/pyglotaran/actions``
-   and make sure that the tests pass for all supported Python versions.
+1.  The pull request should include tests.
+2.  If the pull request adds functionality, the docs should be updated. Put
+    your new functionality into a function with a `docstring`_.
+3.  The pull request should work for Python 3.8 and 3.9
+    Check your Github Actions ``https://github.com/<your_name_here>/pyglotaran/actions``
+    and make sure that the tests pass for all supported Python versions.
 
 .. _docstring:
 
@@ -131,25 +131,160 @@ Some extensions for popular editors are:
 * `vim-python-docstring (Vim) <https://github.com/pixelneo/vim-python-docstring>`_
 
 .. note::
-   If your pull request improves the docstring coverage (check ``pre-commit run -a interrogate``),
-   please raise the value of the interrogate setting ``fail-under`` in
-   `pyproject.toml <https://github.com/glotaran/pyglotaran/blob/master/pyproject.toml#L31>`_.
-   That way the next person will improve the docstring coverage as well and
-   everyone can enjoy a better documentation.
+    If your pull request improves the docstring coverage (check ``pre-commit run -a interrogate``),
+    please raise the value of the interrogate setting ``fail-under`` in
+    `pyproject.toml <https://github.com/glotaran/pyglotaran/blob/master/pyproject.toml#L31>`_.
+    That way the next person will improve the docstring coverage as well and
+    everyone can enjoy a better documentation.
 
 .. warning::
 
-   As soon as all our docstrings in proper shape we will enforce that it stays that way.
-   If you want to check if your docstrings are fine you can use `pydocstyle <https://github.com/PyCQA/pydocstyle>`_
-   and `darglint <https://github.com/terrencepreilly/darglint>`_.
+    As soon as all our docstrings are in proper shape we will enforce that it stays that way.
+    If you want to check if your docstrings are fine you can use `pydocstyle <https://github.com/PyCQA/pydocstyle>`_
+    and `darglint <https://github.com/terrencepreilly/darglint>`_.
 
 Tips
 ----
 
 To run a subset of tests::
 
-$py.test tests.test_pyglotaran
+    $ py.test tests.test_pyglotaran
 
+
+Deprecations
+------------
+
+Only maintainers are allowed to decide about deprecations, thus you should first open an
+issue and check back with them if they are ok with deprecation something.
+
+To make deprecations as robust as possible and give users all needed information
+to adjust their code, we provide helper functions inside the module
+:mod:`glotaran.deprecation`.
+
+The functions you most likely want to use are
+
+*   :func:`deprecate` for functions, methods and classes
+*   :func:`warn_deprecated` for call arguments
+*   :func:`deprecate_module_attribute` for module attributes
+*   :func:`deprecate_submodule` for modules
+
+
+Those functions not only make it easier to deprecate something, but they also check that
+that deprecations will be removed when they are due and that at least the imports in the
+warning work. Thus all deprecations need to be tested.
+
+Tests for deprecations should be placed in ``glotaran/deprecation/modules/test`` which also
+provides the test helper functions ``deprecation_warning_on_call_test_helper`` and
+``changed_import_test_warn``.
+Since the tests for deprecation are mainly for maintainability and not to test the
+functionality (those tests should be in the appropriate place)
+``deprecation_warning_on_call_test_helper`` will by default just test that a
+``DeprecationWarning`` was raised and ignore all raise ``Exception`` s.
+An exception to this rule is when adding back removed functionality
+(which shouldn't happen in the first place but might), which should be
+implemented in a file under ``glotaran/deprecation/modules`` and filenames should be like the
+relative import path from glotaran root, but with ``_`` instead of ``.``.
+
+E.g. ``glotaran.analysis.scheme`` would map to ``analysis_scheme.py``
+
+The only exceptions to this rule are the root ``__init__.py`` which
+is named ``glotaran_root.py`` and testing changed imports which should
+be placed in ``test_changed_imports.py``.
+
+
+Deprecating a Function, method or class
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Deprecating a function, method or class is as easy as adding the ``deprecate``
+decorator to it. Other decorators (e.g. ``@staticmethod`` or ``@classmethod``)
+should be placed both ``deprecate`` in order to work.
+
+.. code-block:: python
+    :caption: glotaran/some_module.py
+
+    from glotaran.deprecation import deprecate
+
+    @deprecate(
+        deprecated_qual_name_usage="glotaran.some_module.function_to_deprecate(filename)",
+        new_qual_name_usage='glotaran.some_module.new_function(filename, format_name="legacy")',
+        to_be_removed_in_version="0.6.0",
+    )
+    def function_to_deprecate(*args, **kwargs):
+        ...
+
+Deprecating a call argument
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When deprecating a call argument you should use ``warn_deprecated`` and set
+the argument to deprecate to a default value (e.g. ``"deprecated"``) to check against.
+Note that for this use case we need to set ``check_qual_names=(False, False)`` which
+will deactivate the import testing.
+This might not always be possible, e.g. if the argument is positional only,
+so it might make more sense to deprecate the whole callable, just discuss what to
+do with our trusted maintainers.
+
+.. code-block:: python
+    :caption: glotaran/some_module.py
+
+    from glotaran.deprecation import deprecate
+
+    def function_to_deprecate(args1, new_arg="new_default_behavior", deprecated_arg="deprecated", **kwargs):
+        if deprecated_arg != "deprecated":
+            warn_deprecated(
+                deprecated_qual_name_usage="deprecated_arg",
+                new_qual_name_usage='new_arg="legacy"',
+                to_be_removed_in_version="0.6.0",
+                check_qual_names=(False, False)
+            )
+            new_arg = "legacy"
+        ...
+
+
+Deprecating a module attribute
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes it might be necessary to remove an attribute (function, class, or constant)
+from a module to prevent circular imports or just to streamline the API.
+In those cases you would use ``deprecate_module_attribute`` inside a module ``__getattr__``
+function definition. This will import the attribute from the new location and return it when
+an import or use is requested.
+
+.. code-block:: python
+    :caption: glotaran/old_package/__init__.py
+
+
+    def __getattr__(attribute_name: str):
+        from glotaran.deprecation import deprecate_module_attribute
+
+        if attribute_name == "deprecated_attribute":
+            return deprecate_module_attribute(
+                deprecated_qual_name="glotaran.old_package.deprecated_attribute",
+                new_qual_name="glotaran.new_package.new_attribute_name",
+                to_be_removed_in_version="0.6.0",
+            )
+
+        raise AttributeError(f"module {__name__} has no attribute {attribute_name}")
+
+
+Deprecating a submodule
+~~~~~~~~~~~~~~~~~~~~~~~
+
+For a better logical structure, it might be needed to move modules to a different
+location in the project. In those cases, you would use ``deprecate_submodule``,
+which imports the module from the new location, add it to ``sys.modules`` and
+as an attribute to the parent package.
+
+
+.. code-block:: python
+    :caption: glotaran/old_package/__init__.py
+
+    from glotaran.deprecation import deprecate_submodule
+
+    module_name = deprecate_submodule(
+        deprecated_module_name="glotaran.old_package.module_name",
+        new_module_name="glotaran.new_package.new_module_name",
+        to_be_removed_in_version="0.6.0",
+    )
 
 Deploying
 ---------

--- a/glotaran/__init__.py
+++ b/glotaran/__init__.py
@@ -1,7 +1,24 @@
 """Glotaran package __init__.py"""
-
+from glotaran.deprecation.modules.glotaran_root import read_model_from_yaml
+from glotaran.deprecation.modules.glotaran_root import read_model_from_yaml_file
+from glotaran.deprecation.modules.glotaran_root import read_parameters_from_csv_file
+from glotaran.deprecation.modules.glotaran_root import read_parameters_from_yaml
+from glotaran.deprecation.modules.glotaran_root import read_parameters_from_yaml_file
 from glotaran.plugin_system.base_registry import load_plugins
 
 load_plugins()
 
 __version__ = "0.3.3"
+
+
+def __getattr__(attribute_name: str):
+    from glotaran.deprecation.deprecation_utils import deprecate_module_attribute
+
+    if attribute_name == "ParameterGroup":
+        return deprecate_module_attribute(
+            deprecated_qual_name="glotaran.ParameterGroup",
+            new_qual_name="glotaran.parameter.ParameterGroup",
+            to_be_removed_in_version="0.6.0",
+        )
+
+    raise AttributeError(f"module {__name__} has no attribute {attribute_name}")

--- a/glotaran/analysis/__init__.py
+++ b/glotaran/analysis/__init__.py
@@ -1,1 +1,14 @@
 """This package contains functions for model simulation and fitting."""
+from glotaran.deprecation.deprecation_utils import deprecate_submodule
+
+result = deprecate_submodule(
+    deprecated_module_name="glotaran.analysis.result",
+    new_module_name="glotaran.project.result",
+    to_be_removed_in_version="0.6.0",
+)
+
+scheme = deprecate_submodule(
+    deprecated_module_name="glotaran.analysis.scheme",
+    new_module_name="glotaran.project.scheme",
+    to_be_removed_in_version="0.6.0",
+)

--- a/glotaran/builtin/__init__.py
+++ b/glotaran/builtin/__init__.py
@@ -1,0 +1,8 @@
+"""This package contains builtin plugins."""
+from glotaran.deprecation.deprecation_utils import deprecate_submodule
+
+read_data_file = deprecate_submodule(
+    deprecated_module_name="glotaran.builtin.read_data_file",
+    new_module_name="glotaran.builtin.io",
+    to_be_removed_in_version="0.6.0",
+)

--- a/glotaran/deprecation/__init__.py
+++ b/glotaran/deprecation/__init__.py
@@ -1,0 +1,5 @@
+"""Deprecation helpers and place to put deprecated implementations till removing."""
+from glotaran.deprecation.deprecation_utils import deprecate
+from glotaran.deprecation.deprecation_utils import deprecate_module_attribute
+from glotaran.deprecation.deprecation_utils import deprecate_submodule
+from glotaran.deprecation.deprecation_utils import warn_deprecated

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -38,7 +38,7 @@ class OverDueDeprecation(Exception):
 
 
 def glotaran_version() -> str:
-    """Pyglotaran version of the distribution.
+    """Version of the distribution.
 
     This is basically the same as ``glotaran.__version__`` but independent from glotaran.
     This way all of the deprecation functionality can be used even in
@@ -48,7 +48,7 @@ def glotaran_version() -> str:
     Returns
     -------
     str
-        Versionstring of glotaran.
+        The version string.
     """
     return distribution("pyglotaran").version
 

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -198,7 +198,10 @@ def warn_deprecated(
             return load_model(model_path)
 
     """
-    if parse_version(glotaran_version()) >= parse_version(to_be_removed_in_version):
+    if (
+        parse_version(glotaran_version()) >= parse_version(to_be_removed_in_version)
+        and "dev" not in glotaran_version()
+    ):
         raise OverDueDeprecation(
             f"Support for {deprecated_qual_name_usage.partition('(')[0]!r} was "
             f"supposed to be dropped in version: {to_be_removed_in_version!r}\n"

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -1,0 +1,504 @@
+"""Helper functions to give deprecation warnings."""
+
+from __future__ import annotations
+
+import os
+import sys
+from functools import wraps
+from importlib import import_module
+from importlib.metadata import distribution
+from types import ModuleType
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import TypeVar
+from typing import cast
+from warnings import warn
+
+DecoratedCallable = TypeVar(
+    "DecoratedCallable", bound=Callable[..., Any]
+)  # decorated function or class
+
+if TYPE_CHECKING:
+    from typing import Sequence
+
+
+class OverDueDeprecation(Exception):
+    """Error thrown when a deprecation should have been removed.
+
+    See Also
+    --------
+    deprecate
+    warn_deprecated
+    deprecate_module_attribute
+    deprecate_submodule
+    """
+
+    pass
+
+
+def glotaran_version() -> str:
+    """Pyglotaran version of the distribution.
+
+    This is basically the same as ``glotaran.__version__`` but independent from glotaran.
+    This way all of the deprecation functionality can be used even in
+    ``glotaran.__init__.py`` without moving the import below the definition of
+    ``__version__`` or causeing a circular import issue.
+
+    Returns
+    -------
+    str
+        Versionstring of glotaran.
+    """
+    return distribution("pyglotaran").version
+
+
+def parse_version(version_str: str) -> tuple[int, int, int]:
+    """Parse version string to tuple of three ints for comparison.
+
+    Parameters
+    ----------
+    version_str : str
+        Fully qualified version string of the form 'major.minor.patch'.
+
+    Returns
+    -------
+    tuple[int, int, int]
+        Version as tuple.
+
+    Raises
+    ------
+    ValueError
+        If ``version_str`` has less that three elements separated by ``.``.
+    ValueError
+        If ``version_str`` 's first three elements can not be casted to int.
+    """
+    error_message = (
+        "version_str need to be a fully qualified version consisting of "
+        f"int parts (e.g. '0.0.1'), got {version_str!r}"
+    )
+    split_version = version_str.partition("-")[0].split(".")
+    if len(split_version) < 3:
+        raise ValueError(error_message)
+    try:
+        return tuple(map(int, split_version[:3]))  # type:ignore [return-value]
+    except ValueError:
+        raise ValueError(error_message)
+
+
+def check_qualnames_in_tests(qual_names: Sequence[str], importable_indices: Sequence[int]):
+    """Test that qualnames import path exists when running tests.
+
+    All deprecations should be tested anyway in order to get the proper
+    errors when a deprecation is overdue.
+    This helperfunction also helps to ensure that at least the import
+    paths (``qual_names``) of the old and new usage exist.
+
+    Parameters
+    ----------
+    qual_names : Sequence[str]
+        Sequence of fully qualified module attribute names,
+        optionally with call arguments.
+    importable_indices: Sequence[int]
+        Indices of corresponding to ``qual_names`` indicating
+        how to slice each ``qual_name`` split at ``.``, for the import
+        and attribute checking.
+
+    See Also
+    --------
+    warn_deprecated
+    deprecate
+    """
+    # Since this is always true for tests run with pytest we ignore the branch coverage
+    if "PYTEST_CURRENT_TEST" in os.environ:  # pragma: no branch
+        for qual_name, slice_index in zip(qual_names, importable_indices):
+            qual_name_parts = qual_name.partition("(")[0].partition("[")[0].split(".")
+            module_name = ".".join(qual_name_parts[:-slice_index])
+            object_name = qual_name_parts[-slice_index]
+            module = __import__(module_name, fromlist=(object_name))
+            assert hasattr(module, object_name)
+            if slice_index != 1:
+                item = getattr(module, object_name)
+                hasattr(item, qual_name_parts[-slice_index + 1])
+
+
+def warn_deprecated(
+    *,
+    deprecated_qual_name_usage: str,
+    new_qual_name_usage: str,
+    to_be_removed_in_version: str,
+    check_qual_names: tuple[bool, bool] = (True, True),
+    stacklevel: int = 2,
+    importable_indices: tuple[int, int] = (1, 1),
+) -> None:
+    """Raise deprecation warning with change information.
+
+    The change information are old / new usage information and end of support version.
+
+    Parameters
+    ----------
+    deprecated_qual_name_usage : str
+        Old usage with fully qualified name e.g.:
+        ``'glotaran.read_model_from_yaml(model_yml_str)'``
+    new_qual_name_usage : str
+        New usage as fully qualified name e.g.:
+        ``'glotaran.io.load_model(model_yml_str, format_name="yml_str")'``
+    to_be_removed_in_version : str
+        Version the support for this usage will be removed.
+    check_qual_names : tuple[bool, bool]
+        Whether or not to check for the existence ``deprecated_qual_name_usage`` and
+        ``deprecated_qual_name_usage``
+
+        *   Set the first value to False to prevent infinite recursion error when changing
+            a module attribute import.
+
+        *   Set the second value to False if the new usage in in a different package or
+            there is none.
+
+    stacklevel: int
+        Stack at which the warning should be shown as raise. Default: 2
+
+    importable_indices : tuple[int, int]
+        Indices from right for most nested item which is importable for
+        ``deprecated_qual_name_usage`` and ``new_qual_name_usage``
+        after splitting at ``.``. This is used when the old or new usage
+        is a method or mapping access. E.g. let ``deprecated_qual_name_usage``
+        be ``package.module.class.mapping["key"]``, then you would use
+        ``importable_indices=(2, 1)``, this way func:`check_qualnames_in_tests`
+        will import ``package.module.class`` and check if ``class`` has an attribute
+        ``mapping``.
+
+    Warns
+    -----
+    OverDueDeprecation
+        If the current version is greater or equal to ``end_of_life_version``.
+
+    See Also
+    --------
+    deprecate
+    deprecate_module_attribute
+    deprecate_submodule
+    check_qualnames_in_tests
+
+    Examples
+    --------
+    This is the way the old ``read_parameters_from_yaml_file`` could deprecated and the usage of
+    ``load_model`` being promoted instead.
+
+
+    .. code-block:: python
+        :caption: glotaran/deprecation/modules/glotaran_root.py
+
+        def read_parameters_from_yaml_file(model_path: str):
+            warn_deprecated(
+                deprecated_qual_name_usage="glotaran.read_parameters_from_yaml_file(model_path)",
+                new_qual_name_usage="glotaran.io.load_model.load_model(model_path)",
+                to_be_removed_in_version="0.6.0",
+            )
+            return load_model(model_path)
+
+    """
+    if parse_version(glotaran_version()) >= parse_version(to_be_removed_in_version):
+        raise OverDueDeprecation(
+            f"Support for {deprecated_qual_name_usage.partition('(')[0]!r} was "
+            f"supposed to be dropped in version: {to_be_removed_in_version!r}\n"
+            f"Current version is: {glotaran_version()!r}"
+        )
+    qual_names = (deprecated_qual_name_usage, new_qual_name_usage)
+    selected_qual_names = [
+        qual_name for qual_name, check in zip(qual_names, check_qual_names) if check
+    ]
+    selected_indices = importable_indices[: len(selected_qual_names)]
+    check_qualnames_in_tests(qual_names=selected_qual_names, importable_indices=selected_indices)
+    warn(
+        DeprecationWarning(
+            f"Usage of {deprecated_qual_name_usage!r} was deprecated, "
+            f"use {new_qual_name_usage!r} instead.\n"
+            f"This usage will be an error in version: {to_be_removed_in_version!r}."
+        ),
+        stacklevel=stacklevel,
+    )
+
+
+def deprecate(
+    *,
+    deprecated_qual_name_usage: str,
+    new_qual_name_usage: str,
+    to_be_removed_in_version: str,
+    has_glotaran_replacement: bool = True,
+    importable_indices: tuple[int, int] = (1, 1),
+) -> Callable[[DecoratedCallable], DecoratedCallable]:
+    """Decorate a function, method or class to deprecate it.
+
+    This raises deprecation warning with old / new usage information and
+    end of support version.
+
+
+    Parameters
+    ----------
+    deprecated_qual_name_usage : str
+        Old usage with fully qualified name e.g.:
+        ``'glotaran.read_model_from_yaml(model_yml_str)'``
+    new_qual_name_usage : str
+        New usage as fully qualified name e.g.:
+        ``'glotaran.io.load_model(model_yml_str, format_name="yml_str")'``
+    to_be_removed_in_version : str
+        Version the support for this usage will be removed.
+    has_glotaran_replacement : bool
+        Whether or not this functionality has a replacement in core
+        pyglotaran. This will be mapped to the second entry of ``check_qualnames``
+        in :func:`warn_deprecated`.
+    importable_indices : Sequence[int]
+        Indices from right for most nested item which is importable for
+        ``deprecated_qual_name_usage`` and ``new_qual_name_usage``
+        after splitting at ``.``. This is used when the old or new usage
+        is a method or mapping access. E.g. let ``deprecated_qual_name_usage``
+        be ``package.module.class.mapping["key"]``, then you would use
+        ``importable_indices=(2, 1)``, this way func:`check_qualnames_in_tests`
+        will import ``package.module.class`` and check if ``class`` has an attribute
+        ``mapping``. Default
+
+
+    Returns
+    -------
+    DecoratedCallable
+        Original function or class throwing a Deprecation warning when used.
+
+    Warns
+    -----
+    OverDueDeprecation
+        If the current version is greater or equal to ``end_of_life_version``.
+
+    See Also
+    --------
+    warn_deprecated
+    deprecate_module_attribute
+    deprecate_submodule
+    check_qualnames_in_tests
+
+    Examples
+    --------
+    This is the way the old ``read_parameters_from_yaml_file`` was deprecated and the usage of
+    ``load_model`` was promoted instead.
+
+
+    .. code-block:: python
+        :caption: glotaran/deprecation/modules/glotaran_root.py
+
+        @deprecate(
+            deprecated_qualname_usage="glotaran.read_parameters_from_yaml_file(model_path)",
+            new_qualname_usage="glotaran.io.load_model(model_path)",
+            to_be_removed_in_version="0.6.0",
+        )
+        def read_parameters_from_yaml_file(model_path: str):
+            return load_model(model_path)
+
+
+    .. # noqa: DAR402
+    """
+
+    def inject_warn_into_call(deprecated_object: DecoratedCallable) -> DecoratedCallable:
+        """Wrap warning into function call.
+
+        Used on deprecated_object.__new__ if it's a class or else on deprecated_object.
+        """
+
+        @wraps(deprecated_object)
+        def inner_wrapper(*args: Any, **kwargs: Any) -> DecoratedCallable:
+            """Wrap running the function and warning."""
+            warn_deprecated(
+                deprecated_qual_name_usage=deprecated_qual_name_usage,
+                new_qual_name_usage=new_qual_name_usage,
+                to_be_removed_in_version=to_be_removed_in_version,
+                stacklevel=3,
+                check_qual_names=(True, has_glotaran_replacement),
+                importable_indices=importable_indices,
+            )
+            return deprecated_object(*args, **kwargs)
+
+        return cast(DecoratedCallable, inner_wrapper)
+
+    def outer_wrapper(deprecated_object: DecoratedCallable) -> DecoratedCallable:
+        """Wrap deprecated_object of all callable kinds."""
+        if type(deprecated_object) is type:
+            setattr(
+                deprecated_object,
+                "__new__",
+                inject_warn_into_call(deprecated_object.__new__),  # type: ignore [arg-type]
+            )
+            return deprecated_object
+        else:
+            return cast(DecoratedCallable, inject_warn_into_call(deprecated_object))
+
+    return outer_wrapper
+
+
+def module_attribute(module_qual_name: str, attribute_name: str) -> Any:
+    """Import and return the attribute (e.g. function or class) of a module.
+
+    This is basically the same as ``from module_name import attribute_name as return_value``
+    where this function returns ``return_value``.
+
+    Parameters
+    ----------
+    module_qual_name : str
+        Fully qualified name for a module e.g. ``glotaran.model.base_model``
+    attribute_name : str
+        Name of the attribute e.g. ``Model``
+
+    Returns
+    -------
+    Any
+        Attribute of the module, e.g. a function or class.
+    """
+    module = import_module(module_qual_name)
+    return getattr(module, attribute_name)
+
+
+def deprecate_module_attribute(
+    *,
+    deprecated_qual_name: str,
+    new_qual_name: str,
+    to_be_removed_in_version: str,
+) -> Any:
+    """Import and return and anttribute from the new location.
+
+    This needs to be wrapped in the definition of a module wide
+    ``__getattr__`` function so it won't throw warnings all the time
+    (see example).
+
+    Parameters
+    ----------
+    deprecated_qual_name : str
+        Fully qualified name of the deprecated attribute e.g.:
+        ``glotaran.ParameterGroup``
+    new_qual_name : str
+        Fully qualified name of the new attribute e.g.:
+        ``glotaran.parameter.ParameterGroup``
+    to_be_removed_in_version : str
+        Version the support for this usage will be removed.
+
+    Returns
+    -------
+    Any
+        Module attribute from its new location.
+
+    See Also
+    --------
+    deprecate
+    warn_deprecated
+    deprecate_submodule
+
+    Examples
+    --------
+    When deprecating the usage of ``ParameterGroup`` the root of ``glotaran``
+    and promoting to import it from ``glotaran.parameter`` the following code
+    was added to the root ``__init__.py``.
+
+    .. code-block:: python
+        :caption: glotaran/__init__.py
+
+
+        def __getattr__(attribute_name: str):
+            from glotaran.deprecation import deprecate_module_attribute
+
+            if attribute_name == "ParameterGroup":
+                return deprecate_module_attribute(
+                    deprecated_qual_name="glotaran.ParameterGroup",
+                    new_qual_name="glotaran.parameter.ParameterGroup",
+                    to_be_removed_in_version="0.6.0",
+                )
+
+            raise AttributeError(f"module {__name__} has no attribute {attribute_name}")
+
+    """
+    module_name = ".".join(new_qual_name.split(".")[:-1])
+    attribute_name = new_qual_name.split(".")[-1]
+
+    warn_deprecated(
+        deprecated_qual_name_usage=deprecated_qual_name,
+        new_qual_name_usage=new_qual_name,
+        to_be_removed_in_version=to_be_removed_in_version,
+        check_qual_names=(False, True),
+        stacklevel=4,
+        importable_indices=(1, 1),
+    )
+    return module_attribute(module_name, attribute_name)
+
+
+def deprecate_submodule(
+    *,
+    deprecated_module_name: str,
+    new_module_name: str,
+    to_be_removed_in_version: str,
+) -> ModuleType:
+    r"""Create a module at runtime which retrieves attributes from new module.
+
+    When moving a module, create a variable with the modules name in the
+    parent packages ``__init__.py``, so imports will be redirected to the
+    new module location and a deprecation warning will be given, to help
+    the user adjust the outdated code.
+    Each time an attribute is retrieved there will be a deprecation warning.
+
+    Parameters
+    ----------
+    deprecated_module_name : str
+        Fully qualified name of the deprecated module e.g.:
+        ``'glotaran.analysis.result'``
+    new_module_name : str
+        Fully qualified name of the new module e.g.:
+        ``'glotaran.project.result'``
+    to_be_removed_in_version : str
+        Version the support for this usage will be removed.
+
+    Returns
+    -------
+    ModuleType
+        Module containing
+
+    See Also
+    --------
+    deprecate
+    deprecate_module_attribute
+
+    Examples
+    --------
+    When moving the module ``result`` from ``glotaran.analysis.result`` to
+    ``glotaran.project.result`` the following code was added to the old parent
+    packages (``glotaran.analysis``) ``__init__.py``.
+
+    .. code-block:: python
+        :caption: glotaran/analysis/__init__.py
+
+        from glotaran.deprecation.deprecation_utils import deprecate_submodule
+
+        result = deprecate_submodule(
+            deprecated_module_name="glotaran.analysis.result",
+            new_module_name="glotaran.project.result",
+            to_be_removed_in_version="0.6.0",
+        )
+    """
+    new_module = import_module(new_module_name)
+    deprecated_module = ModuleType(
+        deprecated_module_name,
+        f"Deprecated use {new_module_name!r} instead.\n\n{new_module.__doc__}",
+    )
+
+    def warn_getattr(attribute_name: str):
+
+        if attribute_name in dir(new_module):
+
+            return deprecate_module_attribute(
+                deprecated_qual_name=deprecated_module_name,
+                new_qual_name=f"{new_module_name}.{attribute_name}",
+                to_be_removed_in_version=to_be_removed_in_version,
+            )
+
+        raise AttributeError(f"module {deprecated_module_name} has no attribute {attribute_name}")
+
+    setattr(deprecated_module, "__getattr__", warn_getattr)
+    setattr(deprecated_module, "__package__", deprecated_module_name.split(".")[:-1])
+    setattr(deprecated_module, "__dir__", new_module.__dir__)
+
+    sys.modules[deprecated_module_name] = deprecated_module
+    return deprecated_module

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -320,15 +320,15 @@ def deprecate(
 
     def outer_wrapper(deprecated_object: DecoratedCallable) -> DecoratedCallable:
         """Wrap deprecated_object of all callable kinds."""
-        if type(deprecated_object) is type:
-            setattr(
-                deprecated_object,
-                "__new__",
-                inject_warn_into_call(deprecated_object.__new__),  # type: ignore [arg-type]
-            )
-            return deprecated_object
-        else:
+        if type(deprecated_object) is not type:
             return cast(DecoratedCallable, inject_warn_into_call(deprecated_object))
+
+        setattr(
+            deprecated_object,
+            "__new__",
+            inject_warn_into_call(deprecated_object.__new__),  # type: ignore [arg-type]
+        )
+        return deprecated_object
 
     return outer_wrapper
 

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -34,8 +34,6 @@ class OverDueDeprecation(Exception):
     deprecate_submodule
     """
 
-    pass
-
 
 def glotaran_version() -> str:
     """Version of the distribution.

--- a/glotaran/deprecation/modules/__init__.py
+++ b/glotaran/deprecation/modules/__init__.py
@@ -1,4 +1,4 @@
-"""Package containing deprated code implementation which were removed.
+"""Package containing deprecated implementations which were removed.
 
 To keep things organized the filenames should be like the
 relative import path from glotaran root, but with ``_`` instead of ``.``.

--- a/glotaran/deprecation/modules/__init__.py
+++ b/glotaran/deprecation/modules/__init__.py
@@ -1,0 +1,10 @@
+"""Package containing deprated code implementation which were removed.
+
+To keep things organized the filenames should be like the
+relative import path from glotaran root, but with ``_`` instead of ``.``.
+E.g. ``glotaran.analysis.scheme`` would map to ``analysis_scheme.py``
+
+The only exceptions to this rule are the root ``__init__.py`` which
+is named ``glotaran_root.py`` and testing changed imports which should
+be placed in ``test_changed_imports.py``.
+"""

--- a/glotaran/deprecation/modules/glotaran_root.py
+++ b/glotaran/deprecation/modules/glotaran_root.py
@@ -1,0 +1,139 @@
+"""Deprecated attributes from ``glotaran.__init__`` which ere removed."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from glotaran.deprecation import deprecate
+from glotaran.io import load_model
+from glotaran.io import load_parameters
+
+if TYPE_CHECKING:
+    from glotaran.model import Model
+    from glotaran.parameter import ParameterGroup
+
+
+@deprecate(
+    deprecated_qual_name_usage="glotaran.read_model_from_yaml(model_yml_str)",
+    new_qual_name_usage='glotaran.io.load_model(model_yml_str, format_name="yml_str")',
+    to_be_removed_in_version="0.6.0",
+)
+def read_model_from_yaml(model_yml_str: str) -> Model:
+    """Parse ``yaml`` string to :class:`Model`.
+
+    Warning
+    -------
+    Deprecated use ``glotaran.io.load_model(model_yml_str, format_name="yml_str")``
+    instead.
+
+    Parameters
+    ----------
+    model_yml_str : str
+        Model spec description in yaml.
+
+    Returns
+    -------
+    Model
+        Model described in ``model_yml_str``.
+    """
+    return load_model(model_yml_str, format_name="yml_str")
+
+
+@deprecate(
+    deprecated_qual_name_usage="glotaran.read_model_from_yaml_file(model_file)",
+    new_qual_name_usage="glotaran.io.load_model(model_file)",
+    to_be_removed_in_version="0.6.0",
+)
+def read_model_from_yaml_file(model_file: str) -> Model:
+    """Parse ``model.yaml`` file to :class:`Model`.
+
+    Warning
+    -------
+    Deprecated use ``glotaran.io.load_model(model_file)`` instead.
+
+    Parameters
+    ----------
+    model_file : str
+        File with model spec description as yaml.
+
+    Returns
+    -------
+    Model
+        Model described in ``model_file``.
+    """
+    return load_model(model_file)
+
+
+@deprecate(
+    deprecated_qual_name_usage="glotaran.read_parameters_from_csv_file(parameters_file)",
+    new_qual_name_usage="glotaran.io.load_parameters(parameters_file)",
+    to_be_removed_in_version="0.6.0",
+)
+def read_parameters_from_csv_file(parameters_file: str) -> ParameterGroup:
+    """Parse ``parameters_file`` to :class:`ParameterGroup`.
+
+    Warning
+    -------
+    Deprecated use ``glotaran.io.load_parameters(parameters_file)`` instead.
+
+    Parameters
+    ----------
+    parameters_file : str
+        File with parameters in csv.
+
+    Returns
+    -------
+    ParameterGroup
+        ParameterGroup described in ``parameters_file``.
+    """
+    return load_parameters(parameters_file)
+
+
+@deprecate(
+    deprecated_qual_name_usage="glotaran.read_parameters_from_yaml(parameters_yml_str)",
+    new_qual_name_usage="glotaran.io.load_model(parameters_yml_str)",
+    to_be_removed_in_version="0.6.0",
+)
+def read_parameters_from_yaml(parameters_yml_str: str) -> ParameterGroup:
+    """Parse ``yaml`` string to :class:`ParameterGroup`.
+
+    Warning
+    -------
+    Deprecated use ``glotaran.io.load_parameters(parameters_yml_str, format_name="yml_str")``
+    instead.
+
+    Parameters
+    ----------
+    parameters_yml_str : str
+        PArameter spec description in yaml.
+
+    Returns
+    -------
+    ParameterGroup
+        ParameterGroup described in ``parameters_yml_str``.
+    """
+    return load_parameters(parameters_yml_str, format_name="yml_str")
+
+
+@deprecate(
+    deprecated_qual_name_usage="glotaran.read_parameters_from_yaml_file(parameters_file)",
+    new_qual_name_usage="glotaran.io.load_parameters(parameters_file)",
+    to_be_removed_in_version="0.6.0",
+)
+def read_parameters_from_yaml_file(parameters_file: str) -> ParameterGroup:
+    """Parse ``parameters_file`` to :class:`ParameterGroup`.
+
+    Warning
+    -------
+    Deprecated use ``glotaran.io.load_parameters(parameters_file)`` instead.
+
+    Parameters
+    ----------
+    parameters_file : str
+        File with parameters in yaml.
+
+    Returns
+    -------
+    ParameterGroup
+        ParameterGroup described in ``parameters_file``.
+    """
+    return load_parameters(parameters_file)

--- a/glotaran/deprecation/modules/glotaran_root.py
+++ b/glotaran/deprecation/modules/glotaran_root.py
@@ -1,4 +1,4 @@
-"""Deprecated attributes from ``glotaran.__init__`` which ere removed."""
+"""Deprecated attributes from ``glotaran.__init__`` which are removed."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/glotaran/deprecation/modules/test/__init__.py
+++ b/glotaran/deprecation/modules/test/__init__.py
@@ -1,0 +1,57 @@
+"""Package with deprecation tests and helper functions."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from typing import Any
+    from typing import Callable
+    from typing import Mapping
+    from typing import Sequence
+
+
+def deprecation_warning_on_call_test_helper(
+    deprecated_callable: Callable[..., Any],
+    *,
+    raise_exception=False,
+    args: Sequence[Any] = [],
+    kwargs: Mapping[str, Any] = {},
+) -> Any:
+    """Helperfunction to quickly test that a deprecated class or function warns.
+
+    By default this ignores error when calling the function/class,
+    since those tests are only supposed to test the deprecation itself.
+
+    However if the code is reimplemented it should be at least tested
+    to return the proper type.
+
+
+    Parameters
+    ----------
+    deprecated_callable : Callable[..., Any]
+        Deprecated function or class.
+    raise_exception : bool
+        Whether or not to reraise an exception e.g. by calling with wrong args.
+    args : Sequence[Any]
+        Positional arguments for deprecated_callable.
+    kwargs : Mapping[str, Any], optional
+        Keyword arguments for deprecated_callable.
+
+    Returns
+    -------
+    Any
+        Return value of deprecated_callable
+
+    Raises
+    ------
+    Exception
+        Exception caused by deprecated_callable if raise_exception is True.
+    """
+    with pytest.warns(DeprecationWarning):
+        try:
+            return deprecated_callable(*args, **kwargs)
+        except Exception:
+            if raise_exception:
+                raise

--- a/glotaran/deprecation/modules/test/test_changed_imports.py
+++ b/glotaran/deprecation/modules/test/test_changed_imports.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import warnings
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+import pytest
+
+from glotaran.deprecation.deprecation_utils import module_attribute
+from glotaran.io import load_dataset
+from glotaran.parameter import ParameterGroup
+from glotaran.project import Result
+from glotaran.project import Scheme
+from glotaran.project import result as project_result
+from glotaran.project import scheme as project_scheme
+
+if TYPE_CHECKING:
+    from _pytest.recwarn import WarningsRecorder
+
+
+def check_recwarn(records: WarningsRecorder, warn_nr=1):
+
+    for record in records:
+        print(record)
+
+    assert len(records) == warn_nr
+    assert records[0].category == DeprecationWarning
+
+    records.clear()
+
+
+def changed_import_test_warn(
+    recwarn: WarningsRecorder, module_qual_name: str, *, attribute_name: str = None, warn_nr=1
+):
+    """Helper for testing changed imports, returning the imported item.
+
+    Parameters
+    ----------
+    module_qual_name : str
+        Fully qualified name for a module e.g. ``glotaran.model.base_model``
+    attribute_name : str, optional
+        Name of the attribute e.g. ``Model``
+
+    Returns
+    -------
+    Any
+        Module attribute or module
+    """
+
+    warnings.simplefilter("always")
+
+    recwarn.clear()
+
+    if attribute_name is not None:
+        result = module_attribute(module_qual_name, attribute_name)
+    else:
+        result = import_module(module_qual_name)
+    check_recwarn(recwarn, warn_nr=warn_nr)
+    return result
+
+
+@pytest.mark.xfail(strict=True, reason="Fail if no warning")
+def test_changed_import_test_warn_attribute_no_warn(
+    recwarn: WarningsRecorder,
+):
+    """Module attribute import not warning"""
+    changed_import_test_warn(recwarn, "glotaran.parameter", attribute_name="ParameterGroup")
+
+
+@pytest.mark.xfail(strict=True, reason="Fail if no warning")
+def test_changed_import_test_warn_module_no_warn(
+    recwarn: WarningsRecorder,
+):
+    """Module import not warning"""
+    changed_import_test_warn(recwarn, "glotaran.parameter")
+
+
+def test_root_ParameterGroup(recwarn: WarningsRecorder):
+    """glotaran.ParameterGroup"""
+    result = changed_import_test_warn(recwarn, "glotaran", attribute_name="ParameterGroup")
+
+    assert result == ParameterGroup
+
+
+def test_analysis_result(recwarn: WarningsRecorder):
+    """Usage of glotaran.analysis.result"""
+    warnings.simplefilter("always")
+
+    from glotaran.analysis import result
+
+    assert len(recwarn) == 0
+    assert result.Result == project_result.Result  # type: ignore [attr-defined]
+
+    check_recwarn(recwarn)
+
+
+def test_analysis_result_from_import(recwarn: WarningsRecorder):
+    """Same as 'from glotaran.analysis.result import Result' as analysis_result"""
+    analysis_result = changed_import_test_warn(
+        recwarn, "glotaran.analysis.result", attribute_name="Result"
+    )
+
+    assert analysis_result == Result
+
+
+def test_analysis_scheme(recwarn: WarningsRecorder):
+    """Usage of glotaran.analysis.scheme"""
+    warnings.simplefilter("always")
+
+    from glotaran.analysis import scheme as analysis_scheme
+
+    assert len(recwarn) == 0
+    assert analysis_scheme.Scheme == project_scheme.Scheme  # type: ignore [attr-defined]
+
+    check_recwarn(recwarn)
+
+
+def test_analysis_scheme_from_import(recwarn: WarningsRecorder):
+    """Same as 'from glotaran.analysis.scheme import Scheme as analysis_scheme'"""
+    analysis_scheme = changed_import_test_warn(
+        recwarn, "glotaran.analysis.scheme", attribute_name="Scheme"
+    )
+
+    assert analysis_scheme == Scheme
+
+
+def test_io_read_data_file(recwarn: WarningsRecorder):
+    """glotaran.io.read_data_file"""
+    result = changed_import_test_warn(recwarn, "glotaran.io", attribute_name="read_data_file")
+
+    assert result.__code__ == load_dataset.__code__

--- a/glotaran/deprecation/modules/test/test_glotaran_root.py
+++ b/glotaran/deprecation/modules/test/test_glotaran_root.py
@@ -1,0 +1,114 @@
+"""Test deprecated imports from 'glotaran/__init__.py' """
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from warnings import warn
+
+import pytest
+
+from glotaran import read_model_from_yaml
+from glotaran import read_model_from_yaml_file
+from glotaran import read_parameters_from_csv_file
+from glotaran import read_parameters_from_yaml
+from glotaran import read_parameters_from_yaml_file
+from glotaran.deprecation.modules.test import deprecation_warning_on_call_test_helper
+from glotaran.model import Model
+from glotaran.parameter import ParameterGroup
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def dummy_warn(foo, bar=False):
+    warn(DeprecationWarning("foo"))
+    if not isinstance(bar, bool):
+        raise ValueError("not a bool")
+    return foo, bar
+
+
+def dummy_no_warn(foo, bar=False):
+    return foo, bar
+
+
+def test_deprecation_warning_on_call_test_helper():
+    """Correct result passed on"""
+    result = deprecation_warning_on_call_test_helper(
+        dummy_warn, args=["foo"], kwargs={"bar": True}
+    )
+
+    assert result == ("foo", True)
+
+
+def test_deprecation_warning_on_call_test_helper_error_reraise():
+    """Raise if raise_exception and args or kwargs"""
+
+    with pytest.raises(ValueError, match="not a bool"):
+        deprecation_warning_on_call_test_helper(
+            dummy_warn, args=["foo"], kwargs={"bar": "baz"}, raise_exception=True
+        )
+
+
+@pytest.mark.xfail(strict=True, reason="Function did not warn.")
+def test_deprecation_warning_on_call_test_helper_no_warn():
+    """Fail no warning"""
+    deprecation_warning_on_call_test_helper(dummy_no_warn, args=["foo"], kwargs={"bar": True})
+
+
+def test_read_model_from_yaml():
+    """read_model_from_yaml raises warning"""
+    result = deprecation_warning_on_call_test_helper(
+        read_model_from_yaml, args=["type: kinetic-spectrum"], raise_exception=True
+    )
+
+    assert isinstance(result, Model)
+    assert result.model_type == "kinetic-spectrum"
+
+
+def test_read_model_from_yaml_file(tmp_path: Path):
+    """read_model_from_yaml_file raises warning"""
+    model_file = tmp_path / "model.yaml"
+    model_file.write_text("type: kinetic-spectrum")
+    result = deprecation_warning_on_call_test_helper(
+        read_model_from_yaml_file, args=[str(model_file)], raise_exception=True
+    )
+
+    assert isinstance(result, Model)
+    assert result.model_type == "kinetic-spectrum"
+
+
+def test_read_parameters_from_csv_file(tmp_path: Path):
+    """read_parameters_from_csv_file raises warning"""
+    parameters_file = tmp_path / "parameters.csv"
+    parameters_file.write_text("label,value\nfoo,123")
+    result = deprecation_warning_on_call_test_helper(
+        read_parameters_from_csv_file,
+        args=[str(parameters_file)],
+        raise_exception=True,
+    )
+
+    assert isinstance(result, ParameterGroup)
+    assert result.get("foo") == 123
+
+
+def test_read_parameters_from_yaml():
+    """read_parameters_from_yaml raises warning"""
+    result = deprecation_warning_on_call_test_helper(
+        read_parameters_from_yaml, args=["foo:\n  - 123"], raise_exception=True
+    )
+
+    assert isinstance(result, ParameterGroup)
+    assert isinstance(result["foo"], ParameterGroup)
+    assert result["foo"].get(1) == 123
+
+
+def test_read_parameters_from_yaml_file(tmp_path: Path):
+    """read_parameters_from_yaml_file raises warning"""
+    parameters_file = tmp_path / "parameters.yaml"
+    parameters_file.write_text("foo:\n  - 123")
+    result = deprecation_warning_on_call_test_helper(
+        read_parameters_from_yaml_file, args=[str(parameters_file)], raise_exception=True
+    )
+
+    assert isinstance(result, ParameterGroup)
+    assert isinstance(result["foo"], ParameterGroup)
+    assert result["foo"].get(1) == 123

--- a/glotaran/deprecation/modules/test/test_project_result.py
+++ b/glotaran/deprecation/modules/test/test_project_result.py
@@ -1,0 +1,49 @@
+"""Test deprecated functionality in 'glotaran.project.result'."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from glotaran.deprecation.modules.test import deprecation_warning_on_call_test_helper
+from glotaran.project.test.test_result import dummy_result  # noqa: F401
+
+if TYPE_CHECKING:
+    from py.path import local as LocalPath
+
+    from glotaran.project.result import Result
+
+
+def test_Result_save_method(tmpdir: LocalPath, dummy_result: Result):  # noqa: F811
+    """Result.save(result_dir) creates all file"""
+    result_dir = tmpdir / "dummy"
+    result_dir.mkdir()
+
+    deprecation_warning_on_call_test_helper(
+        dummy_result.save, args=[str(result_dir)], raise_exception=True
+    )
+
+    assert (result_dir / "result.md").exists()
+    assert (result_dir / "optimized_parameters.csv").exists()
+    assert (result_dir / "dataset1.nc").exists()
+    assert (result_dir / "dataset2.nc").exists()
+    assert (result_dir / "dataset3.nc").exists()
+
+
+def test_Result_get_dataset_method(dummy_result: Result):  # noqa: F811
+    """Result.get_dataset(dataset_label) gives correct dataset."""
+
+    result = deprecation_warning_on_call_test_helper(
+        dummy_result.get_dataset, args=["dataset1"], raise_exception=True
+    )
+
+    assert result == dummy_result.data["dataset1"]
+
+
+def test_Result_get_dataset_method_error(dummy_result: Result):  # noqa: F811
+    """Result.get_dataset(dataset_label) error on wrong key."""
+
+    with pytest.raises(ValueError, match="Unknown dataset 'foo'"):
+        deprecation_warning_on_call_test_helper(
+            dummy_result.get_dataset, args=["foo"], raise_exception=True
+        )

--- a/glotaran/deprecation/modules/test/test_project_sheme.py
+++ b/glotaran/deprecation/modules/test/test_project_sheme.py
@@ -1,0 +1,44 @@
+"""Test deprecated functionality in 'glotaran.project.schmeme'."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import xarray as xr
+
+from glotaran.deprecation.modules.test import deprecation_warning_on_call_test_helper
+from glotaran.project.scheme import Scheme
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_Scheme_from_yaml_file_method(tmp_path: Path):
+    """Create Scheme from file."""
+    scheme_path = tmp_path / "scheme.yml"
+
+    model_path = tmp_path / "model.yml"
+    model_path.write_text("type: kinetic-spectrum\ndataset:\n  dataset1:\n    megacomplex: []")
+
+    parameter_path = tmp_path / "parameters.yml"
+    parameter_path.write_text("[1.0, 67.0]")
+
+    dataset_path = tmp_path / "dataset.nc"
+    xr.DataArray([[1, 2, 3]], coords=[("e", [1]), ("c", [1, 2, 3])]).to_dataset(
+        name="data"
+    ).to_netcdf(dataset_path)
+
+    scheme_path.write_text(
+        f"""
+        model: {model_path}
+        parameters: {parameter_path}
+        non-negative-least-squares: True
+        maximum-number-function-evaluations: 42
+        data:
+            dataset1: {dataset_path}"""
+    )
+
+    result = deprecation_warning_on_call_test_helper(
+        Scheme.from_yaml_file, args=[str(scheme_path)], raise_exception=True
+    )
+
+    assert isinstance(result, Scheme)

--- a/glotaran/deprecation/test/__init__.py
+++ b/glotaran/deprecation/test/__init__.py
@@ -1,0 +1,1 @@
+"""Deprecation test module."""

--- a/glotaran/deprecation/test/dummy_package/__init__.py
+++ b/glotaran/deprecation/test/dummy_package/__init__.py
@@ -1,0 +1,9 @@
+"""Module containing a deprecated fake module."""
+from glotaran.deprecation.deprecation_utils import deprecate_submodule
+
+# just here to be tested
+deprecated_module = deprecate_submodule(
+    deprecated_module_name="glotaran.deprecation.test.dummy_package.deprecated_module",
+    new_module_name="glotaran.deprecation.deprecation_utils",
+    to_be_removed_in_version="0.6.0",
+)

--- a/glotaran/deprecation/test/dummy_package/deprecated_module_attribute.py
+++ b/glotaran/deprecation/test/dummy_package/deprecated_module_attribute.py
@@ -1,0 +1,16 @@
+"""Dummy module to test deprecate_module_attribute."""
+
+
+def __getattr__(attribute_name: str):
+    from glotaran.deprecation import deprecate_module_attribute
+
+    if attribute_name == "deprecated_attribute":
+        return deprecate_module_attribute(
+            deprecated_qual_name=(
+                "glotaran.deprecation.test.dummy_package.deprecated_module_attribute"
+            ),
+            new_qual_name="glotaran.deprecation.deprecation_utils.parse_version",
+            to_be_removed_in_version="0.6.0",
+        )
+
+    raise AttributeError(f"module {__name__} has no attribute {attribute_name}")

--- a/glotaran/deprecation/test/test_deprecation_utils.py
+++ b/glotaran/deprecation/test/test_deprecation_utils.py
@@ -97,12 +97,6 @@ def test_warn_deprecated_overdue_deprecation(monkeypatch: MonkeyPatch):
         glotaran.deprecation.deprecation_utils, "glotaran_version", lambda: "1.0.0"
     )
 
-    expected = (
-        "Support for 'glotaran.read_model_from_yaml' was supposed "
-        "to be dropped in version: '0.6.0'.\n"
-        "Current version is: '1.0.0'"
-    )
-
     with pytest.raises(OverDueDeprecation) as record:
         warn_deprecated(
             deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
@@ -111,6 +105,12 @@ def test_warn_deprecated_overdue_deprecation(monkeypatch: MonkeyPatch):
         )
 
         assert len(record) == 1  # type: ignore [arg-type]
+        expected = (
+            "Support for 'glotaran.read_model_from_yaml' was supposed "
+            "to be dropped in version: '0.6.0'.\n"
+            "Current version is: '1.0.0'"
+        )
+
         assert record[0].message.args[0] == expected  # type: ignore [index]
         assert Path(record[0].filename) == Path(__file__)  # type: ignore [index]
 

--- a/glotaran/deprecation/test/test_deprecation_utils.py
+++ b/glotaran/deprecation/test/test_deprecation_utils.py
@@ -233,7 +233,6 @@ def test_deprecated_decorator_function(recwarn: WarningsRecorder):
     )
     def dummy():
         """Dummy docstring for testing."""
-        pass
 
     dummy()
 

--- a/glotaran/deprecation/test/test_deprecation_utils.py
+++ b/glotaran/deprecation/test/test_deprecation_utils.py
@@ -115,6 +115,22 @@ def test_warn_deprecated_overdue_deprecation(monkeypatch: MonkeyPatch):
         assert Path(record[0].filename) == Path(__file__)  # type: ignore [index]
 
 
+@pytest.mark.filterwarnings("ignore:Usage")
+@pytest.mark.xfail(strict=True, reason="Dev version aren't checked")
+def test_warn_deprecated_no_overdue_deprecation_on_dev(monkeypatch: MonkeyPatch):
+    """Current version is equal or bigger than drop_version but it's a dev version."""
+    monkeypatch.setattr(
+        glotaran.deprecation.deprecation_utils, "glotaran_version", lambda: "0.6.0-dev"
+    )
+
+    with pytest.raises(OverDueDeprecation):
+        warn_deprecated(
+            deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
+            new_qual_name_usage=NEW_QUAL_NAME,
+            to_be_removed_in_version="0.6.0",
+        )
+
+
 @pytest.mark.parametrize(
     "deprecated_qual_name_usage,new_qual_name_usage",
     (

--- a/glotaran/deprecation/test/test_deprecation_utils.py
+++ b/glotaran/deprecation/test/test_deprecation_utils.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+import glotaran
+from glotaran.deprecation.deprecation_utils import OverDueDeprecation
+from glotaran.deprecation.deprecation_utils import deprecate
+from glotaran.deprecation.deprecation_utils import glotaran_version
+from glotaran.deprecation.deprecation_utils import module_attribute
+from glotaran.deprecation.deprecation_utils import parse_version
+from glotaran.deprecation.deprecation_utils import warn_deprecated
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+    from _pytest.recwarn import WarningsRecorder
+
+
+DEP_UTILS_QUALNAME = "glotaran.deprecation.deprecation_utils"
+
+DEPRECATION_QUAL_NAME = f"{DEP_UTILS_QUALNAME}.parse_version(version_str)"
+NEW_QUAL_NAME = f"{DEP_UTILS_QUALNAME}.check_qualnames_in_tests(qualnames)"
+
+DEPRECATION_WARN_MESSAGE = (
+    "Usage of 'glotaran.deprecation.deprecation_utils.parse_version(version_str)' "
+    "was deprecated, use "
+    "'glotaran.deprecation.deprecation_utils.check_qualnames_in_tests(qualnames)' "
+    "instead.\nThis usage will be an error in version: '0.6.0'."
+)
+
+
+class DummyClass:
+    """Dummy class to check check_qualnames_in_tests"""
+
+    foo: dict[str, str] = {}
+
+
+@pytest.fixture
+def glotaran_0_3_0(monkeypatch: MonkeyPatch):
+    """Mock glotaran version to always be 0.3.0 for the test."""
+    monkeypatch.setattr(
+        glotaran.deprecation.deprecation_utils, "glotaran_version", lambda: "0.3.0"
+    )
+    yield
+
+
+def test_glotaran_version():
+    """Versions are the same."""
+    assert glotaran_version() == glotaran.__version__
+
+
+@pytest.mark.parametrize(
+    "version_str, expected",
+    (
+        ("0.0.1", (0, 0, 1)),
+        ("0.0.1.post", (0, 0, 1)),
+        ("0.0.1-dev", (0, 0, 1)),
+        ("0.0.1-dev.post", (0, 0, 1)),
+    ),
+)
+def test_parse_version(version_str: str, expected: tuple[int, int, int]):
+    """Valid version strings."""
+    assert parse_version(version_str) == expected
+
+
+@pytest.mark.parametrize(
+    "version_str",
+    ("1", "0.1", "a.b.c"),
+)
+def test_parse_version_errors(version_str: str):
+    """Invalid version strings"""
+    with pytest.raises(ValueError, match=f"'{version_str}'"):
+        parse_version(version_str)
+
+
+@pytest.mark.usefixtures("glotaran_0_3_0")
+def test_warn_deprecated():
+    """Warning gets shown when all is in order."""
+    with pytest.warns(DeprecationWarning) as record:
+        warn_deprecated(
+            deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
+            new_qual_name_usage=NEW_QUAL_NAME,
+            to_be_removed_in_version="0.6.0",
+        )
+
+        assert len(record) == 1
+        assert record[0].message.args[0] == DEPRECATION_WARN_MESSAGE
+        assert Path(record[0].filename) == Path(__file__)
+
+
+def test_warn_deprecated_overdue_deprecation(monkeypatch: MonkeyPatch):
+    """Current version is equal or bigger than drop_version."""
+    monkeypatch.setattr(
+        glotaran.deprecation.deprecation_utils, "glotaran_version", lambda: "1.0.0"
+    )
+
+    expected = (
+        "Support for 'glotaran.read_model_from_yaml' was supposed "
+        "to be dropped in version: '0.6.0'.\n"
+        "Current version is: '1.0.0'"
+    )
+
+    with pytest.raises(OverDueDeprecation) as record:
+        warn_deprecated(
+            deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
+            new_qual_name_usage=NEW_QUAL_NAME,
+            to_be_removed_in_version="0.6.0",
+        )
+
+        assert len(record) == 1  # type: ignore [arg-type]
+        assert record[0].message.args[0] == expected  # type: ignore [index]
+        assert Path(record[0].filename) == Path(__file__)  # type: ignore [index]
+
+
+@pytest.mark.parametrize(
+    "deprecated_qual_name_usage,new_qual_name_usage",
+    (
+        (
+            "glotaran.does_not_exists(foo)",
+            DEPRECATION_QUAL_NAME,
+        ),
+        (
+            DEPRECATION_QUAL_NAME,
+            "glotaran.does_not_exists(foo)",
+        ),
+    ),
+)
+@pytest.mark.xfail(strict=True, reason="Should fail if any qualname is wrong.")
+@pytest.mark.usefixtures("glotaran_0_3_0")
+def test_warn_deprecated_broken_deprecated_qualname(
+    deprecated_qual_name_usage: str, new_qual_name_usage: str
+):
+    """Fail if any qualname is wrong."""
+    warn_deprecated(
+        deprecated_qual_name_usage=deprecated_qual_name_usage,
+        new_qual_name_usage=new_qual_name_usage,
+        to_be_removed_in_version="0.6.0",
+    )
+
+
+@pytest.mark.parametrize(
+    "deprecated_qual_name_usage,new_qual_name_usage,check_qualnames",
+    (
+        ("glotaran.does_not_exists(foo)", DEPRECATION_QUAL_NAME, (False, True)),
+        (DEPRECATION_QUAL_NAME, "glotaran.does_not_exists(foo)", (True, False)),
+    ),
+)
+@pytest.mark.usefixtures("glotaran_0_3_0")
+def test_warn_deprecated_broken_qualname_no_check(
+    deprecated_qual_name_usage: str, new_qual_name_usage: str, check_qualnames: tuple[bool, bool]
+):
+    """Not checking broken imports."""
+    with pytest.warns(DeprecationWarning):
+        warn_deprecated(
+            deprecated_qual_name_usage=deprecated_qual_name_usage,
+            new_qual_name_usage=new_qual_name_usage,
+            to_be_removed_in_version="0.6.0",
+            check_qual_names=check_qualnames,
+        )
+
+
+@pytest.mark.usefixtures("glotaran_0_3_0")
+def test_warn_deprecated_sliced_method():
+    """Slice away method for importing and check class for attribute"""
+    with pytest.warns(DeprecationWarning):
+        warn_deprecated(
+            deprecated_qual_name_usage=(
+                "glotaran.deprecation.test.test_deprecation_utils.DummyClass.foo()"
+            ),
+            new_qual_name_usage=DEPRECATION_QUAL_NAME,
+            to_be_removed_in_version="0.6.0",
+            importable_indices=(2, 1),
+        )
+
+
+@pytest.mark.usefixtures("glotaran_0_3_0")
+def test_warn_deprecated_sliced_mapping():
+    """Slice away mapping for importing and check class for attribute"""
+    with pytest.warns(DeprecationWarning):
+        warn_deprecated(
+            deprecated_qual_name_usage=(
+                "glotaran.deprecation.test.test_deprecation_utils.DummyClass.foo['bar']"
+            ),
+            new_qual_name_usage=DEPRECATION_QUAL_NAME,
+            to_be_removed_in_version="0.6.0",
+            importable_indices=(2, 1),
+        )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Should fail if new qualname is wrong, even if check_deprecated_qualname is False.",
+)
+@pytest.mark.usefixtures("glotaran_0_3_0")
+def test_warn_deprecated_broken_new_qualname_no_check():
+    """Fail if new qualname is wrong."""
+    warn_deprecated(
+        deprecated_qual_name_usage="glotaran.does_not_exists(foo)",
+        new_qual_name_usage="glotaran.does_not_exists(foo)",
+        to_be_removed_in_version="0.6.0",
+        check_qual_names=(False, True),
+    )
+
+
+@pytest.mark.usefixtures("glotaran_0_3_0")
+def test_deprecated_decorator_function(recwarn: WarningsRecorder):
+    """Deprecate function with decorator."""
+    warnings.simplefilter("always")
+
+    @deprecate(
+        deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
+        new_qual_name_usage=NEW_QUAL_NAME,
+        to_be_removed_in_version="0.6.0",
+    )
+    def dummy():
+        """Dummy docstring for testing."""
+        pass
+
+    dummy()
+
+    assert dummy.__doc__ == "Dummy docstring for testing."
+    assert len(recwarn) == 1
+    assert recwarn[0].category == DeprecationWarning
+    assert recwarn[0].message.args[0] == DEPRECATION_WARN_MESSAGE  # type: ignore [union-attr]
+    assert Path(recwarn[0].filename) == Path(__file__)
+
+    dummy()
+
+    assert len(recwarn) == 2
+
+
+@pytest.mark.usefixtures("glotaran_0_3_0")
+def test_deprecated_decorator_class(recwarn: WarningsRecorder):
+    """Deprecate class with decorator."""
+    warnings.simplefilter("always")
+
+    @deprecate(
+        deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
+        new_qual_name_usage=NEW_QUAL_NAME,
+        to_be_removed_in_version="0.6.0",
+    )
+    class Foo:
+        """Foo class docstring for testing."""
+
+        @classmethod
+        def from_string(cls, string: str):
+            """Just another method to init the class for testing."""
+            return cls()
+
+    Foo()
+
+    assert Foo.__doc__ == "Foo class docstring for testing."
+    assert len(recwarn) == 1
+    assert recwarn[0].category == DeprecationWarning
+    assert recwarn[0].message.args[0] == DEPRECATION_WARN_MESSAGE  # type: ignore [union-attr]
+    assert Path(recwarn[0].filename) == Path(__file__)
+
+    Foo.from_string("foo")
+
+    assert len(recwarn) == 2
+
+
+def test_module_attribute():
+    """Same code as the original import"""
+
+    result = module_attribute("glotaran.deprecation.deprecation_utils", "parse_version")
+
+    assert result.__code__ == parse_version.__code__
+
+
+@pytest.mark.usefixtures("glotaran_0_3_0")
+def test_deprecate_module_attribute():
+    """Same code as the original import and warning"""
+
+    with pytest.warns(DeprecationWarning) as record:
+
+        from glotaran.deprecation.test.dummy_package.deprecated_module_attribute import (
+            deprecated_attribute,
+        )
+
+        assert deprecated_attribute.__code__ == parse_version.__code__
+        assert Path(record[0].filename) == Path(__file__)
+
+
+@pytest.mark.usefixtures("glotaran_0_3_0")
+def test_deprecate_submodule(recwarn: WarningsRecorder):
+    """Raise warning when Attribute of fake module is used"""
+
+    from glotaran.deprecation.test.dummy_package import deprecated_module
+
+    assert (
+        deprecated_module.parse_version.__code__  # type: ignore [attr-defined]
+        == parse_version.__code__
+    )
+
+    assert len(recwarn) == 1
+    assert recwarn[0].category == DeprecationWarning
+
+
+@pytest.mark.usefixtures("glotaran_0_3_0")
+def test_deprecate_submodule_from_import(recwarn: WarningsRecorder):
+    """Raise warning when Attribute of fake module is imported"""
+
+    from glotaran.deprecation.test.dummy_package.deprecated_module import (  # noqa: F401
+        parse_version,
+    )
+
+    assert len(recwarn) == 1
+    assert recwarn[0].category == DeprecationWarning
+    assert Path(recwarn[0].filename) == Path(__file__)
+
+
+@pytest.mark.usefixtures("glotaran_0_3_0")
+def test_deprecate_submodule_import_error(recwarn: WarningsRecorder):
+    """Raise warning when Attribute of fake module is imported"""
+
+    with pytest.raises(ImportError) as record:
+
+        from glotaran.deprecation.test.dummy_package.deprecated_module import (  # noqa: F401
+            does_not_exists,
+        )
+
+        assert len(record) == 1  # type:ignore[arg-type]
+        assert record[0].message.args[0] == (  # type:ignore[index]
+            "ImportError: cannot import name 'does_not_exists' from "
+            "'glotaran.deprecation.test.deprecated_module' (unknown location)"
+        )
+        assert len(recwarn) == 0
+        assert Path(record[0].filename) == Path(__file__)  # type:ignore[index]

--- a/glotaran/io/__init__.py
+++ b/glotaran/io/__init__.py
@@ -28,3 +28,16 @@ from glotaran.plugin_system.project_io_registration import save_parameters
 from glotaran.plugin_system.project_io_registration import save_result
 from glotaran.plugin_system.project_io_registration import save_scheme
 from glotaran.plugin_system.project_io_registration import show_project_io_method_help
+
+
+def __getattr__(attribute_name: str):
+    from glotaran.deprecation.deprecation_utils import deprecate_module_attribute
+
+    if attribute_name == "read_data_file":
+        return deprecate_module_attribute(
+            deprecated_qual_name="glotaran.io.read_data_file",
+            new_qual_name="glotaran.io.load_dataset",
+            to_be_removed_in_version="0.6.0",
+        )
+
+    raise AttributeError(f"module {__name__} has no attribute {attribute_name}")

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -8,6 +8,8 @@ import xarray as xr
 from numpy.typing import ArrayLike
 from tabulate import tabulate
 
+from glotaran.deprecation import deprecate
+from glotaran.io import save_result
 from glotaran.model import Model
 from glotaran.parameter import ParameterGroup
 from glotaran.project.scheme import Scheme
@@ -165,3 +167,64 @@ class Result:
 
     def __str__(self):
         return self.markdown(with_model=False)
+
+    @deprecate(
+        deprecated_qual_name_usage="glotaran.project.result.Result.save(result_path)",
+        new_qual_name_usage=(
+            "glotaran.io.save_result("
+            "result_path=result_path, result=result, "
+            'format_name="legacy", allow_overwrite=True'
+            ")"
+        ),
+        to_be_removed_in_version="0.6.0",
+        importable_indices=(2, 1),
+    )
+    def save(self, path: str) -> list[str]:
+        """Saves the result to given folder.
+
+        Warning
+        -------
+        Deprecated use ``save_result(result_path=result_path, result=result,
+        format_name="legacy", allow_overwrite=True)`` instead.
+
+
+        Returns a list with paths of all saved items.
+        The following files are saved:
+
+        * `result.md`: The result with the model formatted as markdown text.
+
+        * `optimized_parameters.csv`: The optimized parameter as csv file.
+
+        * `{dataset_label}.nc`: The result data for each dataset as NetCDF file.
+
+        Parameters
+        ----------
+        path :
+            The path to the folder in which to save the result.
+        """
+        save_result(result_path=path, result=self, format_name="legacy", allow_overwrite=True)
+
+    @deprecate(
+        deprecated_qual_name_usage="glotaran.project.result.Result.get_dataset(dataset_label)",
+        new_qual_name_usage=("glotaran.project.result.Result.data[dataset_label]"),
+        to_be_removed_in_version="0.6.0",
+        importable_indices=(2, 2),
+    )
+    def get_dataset(self, dataset_label: str) -> xr.Dataset:
+        """Returns the result dataset for the given dataset label.
+
+        Warning
+        -------
+        Deprecated use ``glotaran.project.result.Result.data[dataset_label]``
+        instead.
+
+
+        Parameters
+        ----------
+        dataset_label :
+            The label of the dataset.
+        """
+        try:
+            return self.data[dataset_label]
+        except KeyError:
+            raise ValueError(f"Unknown dataset '{dataset_label}'")

--- a/glotaran/project/scheme.py
+++ b/glotaran/project/scheme.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING
 
-import xarray as xr
+from glotaran.deprecation import deprecate
+from glotaran.io import load_scheme
 
-from glotaran.model import Model
-from glotaran.parameter import ParameterGroup
+if TYPE_CHECKING:
+
+    from typing import Literal
+
+    import xarray as xr
+
+    from glotaran.model import Model
+    from glotaran.parameter import ParameterGroup
 
 default_data_filters = {"minimal": ["fitted_data", "residual"], "full": None}
 
@@ -63,3 +70,29 @@ class Scheme:
         s += f"* *group_tolerance*: {self.group_tolerance}\n"
 
         return s
+
+    @staticmethod
+    @deprecate(
+        deprecated_qual_name_usage="glotaran.project.scheme.Scheme.from_yaml_file(filename)",
+        new_qual_name_usage="glotaran.io.load_scheme(filename)",
+        to_be_removed_in_version="0.6.0",
+        importable_indices=(2, 1),
+    )
+    def from_yaml_file(filename: str) -> Scheme:
+        """Create :class:`Scheme` from specs in yaml file.
+
+        Warning
+        -------
+        Deprecated use ``glotaran.io.load_scheme(filename)`` instead.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the spec file.
+
+        Returns
+        -------
+        Scheme
+            Analysis schmeme
+        """
+        return load_scheme(filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ remove_redundant_aliases = true
 [tool.interrogate]
 exclude = ["setup.py", "docs", "*test/*"]
 ignore-init-module = true
-fail-under = 47
+fail-under = 49
 
 [tool.nbqa.addopts]
 flake8 = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ ignore_messages = xarraydoc
 
 [darglint]
 docstring_style = numpy
+ignore_regex = test_.+|.*wrapper.*|inject_warn_into_call|.*dummy.*
 
 [pydocstyle]
 convention = numpy


### PR DESCRIPTION
This PR adds a deprecation framework and reintroduces the API of glotaran 0.3.x giving deprecation warnings when used, which instruct users how to change their code.

As usual with my PRs you best review it commit by commit, since they are structured by responsibility.
It might be best to start with the updated contributing docs where I describe the intended usage and then review the rest in order.

**Testing**

Passing the tests is mandatory.

**Closing issues**

closes #588 
