### PR TITLE
🧪 Add ability to deactivate the pluginsystem via env variable

### DIFF
--- a/glotaran/plugin_system/base_registry.py
+++ b/glotaran/plugin_system/base_registry.py
@@ -6,6 +6,7 @@ This is to prevent issues with circular imports.
 """
 from __future__ import annotations
 
+import os
 from importlib import metadata
 from typing import TYPE_CHECKING
 from warnings import warn
@@ -115,10 +116,11 @@ def load_plugins():
     - ``glotaran.plugins.model``
     - ``glotaran.plugins.project_io``
     """
-    for entry_point_name, entry_points in metadata.entry_points().items():
-        if entry_point_name.startswith("glotaran.plugins"):
-            for entry_point in entry_points:
-                entry_point.load()
+    if "DEACTIVATE_GTA_PLUGINS" not in os.environ:  # pragma: no branch
+        for entry_point_name, entry_points in metadata.entry_points().items():
+            if entry_point_name.startswith("glotaran.plugins"):
+                for entry_point in entry_points:
+                    entry_point.load()
 
 
 def extend_conflicting_plugin_key(

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -27,6 +27,7 @@ pytest>=3.7.1
 pluggy>=0.7
 coverage[toml]
 pytest-cov>=2.5.1
+pytest-env>=0.6.2
 pytest-runner>=2.11.1
 pytest-benchmark>=3.1.1
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,11 @@ skipsdist = true
 skip_missing_interpreters=true
 envlist = py{38}, pre-commit, docs, docs-notebooks, docs-links
 
+[pytest]
+; Uncomment the following lines to deactivate pyglotaran all plugins
+; env =
+;     DEACTIVATE_GTA_PLUGINS=1
+
 [flake8]
 extend-ignore = E231, E203
 max-line-length = 99


### PR DESCRIPTION
This feature is only useful if you run a subset of the tests, if you try to run them all `pytest` will just error.

- Allows deactivating of the plugin system
- Adds `pytest-env` as dev dependency

Plugins can be deactivated by changing the `pytest` config in  `tox.ini`

```ini
[pytest]
; Uncomment the following lines to deactivate pyglotaran plugins
env =
    DEACTIVATE_GTA_PLUGINS=1
```

**Testing**

Passing the tests is mandatory.

**Closing issues**

closes #661 
