### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.11.0
+    rev: v2.12.0
     hooks:
       - id: pyupgrade
         types: [file]
@@ -55,7 +55,7 @@ repos:
       - id: nbstripout
 
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.5.9
+    rev: 0.6.0
     hooks:
       - id: nbqa-black
         additional_dependencies: [black==20.8b1]

--- a/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
+++ b/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
@@ -75,7 +75,7 @@ class ExplicitFile:
         # TODO: write a more elegant method
 
         if os.path.isfile(self._file) and not overwrite:
-            print("File {} already exists".format(os.path.isfile(self._file)))
+            print(f"File {os.path.isfile(self._file)} already exists")
             raise Exception("File already exist.")
         comment = self._comment + " " + comment
 


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/glotaran/pyglotaran/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-2.12.0-py2.py3-none-any.whl (189 kB)
Collecting pyyaml>=5.1
  Downloading PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl (630 kB)
Collecting toml
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting identify>=1.0.0
  Downloading identify-2.2.3-py2.py3-none-any.whl (98 kB)
Collecting cfgv>=2.0.0
  Downloading cfgv-3.2.0-py2.py3-none-any.whl (7.3 kB)
Collecting virtualenv>=20.0.8
  Downloading virtualenv-20.4.3-py2.py3-none-any.whl (7.2 MB)
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.6.0-py2.py3-none-any.whl (21 kB)
Collecting six<2,>=1.9.0
  Downloading six-1.15.0-py2.py3-none-any.whl (10 kB)
Collecting distlib<1,>=0.3.1
  Downloading distlib-0.3.1-py2.py3-none-any.whl (335 kB)
Collecting appdirs<2,>=1.4.3
  Downloading appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)
Collecting filelock<4,>=3.0.0
  Downloading filelock-3.0.12-py3-none-any.whl (7.6 kB)
Installing collected packages: six, filelock, distlib, appdirs, virtualenv, toml, pyyaml, nodeenv, identify, cfgv, pre-commit
Successfully installed appdirs-1.4.4 cfgv-3.2.0 distlib-0.3.1 filelock-3.0.12 identify-2.2.3 nodeenv-1.6.0 pre-commit-2.12.0 pyyaml-5.4.1 six-1.15.0 toml-0.10.2 virtualenv-20.4.3
```



</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... already up to date.
Updating https://github.com/asottile/pyupgrade ... [INFO] Initializing environment for https://github.com/asottile/pyupgrade.
updating v2.11.0 -> v2.12.0.
Updating https://github.com/MarcoGorelli/absolufy-imports ... [INFO] Initializing environment for https://github.com/MarcoGorelli/absolufy-imports.
already up to date.
Updating https://github.com/python/black ... already up to date.
Updating https://github.com/PyCQA/isort ... [INFO] Initializing environment for https://github.com/PyCQA/isort.
already up to date.
Updating https://github.com/asottile/setup-cfg-fmt ... [INFO] Initializing environment for https://github.com/asottile/setup-cfg-fmt.
already up to date.
Updating https://github.com/kynan/nbstripout ... [INFO] Initializing environment for https://github.com/kynan/nbstripout.
already up to date.
Updating https://github.com/nbQA-dev/nbQA ... [INFO] Initializing environment for https://github.com/nbQA-dev/nbQA.
updating 0.5.9 -> 0.6.0.
Updating https://github.com/econchick/interrogate ... already up to date.
Updating https://github.com/asottile/yesqa ... already up to date.
Updating https://gitlab.com/pycqa/flake8 ... [INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
already up to date.
Updating https://github.com/myint/rstcheck ... 
=====> /home/runner/.cache/pre-commit/repo8ti1iua6/.pre-commit-hooks.yaml does not exist
Updating https://github.com/pre-commit/pygrep-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pygrep-hooks.
already up to date.
Updating https://github.com/codespell-project/codespell ... already up to date.
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/nbQA-dev/nbQA:black==20.8b1.
[INFO] Initializing environment for https://github.com/nbQA-dev/nbQA:pyupgrade==2.9.0.
[INFO] Initializing environment for https://github.com/nbQA-dev/nbQA:flake8.
[INFO] Initializing environment for https://github.com/nbQA-dev/nbQA:pre-commit-hooks.
[INFO] Initializing environment for https://github.com/nbQA-dev/nbQA:isort==5.7.0.
[INFO] Initializing environment for https://gitlab.com/pycqa/flake8:flake8-pyi.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/MarcoGorelli/absolufy-imports.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/python/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/setup-cfg-fmt.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/kynan/nbstripout.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/nbQA-dev/nbQA.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/nbQA-dev/nbQA.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/nbQA-dev/nbQA.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/nbQA-dev/nbQA.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/nbQA-dev/nbQA.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/econchick/interrogate.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/yesqa.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://gitlab.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/myint/rstcheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Check python ast.........................................................Passed
Check builtin type constructor use.......................................Passed
Check for merge conflicts................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
Debug Statements (Python)................................................Passed
Fix python encoding pragma...............................................Passed
pyupgrade................................................................Failed
- hook id: pyupgrade
- exit code: 1
- files were modified by this hook

Rewriting glotaran/builtin/io/ascii/wavelength_time_explicit_file.py

absolufy-imports.........................................................Passed
black....................................................................Passed
isort....................................................................Passed
setup-cfg-fmt............................................................Passed
nbstripout...............................................................Passed
nbqa-black...............................................................Passed
nbqa-pyupgrade...........................................................Passed
nbqa-flake8..............................................................Passed
nbqa-check-ast...........................................................Passed
nbqa-isort...............................................................Passed
Strip empty notebook cells...............................................Passed
interrogate..............................................................Passed
Strip unnecessary `# noqa`s..............................................Passed
flake8...................................................................Passed
rstcheck.................................................................Passed
rst ``code`` is two backticks............................................Passed
codespell................................................................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- .pre-commit-config.yaml
- glotaran/builtin/io/ascii/wavelength_time_explicit_file.py

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)