### PR TITLE
♻️ Polish the plugin system

### DIFF
--- a/docs/source/notebooks/plugin_system/plugin_howto_write_a_io_plugin.ipynb
+++ b/docs/source/notebooks/plugin_system/plugin_howto_write_a_io_plugin.ipynb
@@ -134,16 +134,16 @@
     "        return xr.Dataset.from_dict(data_dict)\n",
     "\n",
     "    def save_dataset(\n",
-    "        self, file_name: str, dataset: xr.Dataset | xr.DataArray, *, my_extra_option=None\n",
+    "        self, dataset: xr.Dataset | xr.DataArray, file_name: str, *, my_extra_option=None\n",
     "    ):\n",
     "        \"\"\"Write xarray.Dataset to a json file\n",
     "\n",
     "        Parameters\n",
     "        ----------\n",
-    "        file_name : str\n",
-    "            File to write the result data to.\n",
     "        dataset : xr.Dataset\n",
     "            Dataset to be saved to file.\n",
+    "        file_name : str\n",
+    "            File to write the result data to.\n",
     "        my_extra_option: str\n",
     "            This argument is only for demonstration\n",
     "        \"\"\"\n",
@@ -287,7 +287,7 @@
    "outputs": [],
    "source": [
     "save_dataset(\n",
-    "    \"half_intensity.json\", dataset, allow_overwrite=True, my_extra_option=\"just as an example\"\n",
+    "    dataset, \"half_intensity.json\", allow_overwrite=True, my_extra_option=\"just as an example\"\n",
     ")"
    ]
   },

--- a/docs/source/notebooks/quickstart/quickstart.ipynb
+++ b/docs/source/notebooks/quickstart/quickstart.ipynb
@@ -356,7 +356,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "save_dataset(\"dataset1.nc\", result_dataset)"
+    "save_dataset(result_dataset, \"dataset1.nc\")"
    ]
   }
  ],

--- a/docs/source/user_documentation/using_plugins.rst
+++ b/docs/source/user_documentation/using_plugins.rst
@@ -56,7 +56,7 @@ to the beginning of your analysis code.
 .. code-block:: python
 
     from glotaran.io import set_data_plugin
-    set_data_plugin("sdt", "glotaran.builtin.io.sdt.sdt_file_reader.SdtDataIo")
+    set_data_plugin("sdt", "glotaran.builtin.io.sdt.sdt_file_reader.SdtDataIo_sdt")
 
 Models
 ^^^^^^

--- a/docs/source/user_documentation/using_plugins.rst
+++ b/docs/source/user_documentation/using_plugins.rst
@@ -39,7 +39,7 @@ Plugins reading and writing, :class:`Model`,:class:`Schema`,:class:`ParameterGro
 Reproducibility and plugins
 ---------------------------
 
-With a  plugin ecosystem there always is the possibility that multiple plugins try register under the same format/name.
+With a plugin ecosystem there always is the possibility that multiple plugins try register under the same format/name.
 This is why plugins are registered at least twice. Once under the name the developer intended and secondly
 under their full name (full import path).
 This allows to ensure that a specific plugin is used by manually specifying the plugin,

--- a/docs/source/user_documentation/using_plugins.rst
+++ b/docs/source/user_documentation/using_plugins.rst
@@ -4,10 +4,9 @@ Plugins
 To be as flexible as possible ``pyglotaran`` uses a plugin system to handle new ``Models``, ``DataIo`` and ``ProjectIo``.
 Those plugins can be defined by ``pyglotaran`` itself, the user or a 3rd party plugin package.
 
-.. TODO: Write IO guide
 
-Builtin plugin
---------------
+Builtin plugins
+---------------
 
 Models
 ^^^^^^
@@ -30,11 +29,49 @@ Plugins reading and writing data to and from :xarraydoc:`Dataset` or :xarraydoc:
 Project Io
 ^^^^^^^^^^
 
-Plugins reading and writing, :class:`Model`,:class:`Schema`,:class:`ParameterGroup` and :class:`Result`.
+Plugins reading and writing, :class:`Model`,:class:`Schema`,:class:`ParameterGroup` or :class:`Result`.
 
 - :class:`YmlProjectIo`
-- :class:`YmlProjectIo`
+- :class:`CsvProjectIo`
+- :class:`FolderProjectIo`
 
+
+Reproducibility and plugins
+---------------------------
+
+With a  plugin ecosystem there always is the possibility that multiple plugins try register under the same format/name.
+This is why plugins are registered at least twice. Once under the name the developer intended and secondly
+under their full name (full import path).
+This allows to ensure that a specific plugin is used by manually specifying the plugin,
+so if someone wants to run your analysis the results will be reproducible even if they have conflicting plugins installed.
+You can gain all information about the installed plugins by calling the corresponding ``*_plugin_table`` function with both
+options (``plugin_names`` and ``full_names``) set to true.
+To pin a used plugin use the corresponding ``set_*_plugin`` function with the intended name (``format_name``/``model_name``)
+and the full name (``full_plugin_name``) of the plugin to use.
+
+If you wanted to ensure that the pyglotaran builtin plugin is used for ``sdt`` files you could add the following lines
+to the beginning of your analysis code.
+
+
+.. code-block:: python
+
+    from glotaran.io import set_data_plugin
+    set_data_plugin("sdt", "glotaran.builtin.io.sdt.sdt_file_reader.SdtDataIo")
+
+Models
+^^^^^^
+
+The functions for model plugins are located in ``glotaran.model`` and called ``model_plugin_table`` and ``set_model_plugin``.
+
+Data Io
+^^^^^^^
+
+The functions for data io plugins are located in ``glotaran.io`` and called ``data_io_plugin_table`` and ``set_data_plugin``.
+
+Project Io
+^^^^^^^^^^
+
+The functions for project io plugins are located in ``glotaran.io`` and called ``project_io_plugin_table`` and ``set_project_plugin``.
 
 3rd party plugins
 -----------------

--- a/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
+++ b/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
@@ -279,8 +279,8 @@ class AsciiDataIo(DataIoInterface):
 
     def save_dataset(
         self,
-        file_name: str,
         dataset: xr.DataArray,
+        file_name: str,
         *,
         comment: str = "",
         file_format: DataFileType = DataFileType.time_explicit,

--- a/glotaran/builtin/io/csv/csv.py
+++ b/glotaran/builtin/io/csv/csv.py
@@ -13,6 +13,6 @@ class CsvProjectIo(ProjectIoInterface):
         df = pd.read_csv(file_name, skipinitialspace=True, na_values=["None", "none"])
         return ParameterGroup.from_dataframe(df, source=file_name)
 
-    def save_parameters(self, file_name: str, parameters: ParameterGroup):
+    def save_parameters(self, parameters: ParameterGroup, file_name: str):
         """Save a :class:`ParameterGroup` to a CSV file."""
         parameters.to_dataframe().to_csv(file_name, na_rep="None", index=False)

--- a/glotaran/builtin/io/folder/folder_plugin.py
+++ b/glotaran/builtin/io/folder/folder_plugin.py
@@ -24,7 +24,7 @@ class FolderProjectIo(ProjectIoInterface):
     a markdown summary output and the important data saved to files.
     """
 
-    def save_result(self, result_path: str, result: Result) -> list[str]:
+    def save_result(self, result: Result, result_path: str) -> list[str]:
         """Save the result to a given folder.
 
         Returns a list with paths of all saved items.
@@ -35,10 +35,10 @@ class FolderProjectIo(ProjectIoInterface):
 
         Parameters
         ----------
-        result_path : str
-            The path to the folder in which to save the result.
         result : Result
             Result instance to be saved.
+        result_path : str
+            The path to the folder in which to save the result.
 
         Returns
         -------

--- a/glotaran/builtin/io/netCDF/netCDF.py
+++ b/glotaran/builtin/io/netCDF/netCDF.py
@@ -15,8 +15,8 @@ class NetCDFDataIo(DataIoInterface):
 
     def save_dataset(
         self,
-        file_name: str,
         dataset: xr.Dataset,
+        file_name: str,
         *,
         saving_options: SavingOptions = SavingOptions(),
     ):

--- a/glotaran/builtin/io/yml/test/test_save_result.py
+++ b/glotaran/builtin/io/yml/test/test_save_result.py
@@ -19,7 +19,7 @@ def test_save_result_yml(
     """Check all files exist."""
 
     result_dir = Path(tmpdir / "testresult")
-    save_result(result_path=str(result_dir), format_name="yml", result=dummy_result)
+    save_result(result_path=result_dir, format_name="yml", result=dummy_result)
 
     assert (result_dir / "result.md").exists()
     assert (result_dir / "scheme.yml").exists()

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -177,7 +177,7 @@ class YmlProjectIo(ProjectIoInterface):
         dataset_format = options.data_format
         for label, dataset in result.data.items():
             dataset_path = os.path.join(result_path, f"{label}.{dataset_format}")
-            save_dataset(dataset_path, dataset, dataset_format, saving_options=options)
+            save_dataset(dataset, dataset_path, dataset_format, saving_options=options)
             result.data[label] = dataset_path
             result_scheme.data[label] = dataset_path
 

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -164,14 +164,14 @@ class YmlProjectIo(ProjectIoInterface):
         initial_parameters_path = os.path.join(
             result_path, f"initial_parameters.{parameters_format}"
         )
-        save_parameters(initial_parameters_path, result.initial_parameters, parameters_format)
+        save_parameters(result.initial_parameters, initial_parameters_path, parameters_format)
         result.initial_parameters = initial_parameters_path
         result_scheme.parameters = initial_parameters_path
 
         optimized_parameters_path = os.path.join(
             result_path, f"optimized_parameters.{parameters_format}"
         )
-        save_parameters(optimized_parameters_path, result.optimized_parameters, parameters_format)
+        save_parameters(result.optimized_parameters, optimized_parameters_path, parameters_format)
         result.optimized_parameters = optimized_parameters_path
 
         dataset_format = options.data_format

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -138,10 +138,10 @@ class YmlProjectIo(ProjectIoInterface):
             saving=saving,
         )
 
-    def save_scheme(self, file_name: str, scheme: Scheme):
+    def save_scheme(self, scheme: Scheme, file_name: str):
         _write_dict(file_name, dataclasses.asdict(scheme))
 
-    def save_result(self, result_path: str, result: Result):
+    def save_result(self, result: Result, result_path: str):
         options = result.scheme.saving
 
         if os.path.exists(result_path):
@@ -185,7 +185,7 @@ class YmlProjectIo(ProjectIoInterface):
         _write_dict(result_file_path, dataclasses.asdict(result))
         result_scheme.result_path = result_file_path
 
-        self.save_scheme(scheme_path, result_scheme)
+        self.save_scheme(scheme=result_scheme, file_name=scheme_path)
 
 
 def _write_dict(file_name: str, d: dict):

--- a/glotaran/io/__init__.py
+++ b/glotaran/io/__init__.py
@@ -15,6 +15,7 @@ from glotaran.plugin_system.data_io_registration import get_datasaver
 from glotaran.plugin_system.data_io_registration import load_dataset
 from glotaran.plugin_system.data_io_registration import register_data_io
 from glotaran.plugin_system.data_io_registration import save_dataset
+from glotaran.plugin_system.data_io_registration import set_data_plugin
 from glotaran.plugin_system.data_io_registration import show_data_io_method_help
 from glotaran.plugin_system.project_io_registration import get_project_io_method
 from glotaran.plugin_system.project_io_registration import load_model
@@ -27,6 +28,7 @@ from glotaran.plugin_system.project_io_registration import save_model
 from glotaran.plugin_system.project_io_registration import save_parameters
 from glotaran.plugin_system.project_io_registration import save_result
 from glotaran.plugin_system.project_io_registration import save_scheme
+from glotaran.plugin_system.project_io_registration import set_project_plugin
 from glotaran.plugin_system.project_io_registration import show_project_io_method_help
 
 

--- a/glotaran/io/interface.py
+++ b/glotaran/io/interface.py
@@ -63,17 +63,17 @@ class DataIoInterface:
 
     def save_dataset(
         self,
-        file_name: str,
         dataset: xr.Dataset | xr.DataArray,
+        file_name: str,
     ):
         """Save data from :xarraydoc:`Dataset` to a file (**NOT IMPLEMENTED**).
 
         Parameters
         ----------
-        file_name : str
-            File to write the data to.
         dataset : xr.Dataset
             Dataset to be saved to file.
+        file_name : str
+            File to write the data to.
 
 
         .. # noqa: DAR101

--- a/glotaran/io/interface.py
+++ b/glotaran/io/interface.py
@@ -114,15 +114,15 @@ class ProjectIoInterface:
         """
         raise NotImplementedError(f"Cannot read models with format {self.format!r}")
 
-    def save_model(self, file_name: str, model: Model):
+    def save_model(self, model: Model, file_name: str):
         """Save a Model instance to a spec file (**NOT IMPLEMENTED**).
 
         Parameters
         ----------
-        file_name : str
-            File to write the model specs to.
         model: Model
             Model instance to save to specs file.
+        file_name : str
+            File to write the model specs to.
 
 
         .. # noqa: DAR101
@@ -149,15 +149,15 @@ class ProjectIoInterface:
         """
         raise NotImplementedError(f"Cannot read parameters with format {self.format!r}")
 
-    def save_parameters(self, file_name: str, parameters: ParameterGroup):
+    def save_parameters(self, parameters: ParameterGroup, file_name: str):
         """Save a ParameterGroup instance to a spec file (**NOT IMPLEMENTED**).
 
         Parameters
         ----------
-        file_name : str
-            File to write the parameter specs to.
         parameters : ParameterGroup
             ParameterGroup instance to save to specs file.
+        file_name : str
+            File to write the parameter specs to.
 
 
         .. # noqa: DAR101
@@ -183,15 +183,15 @@ class ProjectIoInterface:
         """
         raise NotImplementedError(f"Cannot read scheme with format {self.format!r}")
 
-    def save_scheme(self, file_name: str, scheme: Scheme):
+    def save_scheme(self, scheme: Scheme, file_name: str):
         """Save a Scheme instance to a spec file (**NOT IMPLEMENTED**).
 
         Parameters
         ----------
-        file_name : str
-            File to write the scheme specs to.
         scheme : Scheme
             Scheme instance to save to specs file.
+        file_name : str
+            File to write the scheme specs to.
 
 
         .. # noqa: DAR101
@@ -218,15 +218,15 @@ class ProjectIoInterface:
         """
         raise NotImplementedError(f"Cannot read result with format {self.format!r}")
 
-    def save_result(self, result_path: str, result: Result):
+    def save_result(self, result: Result, result_path: str):
         """Save a Result instance to a spec file (**NOT IMPLEMENTED**).
 
         Parameters
         ----------
-        result_path : str
-            Path to write the result data to.
         result : Result
             Result instance to save to specs file.
+        result_path : str
+            Path to write the result data to.
 
 
         .. # noqa: DAR101

--- a/glotaran/model/__init__.py
+++ b/glotaran/model/__init__.py
@@ -13,3 +13,5 @@ from glotaran.model.weight import Weight
 from glotaran.plugin_system.model_registration import get_model
 from glotaran.plugin_system.model_registration import is_known_model
 from glotaran.plugin_system.model_registration import known_model_names
+from glotaran.plugin_system.model_registration import model_plugin_table
+from glotaran.plugin_system.model_registration import set_model_plugin

--- a/glotaran/parameter/test/test_parameter.py
+++ b/glotaran/parameter/test/test_parameter.py
@@ -460,7 +460,7 @@ def test_parameter_to_csv(tmpdir):
         format_name="yml_str",
     )
 
-    save_parameters(csv_path, params, "csv")
+    save_parameters(params, csv_path, "csv")
 
     with open(csv_path) as f:
         print(f.read())

--- a/glotaran/plugin_system/base_registry.py
+++ b/glotaran/plugin_system/base_registry.py
@@ -98,7 +98,7 @@ class PluginOverwriteWarning(UserWarning):
         old_plugin_name = full_plugin_name(old_plugin)
         new_plugin_name = full_plugin_name(new_plugin)
         message = (
-            f"The plugin {new_plugin_name!r} tried to overwrite the plugin {old_plugin_name!r}, "
+            f"The plugin '{new_plugin_name}' tried to overwrite the plugin '{old_plugin_name}', "
             f"with the access_name {old_key!r}. Use {new_key!r} to access {new_plugin_name!r}."
         )
         super().__init__(message, *args)
@@ -192,7 +192,9 @@ def add_plugin_to_registry(
     --------
     add_instantiated_plugin_to_register
     """
-    if plugin_register_key in plugin_registry:
+    if plugin_register_key in plugin_registry and full_plugin_name(
+        plugin_registry[plugin_register_key]
+    ) != full_plugin_name(plugin):
         old_key = plugin_register_key
         plugin_register_key = extend_conflicting_plugin_key(
             plugin_register_key, plugin, plugin_registry

--- a/glotaran/plugin_system/base_registry.py
+++ b/glotaran/plugin_system/base_registry.py
@@ -225,7 +225,8 @@ def add_plugin_to_registry(
                     old_plugin=plugin_registry[old_key],
                     new_plugin=plugin,
                     plugin_set_func_name=plugin_set_func_name,
-                )
+                ),
+                stacklevel=4,
             )
     plugin_registry[full_plugin_name(plugin)] = plugin
     plugin_registry[plugin_register_key] = plugin

--- a/glotaran/plugin_system/base_registry.py
+++ b/glotaran/plugin_system/base_registry.py
@@ -472,7 +472,7 @@ def methods_differ_from_baseclass_table(
         Function to get plugin from plugin registry.
     base_class : type[GenericPluginInstance]
         Base class the plugin inherited from.
-    plugin_names: bool
+    plugin_names : bool
         Whether or not to add the names of the plugins to the lists.
 
     Returns

--- a/glotaran/plugin_system/base_registry.py
+++ b/glotaran/plugin_system/base_registry.py
@@ -482,6 +482,7 @@ def methods_differ_from_baseclass_table(
     plugin_registry_keys: str | Sequence[str],
     get_plugin_function: Callable[[str], GenericPluginInstance | type[GenericPluginInstance]],
     base_class: type[GenericPluginInstance],
+    plugin_names: bool = False,
 ) -> list[list[str | bool]]:
     """Create table of which plugins methods differ from their baseclass.
 
@@ -505,6 +506,8 @@ def methods_differ_from_baseclass_table(
         Function to get plugin from plugin registry.
     base_class : type[GenericPluginInstance]
         Base class the plugin inherited from.
+    plugin_names: bool
+        Whether or not to add the names of the plugins to the lists.
 
     Returns
     -------
@@ -523,5 +526,8 @@ def methods_differ_from_baseclass_table(
     for plugin_registry_key in plugin_registry_keys:
         plugin = get_plugin_function(plugin_registry_key)
         differs_list = methods_differ_from_baseclass(method_names, plugin, base_class)
-        differs_table.append([f"`{plugin_registry_key}`", *differs_list])
+        row: list[str | bool] = [f"`{plugin_registry_key}`", *differs_list]
+        if plugin_names:
+            row.append(f"`{full_plugin_name(plugin)}`")
+        differs_table.append(row)
     return differs_table

--- a/glotaran/plugin_system/data_io_registration.py
+++ b/glotaran/plugin_system/data_io_registration.py
@@ -106,7 +106,7 @@ def known_data_formats(full_names: bool = False) -> list[str]:
 
     Parameters
     ----------
-    full_names: bool
+    full_names : bool
         Whether to display the full names the plugins are
         registered under as well.
 
@@ -135,7 +135,7 @@ def set_data_plugin(
     Parameters
     ----------
     format_name : str
-        Format to use the plugin for.
+        Format name used to refer to the plugin when used for ``save`` and ``load`` functions.
     full_plugin_name : str
         Full name (import path) of the registered plugin.
     """
@@ -180,7 +180,7 @@ def load_dataset(
         File containing the data.
     format_name : str
         Format the file is in, if not provided it will be inferred from the file extension.
-    **kwargs: Any
+    **kwargs : Any
         Additional keyword arguments passes to the ``read_dataset`` implementation
         of the data io plugin. If you aren't sure about those use ``get_dataloader``
         to get the implementation with the proper help and autocomplete.
@@ -207,7 +207,7 @@ def save_dataset(
 
     Parameters
     ----------
-    dataset: xr.Dataset|xr.DataArray
+    dataset : xr.Dataset | xr.DataArray
         Data to be written to file.
     file_name : str | PathLike[str]
         File to write the data to.
@@ -215,7 +215,7 @@ def save_dataset(
         Format the file should be in, if not provided it will be inferred from the file extension.
     allow_overwrite : bool
         Whether or not to allow overwriting existing files, by default False
-    **kwargs: Any
+    **kwargs : Any
         Additional keyword arguments passes to the ``write_dataset`` implementation
         of the data io plugin. If you aren't sure about those use ``get_datawriter``
         to get the implementation with the proper help and autocomplete.
@@ -293,9 +293,9 @@ def data_io_plugin_table(*, plugin_names: bool = False, full_names: bool = False
 
     Parameters
     ----------
-    plugin_names:bool
+    plugin_names : bool
         Whether or not to add the names of the plugins to the table.
-    full_names: bool
+    full_names : bool
         Whether to display the full names the plugins are
         registered under as well.
 

--- a/glotaran/plugin_system/data_io_registration.py
+++ b/glotaran/plugin_system/data_io_registration.py
@@ -75,6 +75,7 @@ def register_data_io(
             plugin_register_keys=format_names,
             plugin_class=cls,
             plugin_registry=__PluginRegistry.data_io,
+            plugin_set_func_name="set_data_plugin",
         )
         return cls
 

--- a/glotaran/plugin_system/data_io_registration.py
+++ b/glotaran/plugin_system/data_io_registration.py
@@ -126,8 +126,9 @@ def set_data_plugin(
     or overwrite the plugin used for a specific format.
 
     Effected functions:
-    * ``load_dataset``
-    * ``save_dataset``
+
+    - :func:`load_dataset`
+    - :func:`save_dataset`
 
     Parameters
     ----------
@@ -283,13 +284,15 @@ def show_data_io_method_help(
     show_method_help(io, method_name)
 
 
-def data_io_plugin_table(full_names: bool = False) -> str:
+def data_io_plugin_table(*, plugin_names: bool = False, full_names: bool = False) -> str:
     """Return registered data io plugins and which functions they support as markdown table.
 
     This is especially useful when you work with new plugins.
 
     Parameters
     ----------
+    plugin_names:bool
+        Whether or not to add the names of the plugins to the table.
     full_names: bool
         Whether to display the full names the plugins are
         registered under as well.
@@ -304,8 +307,12 @@ def data_io_plugin_table(full_names: bool = False) -> str:
         known_data_formats(full_names=full_names),
         get_data_io,
         DataIoInterface,
+        plugin_names=plugin_names,
     )
-    headers = tuple(map(lambda x: f"__{x}__", ["Plugin", *DATA_IO_METHODS]))
+    header_values = ["Format name", *DATA_IO_METHODS]
+    if plugin_names:
+        header_values.append("Plugin name")
+    headers = tuple(map(lambda x: f"__{x}__", header_values))
     return tabulate(
         bool_table_repr(table_data), tablefmt="github", headers=headers, stralign="center"
     )

--- a/glotaran/plugin_system/data_io_registration.py
+++ b/glotaran/plugin_system/data_io_registration.py
@@ -20,6 +20,7 @@ from glotaran.plugin_system.base_registry import get_plugin_from_registry
 from glotaran.plugin_system.base_registry import is_registered_plugin
 from glotaran.plugin_system.base_registry import methods_differ_from_baseclass_table
 from glotaran.plugin_system.base_registry import registered_plugins
+from glotaran.plugin_system.base_registry import set_plugin
 from glotaran.plugin_system.base_registry import show_method_help
 from glotaran.plugin_system.io_plugin_utils import bool_table_repr
 from glotaran.plugin_system.io_plugin_utils import inferr_file_format
@@ -98,15 +99,48 @@ def is_known_data_format(format_name: str) -> bool:
     )
 
 
-def known_data_formats() -> list[str]:
+def known_data_formats(full_names: bool = False) -> list[str]:
     """Names of the registered data io plugins.
+
+    Parameters
+    ----------
+    full_names: bool
+        Whether to display the full names the plugins are
+        registered under as well.
 
     Returns
     -------
     list[str]
         List of registered data io plugins.
     """
-    return registered_plugins(plugin_registry=__PluginRegistry.data_io)
+    return registered_plugins(plugin_registry=__PluginRegistry.data_io, full_names=full_names)
+
+
+def set_data_plugin(
+    format_name: str,
+    full_plugin_name: str,
+) -> None:
+    """Set the plugin used for a specific data format.
+
+    This function is useful when you want to resolve conflicts of installed plugins
+    or overwrite the plugin used for a specific format.
+
+    Effected functions:
+    * ``load_dataset``
+    * ``save_dataset``
+
+    Parameters
+    ----------
+    format_name : str
+        Format to use the plugin for.
+    full_plugin_name : str
+        Full name (import path) of the registered plugin.
+    """
+    set_plugin(
+        plugin_register_key=format_name,
+        full_plugin_name=full_plugin_name,
+        plugin_registry=__PluginRegistry.data_io,
+    )
 
 
 def get_data_io(format_name: str) -> DataIoInterface:
@@ -249,10 +283,16 @@ def show_data_io_method_help(
     show_method_help(io, method_name)
 
 
-def data_io_plugin_table() -> str:
+def data_io_plugin_table(full_names: bool = False) -> str:
     """Return registered data io plugins and which functions they support as markdown table.
 
     This is especially useful when you work with new plugins.
+
+    Parameters
+    ----------
+    full_names: bool
+        Whether to display the full names the plugins are
+        registered under as well.
 
     Returns
     -------
@@ -260,7 +300,10 @@ def data_io_plugin_table() -> str:
         Markdown table of data io plugins.
     """
     table_data = methods_differ_from_baseclass_table(
-        DATA_IO_METHODS, known_data_formats(), get_data_io, DataIoInterface
+        DATA_IO_METHODS,
+        known_data_formats(full_names=full_names),
+        get_data_io,
+        DataIoInterface,
     )
     headers = tuple(map(lambda x: f"__{x}__", ["Plugin", *DATA_IO_METHODS]))
     return tabulate(

--- a/glotaran/plugin_system/data_io_registration.py
+++ b/glotaran/plugin_system/data_io_registration.py
@@ -159,8 +159,8 @@ def load_dataset(
 
 @not_implemented_to_value_error
 def save_dataset(
-    file_name: str,
     dataset: xr.Dataset | xr.DataArray,
+    file_name: str,
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -170,12 +170,12 @@ def save_dataset(
 
     Parameters
     ----------
+    dataset: xr.Dataset|xr.DataArray
+        Data to be written to file.
     file_name : str
         File to write the data to.
     format_name : str
         Format the file should be in, if not provided it will be inferred from the file extension.
-    dataset: xr.Dataset|xr.DataArray
-        Data to be written to file.
     allow_overwrite : bool
         Whether or not to allow overwriting existing files, by default False
     **kwargs: Any

--- a/glotaran/plugin_system/data_io_registration.py
+++ b/glotaran/plugin_system/data_io_registration.py
@@ -28,6 +28,7 @@ from glotaran.plugin_system.io_plugin_utils import not_implemented_to_value_erro
 from glotaran.plugin_system.io_plugin_utils import protect_from_overwrite
 
 if TYPE_CHECKING:
+    from os import PathLike
     from typing import Any
     from typing import Callable
     from typing import Literal
@@ -169,13 +170,13 @@ def get_data_io(format_name: str) -> DataIoInterface:
 
 @not_implemented_to_value_error
 def load_dataset(
-    file_name: str, format_name: str = None, **kwargs: Any
+    file_name: str | PathLike[str], format_name: str = None, **kwargs: Any
 ) -> xr.Dataset | xr.DataArray:
     """Read data from a file to :xarraydoc:`Dataset` or :xarraydoc:`DataArray`.
 
     Parameters
     ----------
-    file_name : str
+    file_name : str | PathLike[str]
         File containing the data.
     format_name : str
         Format the file is in, if not provided it will be inferred from the file extension.
@@ -190,13 +191,13 @@ def load_dataset(
         Data loaded from the file.
     """
     io = get_data_io(format_name or inferr_file_format(file_name))
-    return io.load_dataset(file_name, **kwargs)  # type: ignore[call-arg]
+    return io.load_dataset(str(file_name), **kwargs)  # type: ignore[call-arg]
 
 
 @not_implemented_to_value_error
 def save_dataset(
     dataset: xr.Dataset | xr.DataArray,
-    file_name: str,
+    file_name: str | PathLike[str],
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -208,7 +209,7 @@ def save_dataset(
     ----------
     dataset: xr.Dataset|xr.DataArray
         Data to be written to file.
-    file_name : str
+    file_name : str | PathLike[str]
         File to write the data to.
     format_name : str
         Format the file should be in, if not provided it will be inferred from the file extension.
@@ -222,7 +223,7 @@ def save_dataset(
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_data_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
     io.save_dataset(  # type: ignore[call-arg]
-        file_name=file_name,
+        file_name=str(file_name),
         dataset=dataset,
         **kwargs,
     )

--- a/glotaran/plugin_system/model_registration.py
+++ b/glotaran/plugin_system/model_registration.py
@@ -28,7 +28,10 @@ def register_model(model_type: str, model: type[Model]) -> None:
         model class to be registered.
     """
     add_plugin_to_registry(
-        plugin_register_key=model_type, plugin=model, plugin_registry=__PluginRegistry.model
+        plugin_register_key=model_type,
+        plugin=model,
+        plugin_registry=__PluginRegistry.model,
+        plugin_set_func_name="set_model_plugin",
     )
 
 

--- a/glotaran/plugin_system/model_registration.py
+++ b/glotaran/plugin_system/model_registration.py
@@ -81,7 +81,7 @@ def known_model_names(full_names: bool = False) -> list[str]:
 
     Parameters
     ----------
-    full_names: bool
+    full_names : bool
         Whether to display the full names the plugins are
         registered under as well.
 
@@ -125,9 +125,9 @@ def model_plugin_table(*, plugin_names: bool = False, full_names: bool = False) 
 
     Parameters
     ----------
-    plugin_names:bool
+    plugin_names : bool
         Whether or not to add the names of the plugins to the table.
-    full_names: bool
+    full_names : bool
         Whether to display the full names the plugins are
         registered under as well.
 

--- a/glotaran/plugin_system/model_registration.py
+++ b/glotaran/plugin_system/model_registration.py
@@ -8,6 +8,7 @@ from glotaran.plugin_system.base_registry import add_plugin_to_registry
 from glotaran.plugin_system.base_registry import get_plugin_from_registry
 from glotaran.plugin_system.base_registry import is_registered_plugin
 from glotaran.plugin_system.base_registry import registered_plugins
+from glotaran.plugin_system.base_registry import set_plugin
 
 if TYPE_CHECKING:
     from glotaran.model import Model
@@ -63,17 +64,48 @@ def get_model(model_type: str) -> type[Model]:
         plugin_register_key=model_type,
         plugin_registry=__PluginRegistry.model,
         not_found_error_message=(
-            f"Unknown model type {model_type!r}. Known model types are: {known_model_names()}"
+            f"Unknown model type {model_type!r}. "
+            f"Known model types are: {known_model_names(full_names=True)}"
         ),
     )
 
 
-def known_model_names() -> list[str]:
+def known_model_names(full_names: bool = False) -> list[str]:
     """Names of the registered models.
+
+    Parameters
+    ----------
+    full_names: bool
+        Whether to display the full names the plugins are
+        registered under as well.
 
     Returns
     -------
     list[str]
         List of registered models.
     """
-    return registered_plugins(__PluginRegistry.model)
+    return registered_plugins(__PluginRegistry.model, full_names=full_names)
+
+
+def set_model_plugin(model_name: str, full_plugin_name: str) -> None:
+    """Set the plugin used for a specific model name.
+
+    This function is useful when you want to resolve conflicts of installed plugins
+    or overwrite the plugin used for a specific model name.
+
+    Effected functions:
+    * ``optimize``
+
+    Parameters
+    ----------
+    model_name : str
+        Name of the model to use the plugin for.
+    full_plugin_name : str
+        Full name (import path) of the registered plugin.
+    """
+    set_plugin(
+        plugin_register_key=model_name,
+        full_plugin_name=full_plugin_name,
+        plugin_registry=__PluginRegistry.model,
+        plugin_register_key_name="model_name",
+    )

--- a/glotaran/plugin_system/model_registration.py
+++ b/glotaran/plugin_system/model_registration.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from tabulate import tabulate
+
 from glotaran.plugin_system.base_registry import __PluginRegistry
 from glotaran.plugin_system.base_registry import add_plugin_to_registry
+from glotaran.plugin_system.base_registry import full_plugin_name
 from glotaran.plugin_system.base_registry import get_plugin_from_registry
 from glotaran.plugin_system.base_registry import is_registered_plugin
 from glotaran.plugin_system.base_registry import registered_plugins
@@ -94,7 +97,8 @@ def set_model_plugin(model_name: str, full_plugin_name: str) -> None:
     or overwrite the plugin used for a specific model name.
 
     Effected functions:
-    * ``optimize``
+
+    - :func:`optimize`
 
     Parameters
     ----------
@@ -109,3 +113,34 @@ def set_model_plugin(model_name: str, full_plugin_name: str) -> None:
         plugin_registry=__PluginRegistry.model,
         plugin_register_key_name="model_name",
     )
+
+
+def model_plugin_table(*, plugin_names: bool = False, full_names: bool = False) -> str:
+    """Return registered model plugins as markdown table.
+
+    This is especially useful when you work with new plugins.
+
+    Parameters
+    ----------
+    plugin_names:bool
+        Whether or not to add the names of the plugins to the table.
+    full_names: bool
+        Whether to display the full names the plugins are
+        registered under as well.
+
+    Returns
+    -------
+    str
+        Markdown table of modelnames.
+    """
+    table_data = []
+    model_names = known_model_names(full_names=full_names)
+    header_values = ["Model name"]
+    if plugin_names:
+        header_values.append("Plugin name")
+        for model_name in model_names:
+            table_data.append([f"`{model_name}`", f"`{full_plugin_name(get_model(model_name))}`"])
+    else:
+        table_data = [[f"`{model_name}`"] for model_name in model_names]
+    headers = tuple(map(lambda x: f"__{x}__", header_values))
+    return tabulate(table_data, tablefmt="github", headers=headers, stralign="center")

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -21,6 +21,7 @@ from glotaran.plugin_system.base_registry import get_plugin_from_registry
 from glotaran.plugin_system.base_registry import is_registered_plugin
 from glotaran.plugin_system.base_registry import methods_differ_from_baseclass_table
 from glotaran.plugin_system.base_registry import registered_plugins
+from glotaran.plugin_system.base_registry import set_plugin
 from glotaran.plugin_system.base_registry import show_method_help
 from glotaran.plugin_system.io_plugin_utils import bool_table_repr
 from glotaran.plugin_system.io_plugin_utils import inferr_file_format
@@ -120,15 +121,54 @@ def is_known_project_format(format_name: str) -> bool:
     )
 
 
-def known_project_formats() -> list[str]:
+def known_project_formats(full_names: bool = False) -> list[str]:
     """Names of the registered project io plugins.
+
+    Parameters
+    ----------
+    full_names: bool
+        Whether to display the full names the plugins are
+        registered under as well.
 
     Returns
     -------
     list[str]
         List of registered project io plugins.
     """
-    return registered_plugins(plugin_registry=__PluginRegistry.project_io)
+    return registered_plugins(plugin_registry=__PluginRegistry.project_io, full_names=full_names)
+
+
+def set_project_plugin(
+    format_name: str,
+    full_plugin_name: str,
+) -> None:
+    """Set the plugin used for a specific project format.
+
+    This function is useful when you want to resolve conflicts of installed plugins
+    or overwrite the plugin used for a specific format.
+
+    Effected functions:
+    * ``load_model``
+    * ``save_model``
+    * ``load_parameters``
+    * ``save_parameters``
+    * ``load_scheme``
+    * ``save_scheme``
+    * ``load_result``
+    * ``save_result``
+
+    Parameters
+    ----------
+    format_name : str
+        Format to use the plugin for.
+    full_plugin_name : str
+        Full name (import path) of the registered plugin.
+    """
+    set_plugin(
+        plugin_register_key=format_name,
+        full_plugin_name=full_plugin_name,
+        plugin_registry=__PluginRegistry.project_io,
+    )
 
 
 def get_project_io(format_name: str) -> ProjectIoInterface:
@@ -423,10 +463,16 @@ def show_project_io_method_help(format_name: str, method_name: ProjectIoMethods)
     show_method_help(io, method_name)
 
 
-def project_io_plugin_table() -> str:
+def project_io_plugin_table(full_names: bool = False) -> str:
     """Return registered project io plugins and which functions they support as markdown table.
 
     This is especially useful when you work with new plugins.
+
+    Parameters
+    ----------
+    full_names: bool
+        Whether to display the full names the plugins are
+        registered under as well.
 
     Returns
     -------
@@ -434,7 +480,10 @@ def project_io_plugin_table() -> str:
         Markdown table of project io plugins.
     """
     table_data = methods_differ_from_baseclass_table(
-        PROJECT_IO_METHODS, known_project_formats(), get_project_io, ProjectIoInterface
+        PROJECT_IO_METHODS,
+        known_project_formats(full_names=full_names),
+        get_project_io,
+        ProjectIoInterface,
     )
     headers = tuple(map(lambda x: f"__{x}__", ["Plugin", *PROJECT_IO_METHODS]))
     return tabulate(

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -148,14 +148,15 @@ def set_project_plugin(
     or overwrite the plugin used for a specific format.
 
     Effected functions:
-    * ``load_model``
-    * ``save_model``
-    * ``load_parameters``
-    * ``save_parameters``
-    * ``load_scheme``
-    * ``save_scheme``
-    * ``load_result``
-    * ``save_result``
+
+    - :func:`load_model`
+    - :func:`save_model`
+    - :func:`load_parameters`
+    - :func:`save_parameters`
+    - :func:`load_scheme`
+    - :func:`save_scheme`
+    - :func:`load_result`
+    - :func:`save_result`
 
     Parameters
     ----------
@@ -463,13 +464,15 @@ def show_project_io_method_help(format_name: str, method_name: ProjectIoMethods)
     show_method_help(io, method_name)
 
 
-def project_io_plugin_table(full_names: bool = False) -> str:
+def project_io_plugin_table(*, plugin_names: bool = False, full_names: bool = False) -> str:
     """Return registered project io plugins and which functions they support as markdown table.
 
     This is especially useful when you work with new plugins.
 
     Parameters
     ----------
+    plugin_names:bool
+        Whether or not to add the names of the plugins to the table.
     full_names: bool
         Whether to display the full names the plugins are
         registered under as well.
@@ -484,8 +487,12 @@ def project_io_plugin_table(full_names: bool = False) -> str:
         known_project_formats(full_names=full_names),
         get_project_io,
         ProjectIoInterface,
+        plugin_names=plugin_names,
     )
-    headers = tuple(map(lambda x: f"__{x}__", ["Plugin", *PROJECT_IO_METHODS]))
+    header_values = ["Format name", *PROJECT_IO_METHODS]
+    if plugin_names:
+        header_values.append("Plugin name")
+    headers = tuple(map(lambda x: f"__{x}__", header_values))
     return tabulate(
         bool_table_repr(table_data), tablefmt="github", headers=headers, stralign="center"
     )

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -29,6 +29,7 @@ from glotaran.plugin_system.io_plugin_utils import not_implemented_to_value_erro
 from glotaran.plugin_system.io_plugin_utils import protect_from_overwrite
 
 if TYPE_CHECKING:
+    from os import PathLike
     from typing import Any
     from typing import Callable
     from typing import Literal
@@ -197,12 +198,12 @@ def get_project_io(format_name: str) -> ProjectIoInterface:
 
 
 @not_implemented_to_value_error
-def load_model(file_name: str, format_name: str = None, **kwargs: Any) -> Model:
+def load_model(file_name: str | PathLike[str], format_name: str = None, **kwargs: Any) -> Model:
     """Create a Model instance from the specs defined in a file.
 
     Parameters
     ----------
-    file_name : str
+    file_name : str | PathLike[str]
         File containing the model specs.
     format_name : str
         Format the file is in, if not provided it will be inferred from the file extension.
@@ -216,13 +217,13 @@ def load_model(file_name: str, format_name: str = None, **kwargs: Any) -> Model:
         Model instance created from the file.
     """
     io = get_project_io(format_name or inferr_file_format(file_name))
-    return io.load_model(file_name, **kwargs)  # type: ignore[call-arg]
+    return io.load_model(str(file_name), **kwargs)  # type: ignore[call-arg]
 
 
 @not_implemented_to_value_error
 def save_model(
     model: Model,
-    file_name: str,
+    file_name: str | PathLike[str],
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -234,7 +235,7 @@ def save_model(
     ----------
     model: Model
         :class:`Model` instance to save to specs file.
-    file_name : str
+    file_name : str | PathLike[str]
         File to write the model specs to.
     format_name : str
         Format the file should be in, if not provided it will be inferred from the file extension.
@@ -246,16 +247,18 @@ def save_model(
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
-    io.save_model(file_name=file_name, model=model, **kwargs)  # type: ignore[call-arg]
+    io.save_model(file_name=str(file_name), model=model, **kwargs)  # type: ignore[call-arg]
 
 
 @not_implemented_to_value_error
-def load_parameters(file_name: str, format_name: str = None, **kwargs) -> ParameterGroup:
+def load_parameters(
+    file_name: str | PathLike[str], format_name: str = None, **kwargs
+) -> ParameterGroup:
     """Create a :class:`ParameterGroup` instance from the specs defined in a file.
 
     Parameters
     ----------
-    file_name : str
+    file_name : str | PathLike[str]
         File containing the parameter specs.
     format_name : str
         Format the file is in, if not provided it will be inferred from the file extension.
@@ -269,13 +272,13 @@ def load_parameters(file_name: str, format_name: str = None, **kwargs) -> Parame
         :class:`ParameterGroup` instance created from the file.
     """
     io = get_project_io(format_name or inferr_file_format(file_name))
-    return io.load_parameters(file_name, **kwargs)  # type: ignore[call-arg]
+    return io.load_parameters(str(file_name), **kwargs)  # type: ignore[call-arg]
 
 
 @not_implemented_to_value_error
 def save_parameters(
     parameters: ParameterGroup,
-    file_name: str,
+    file_name: str | PathLike[str],
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -287,7 +290,7 @@ def save_parameters(
     ----------
     parameters : ParameterGroup
         :class:`ParameterGroup` instance to save to specs file.
-    file_name : str
+    file_name : str | PathLike[str]
         File to write the parameter specs to.
     format_name : str
         Format the file should be in, if not provided it will be inferred from the file extension.
@@ -300,19 +303,19 @@ def save_parameters(
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
     io.save_parameters(  # type: ignore[call-arg]
-        file_name=file_name,
+        file_name=str(file_name),
         parameters=parameters,
         **kwargs,
     )
 
 
 @not_implemented_to_value_error
-def load_scheme(file_name: str, format_name: str = None, **kwargs: Any) -> Scheme:
+def load_scheme(file_name: str | PathLike[str], format_name: str = None, **kwargs: Any) -> Scheme:
     """Create a :class:`Scheme` instance from the specs defined in a file.
 
     Parameters
     ----------
-    file_name : str
+    file_name : str | PathLike[str]
         File containing the parameter specs.
     format_name : str
         Format the file is in, if not provided it will be inferred from the file extension.
@@ -326,13 +329,13 @@ def load_scheme(file_name: str, format_name: str = None, **kwargs: Any) -> Schem
         :class:`Scheme` instance created from the file.
     """
     io = get_project_io(format_name or inferr_file_format(file_name))
-    return io.load_scheme(file_name, **kwargs)  # type: ignore[call-arg]
+    return io.load_scheme(str(file_name), **kwargs)  # type: ignore[call-arg]
 
 
 @not_implemented_to_value_error
 def save_scheme(
     scheme: Scheme,
-    file_name: str,
+    file_name: str | PathLike[str],
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -344,7 +347,7 @@ def save_scheme(
     ----------
     scheme : Scheme
         :class:`Scheme` instance to save to specs file.
-    file_name : str
+    file_name : str | PathLike[str]
         File to write the scheme specs to.
     format_name : str
         Format the file should be in, if not provided it will be inferred from the file extension.
@@ -356,16 +359,18 @@ def save_scheme(
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
-    io.save_scheme(file_name=file_name, scheme=scheme, **kwargs)  # type: ignore[call-arg]
+    io.save_scheme(file_name=str(file_name), scheme=scheme, **kwargs)  # type: ignore[call-arg]
 
 
 @not_implemented_to_value_error
-def load_result(result_path: str, format_name: str = None, **kwargs: Any) -> Result:
+def load_result(
+    result_path: str | PathLike[str], format_name: str = None, **kwargs: Any
+) -> Result:
     """Create a :class:`Result` instance from the specs defined in a file.
 
     Parameters
     ----------
-    result_path : str
+    result_path : str | PathLike[str]
         Path containing the result data.
     format_name : str
         Format the result is in, if not provided and it is a file
@@ -380,13 +385,13 @@ def load_result(result_path: str, format_name: str = None, **kwargs: Any) -> Res
         :class:`Result` instance created from the saved format.
     """
     io = get_project_io(format_name or inferr_file_format(result_path))
-    return io.load_result(result_path, **kwargs)  # type: ignore[call-arg]
+    return io.load_result(str(result_path), **kwargs)  # type: ignore[call-arg]
 
 
 @not_implemented_to_value_error
 def save_result(
     result: Result,
-    result_path: str,
+    result_path: str | PathLike[str],
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -398,7 +403,7 @@ def save_result(
     ----------
     result : Result
         :class:`Result` instance to write.
-    result_path : str
+    result_path : str | PathLike[str]
         Path to write the result data to.
     format_name : str
         Format the result should be saved in, if not provided and it is a file
@@ -414,7 +419,7 @@ def save_result(
         format_name or inferr_file_format(result_path, needs_to_exist=False, allow_folder=True)
     )
     io.save_result(  # type: ignore[call-arg]
-        result_path=result_path,
+        result_path=str(result_path),
         result=result,
         **kwargs,
     )

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -179,8 +179,8 @@ def load_model(file_name: str, format_name: str = None, **kwargs: Any) -> Model:
 
 @not_implemented_to_value_error
 def save_model(
-    file_name: str,
     model: Model,
+    file_name: str,
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -190,10 +190,10 @@ def save_model(
 
     Parameters
     ----------
-    file_name : str
-        File to write the model specs to.
     model: Model
         :class:`Model` instance to save to specs file.
+    file_name : str
+        File to write the model specs to.
     format_name : str
         Format the file should be in, if not provided it will be inferred from the file extension.
     allow_overwrite : bool
@@ -232,8 +232,8 @@ def load_parameters(file_name: str, format_name: str = None, **kwargs) -> Parame
 
 @not_implemented_to_value_error
 def save_parameters(
-    file_name: str,
     parameters: ParameterGroup,
+    file_name: str,
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -243,10 +243,10 @@ def save_parameters(
 
     Parameters
     ----------
-    file_name : str
-        File to write the parameter specs to.
     parameters : ParameterGroup
         :class:`ParameterGroup` instance to save to specs file.
+    file_name : str
+        File to write the parameter specs to.
     format_name : str
         Format the file should be in, if not provided it will be inferred from the file extension.
     allow_overwrite : bool
@@ -289,8 +289,8 @@ def load_scheme(file_name: str, format_name: str = None, **kwargs: Any) -> Schem
 
 @not_implemented_to_value_error
 def save_scheme(
-    file_name: str,
     scheme: Scheme,
+    file_name: str,
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -300,10 +300,10 @@ def save_scheme(
 
     Parameters
     ----------
-    file_name : str
-        File to write the scheme specs to.
     scheme : Scheme
         :class:`Scheme` instance to save to specs file.
+    file_name : str
+        File to write the scheme specs to.
     format_name : str
         Format the file should be in, if not provided it will be inferred from the file extension.
     allow_overwrite : bool
@@ -343,8 +343,8 @@ def load_result(result_path: str, format_name: str = None, **kwargs: Any) -> Res
 
 @not_implemented_to_value_error
 def save_result(
-    result_path: str,
     result: Result,
+    result_path: str,
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -354,10 +354,10 @@ def save_result(
 
     Parameters
     ----------
-    result_path : str
-        Path to write the result data to.
     result : Result
         :class:`Result` instance to write.
+    result_path : str
+        Path to write the result data to.
     format_name : str
         Format the result should be saved in, if not provided and it is a file
         it will be inferred from the file extension.

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -128,7 +128,7 @@ def known_project_formats(full_names: bool = False) -> list[str]:
 
     Parameters
     ----------
-    full_names: bool
+    full_names : bool
         Whether to display the full names the plugins are
         registered under as well.
 
@@ -163,7 +163,7 @@ def set_project_plugin(
     Parameters
     ----------
     format_name : str
-        Format to use the plugin for.
+        Format name used to refer to the plugin when used for ``save`` and ``load`` functions.
     full_plugin_name : str
         Full name (import path) of the registered plugin.
     """
@@ -241,7 +241,7 @@ def save_model(
         Format the file should be in, if not provided it will be inferred from the file extension.
     allow_overwrite : bool
         Whether or not to allow overwriting existing files, by default False
-    **kwargs: Any
+    **kwargs : Any
         Additional keyword arguments passes to the ``save_model`` implementation
         of the project io plugin.
     """
@@ -296,7 +296,7 @@ def save_parameters(
         Format the file should be in, if not provided it will be inferred from the file extension.
     allow_overwrite : bool
         Whether or not to allow overwriting existing files, by default False
-    **kwargs: Any
+    **kwargs : Any
         Additional keyword arguments passes to the ``save_parameters`` implementation
         of the project io plugin.
     """
@@ -319,7 +319,7 @@ def load_scheme(file_name: str | PathLike[str], format_name: str = None, **kwarg
         File containing the parameter specs.
     format_name : str
         Format the file is in, if not provided it will be inferred from the file extension.
-    **kwargs: Any
+    **kwargs : Any
         Additional keyword arguments passes to the ``load_scheme`` implementation
         of the project io plugin.
 
@@ -353,7 +353,7 @@ def save_scheme(
         Format the file should be in, if not provided it will be inferred from the file extension.
     allow_overwrite : bool
         Whether or not to allow overwriting existing files, by default False
-    **kwargs: Any
+    **kwargs : Any
         Additional keyword arguments passes to the ``save_scheme`` implementation
         of the project io plugin.
     """
@@ -375,7 +375,7 @@ def load_result(
     format_name : str
         Format the result is in, if not provided and it is a file
         it will be inferred from the file extension.
-    **kwargs: Any
+    **kwargs : Any
         Additional keyword arguments passes to the ``load_result`` implementation
         of the project io plugin.
 
@@ -410,7 +410,7 @@ def save_result(
         it will be inferred from the file extension.
     allow_overwrite : bool
         Whether or not to allow overwriting existing files, by default False
-    **kwargs: Any
+    **kwargs : Any
         Additional keyword arguments passes to the ``save_result`` implementation
         of the project io plugin.
     """
@@ -477,9 +477,9 @@ def project_io_plugin_table(*, plugin_names: bool = False, full_names: bool = Fa
 
     Parameters
     ----------
-    plugin_names:bool
+    plugin_names : bool
         Whether or not to add the names of the plugins to the table.
-    full_names: bool
+    full_names : bool
         Whether to display the full names the plugins are
         registered under as well.
 

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -97,6 +97,7 @@ def register_project_io(
             plugin_register_keys=format_names,
             plugin_class=cls,
             plugin_registry=__PluginRegistry.project_io,
+            plugin_set_func_name="set_project_plugin",
         )
         return cls
 

--- a/glotaran/plugin_system/test/test_base_registry.py
+++ b/glotaran/plugin_system/test/test_base_registry.py
@@ -84,14 +84,6 @@ def test_full_plugin_name(plugin: object | type[object], expected: str):
 def test_PluginOverwriteWarning():
     """Ignore the values this is just for testing, even if it doesn't make sense."""
 
-    expected = (
-        "The plugin 'glotaran.builtin.io.sdt.sdt_file_reader.SdtDataIo' tried to "
-        "overwrite the plugin 'glotaran.builtin.io.yml.yml.YmlProjectIo', "
-        "with the access_name 'yml'. "
-        "Use set_plugin('yml', 'glotaran.builtin.io.sdt.sdt_file_reader.SdtDataIo') "
-        "to use 'glotaran.builtin.io.sdt.sdt_file_reader.SdtDataIo' instead."
-    )
-
     with pytest.warns(PluginOverwriteWarning) as record:
         warn(
             PluginOverwriteWarning(
@@ -103,6 +95,14 @@ def test_PluginOverwriteWarning():
         )
 
         assert len(record) == 1
+        expected = (
+            "The plugin 'glotaran.builtin.io.sdt.sdt_file_reader.SdtDataIo' tried to "
+            "overwrite the plugin 'glotaran.builtin.io.yml.yml.YmlProjectIo', "
+            "with the access_name 'yml'. "
+            "Use set_plugin('yml', 'glotaran.builtin.io.sdt.sdt_file_reader.SdtDataIo') "
+            "to use 'glotaran.builtin.io.sdt.sdt_file_reader.SdtDataIo' instead."
+        )
+
         assert record[0].message.args[0] == expected  # type: ignore
 
 
@@ -368,9 +368,7 @@ def test_methods_differ_from_baseclass_table(
     def get_plugin_function(plugin_registry_key: str):
         if plugin_registry_key == "base":
             return MockPlugin
-        elif plugin_registry_key == "sub_class":
-            return MockPluginSubclass
-        elif plugin_registry_key == "sub_class_inst":
+        elif plugin_registry_key in ["sub_class", "sub_class_inst"]:
             return MockPluginSubclass
 
     result = methods_differ_from_baseclass_table(

--- a/glotaran/plugin_system/test/test_base_registry.py
+++ b/glotaran/plugin_system/test/test_base_registry.py
@@ -395,3 +395,19 @@ def test_methods_differ_from_baseclass_table(
     )
 
     assert result == expected
+
+
+def test_methods_differ_from_baseclass_table_plugin_names():
+    """Show plugin name"""
+
+    def get_plugin_function(plugin_registry_key: str):
+        if plugin_registry_key == "base":
+            return MockPlugin
+        elif plugin_registry_key == "sub_class":
+            return MockPluginSubclass
+
+    result = methods_differ_from_baseclass_table(
+        "some_method", "base", get_plugin_function, MockPlugin, plugin_names=True
+    )
+
+    assert result == [["`base`", False, "`test_base_registry.MockPlugin`"]]

--- a/glotaran/plugin_system/test/test_base_registry.py
+++ b/glotaran/plugin_system/test/test_base_registry.py
@@ -149,14 +149,24 @@ def test_add_plugin_to_register(
 
 
 def test_add_plugin_to_register_existing_plugin():
-    """Try plugin_overwrite"""
+    """Warn if different plugin overwrites existing."""
+
+    plugin_registy = copy(mock_registry_data_io)
+    with pytest.warns(PluginOverwriteWarning, match="SdtDataIo.+sdt.+sdt_gta") as record:
+        add_plugin_to_registry("sdt", YmlProjectIo("sdt"), plugin_registy)  # type:ignore
+        assert len(record) == 1
+    assert "sdt_gta" in plugin_registy
+    assert plugin_registy["sdt_gta"].format == "sdt"
+
+
+@pytest.mark.xfail(strict=True, reason="Should not warn")
+def test_add_plugin_to_register_existing_plugin_self():
+    """Don't warn if plugin overwrites itself."""
 
     plugin_registy = copy(mock_registry_data_io)
     with pytest.warns(PluginOverwriteWarning, match="SdtDataIo.+sdt.+sdt_gta") as record:
         add_plugin_to_registry("sdt", SdtDataIo("sdt"), plugin_registy)
-        assert len(record) == 1
-    assert "sdt_gta" in plugin_registy
-    assert plugin_registy["sdt_gta"].format == "sdt"
+        assert len(record) == 0
 
 
 @pytest.mark.parametrize(

--- a/glotaran/plugin_system/test/test_data_io_registration.py
+++ b/glotaran/plugin_system/test/test_data_io_registration.py
@@ -160,7 +160,7 @@ def test_protect_from_overwrite_write_functions(tmp_path: Path):
     file_path.touch()
 
     with pytest.raises(FileExistsError, match="The file .+? already exists"):
-        save_dataset(str(file_path), "")  # type:ignore
+        save_dataset("", str(file_path))  # type:ignore
 
 
 @pytest.mark.usefixtures("mocked_registry")
@@ -170,8 +170,8 @@ def test_write_dataset(tmp_path: Path):
 
     result: dict[str, Any] = {}
     save_dataset(
-        str(file_path),
         "no_dataset",  # type:ignore
+        str(file_path),
         result_container=result,
         dummy_arg="baz",
     )

--- a/glotaran/plugin_system/test/test_data_io_registration.py
+++ b/glotaran/plugin_system/test/test_data_io_registration.py
@@ -66,7 +66,7 @@ def mocked_registry(monkeypatch: MonkeyPatch):
         {
             "foo": DataIoInterface("foo"),
             "mock": MockDataIO("bar"),
-            "test_data_io_registration.MockDataIO": MockDataIO("bar"),
+            "test_data_io_registration.MockDataIO_bar": MockDataIO("bar"),
         },
     )
 
@@ -88,7 +88,9 @@ def test_register_data_io():
         assert isinstance(__PluginRegistry.data_io[format_name], plugin_class)
         assert __PluginRegistry.data_io[format_name].format == format_name
         assert isinstance(
-            __PluginRegistry.data_io[f"test_data_io_registration.{plugin_class.__name__}"],
+            __PluginRegistry.data_io[
+                f"test_data_io_registration.{plugin_class.__name__}_{format_name}"
+            ],
             plugin_class,
         )
 
@@ -124,11 +126,11 @@ def test_known_data_format_actual_register():
     assert is_known_data_format("sdt")
     assert is_known_data_format("ascii")
     assert is_known_data_format("nc")
-    assert is_known_data_format("glotaran.builtin.io.sdt.sdt_file_reader.SdtDataIo")
+    assert is_known_data_format("glotaran.builtin.io.sdt.sdt_file_reader.SdtDataIo_sdt")
     assert is_known_data_format(
-        "glotaran.builtin.io.ascii.wavelength_time_explicit_file.AsciiDataIo"
+        "glotaran.builtin.io.ascii.wavelength_time_explicit_file.AsciiDataIo_ascii"
     )
-    assert is_known_data_format("glotaran.builtin.io.netCDF.netCDF.NetCDFDataIo")
+    assert is_known_data_format("glotaran.builtin.io.netCDF.netCDF.NetCDFDataIo_nc")
 
 
 @pytest.mark.parametrize(
@@ -155,7 +157,7 @@ def test_known_data_formats():
 def test_set_data_plugin():
     """Set Change Plugin used for format foo"""
     assert isinstance(get_data_io("foo"), DataIoInterface)
-    set_data_plugin("foo", "test_data_io_registration.MockDataIO")
+    set_data_plugin("foo", "test_data_io_registration.MockDataIO_bar")
     assert isinstance(get_data_io("foo"), MockDataIO)
 
 
@@ -277,11 +279,11 @@ def test_data_io_plugin_table_full():
     """Full Table with all extras"""
     expected = dedent(
         """\
-        |            __Format name__             |  __load_dataset__  |  __save_dataset__  |             __Plugin name__             |
-        |----------------------------------------|--------------------|--------------------|-----------------------------------------|
-        |                 `foo`                  |         /          |         /          | `glotaran.io.interface.DataIoInterface` |
-        |                 `mock`                 |         *          |         *          | `test_data_io_registration.MockDataIO`  |
-        | `test_data_io_registration.MockDataIO` |         *          |         *          | `test_data_io_registration.MockDataIO`  |
+        |              __Format name__               |  __load_dataset__  |  __save_dataset__  |               __Plugin name__               |
+        |--------------------------------------------|--------------------|--------------------|---------------------------------------------|
+        |                   `foo`                    |         /          |         /          | `glotaran.io.interface.DataIoInterface_foo` |
+        |                   `mock`                   |         *          |         *          | `test_data_io_registration.MockDataIO_mock` |
+        | `test_data_io_registration.MockDataIO_bar` |         *          |         *          | `test_data_io_registration.MockDataIO_bar`  |
         """  # noqa: E501
     )
 

--- a/glotaran/plugin_system/test/test_data_io_registration.py
+++ b/glotaran/plugin_system/test/test_data_io_registration.py
@@ -24,6 +24,7 @@ from glotaran.plugin_system.data_io_registration import set_data_plugin
 from glotaran.plugin_system.data_io_registration import show_data_io_method_help
 
 if TYPE_CHECKING:
+    from os import PathLike
     from pathlib import Path
     from typing import Any
 
@@ -32,14 +33,16 @@ if TYPE_CHECKING:
 
 
 class MockDataIO(DataIoInterface):
-    def load_dataset(self, file_name: str, **kwargs: Any) -> xr.Dataset | xr.DataArray:
+    def load_dataset(
+        self, file_name: str | PathLike[str], **kwargs: Any
+    ) -> xr.Dataset | xr.DataArray:
         """This docstring is just for help testing of 'load_dataset'."""
         return {"file_name": file_name, **kwargs}  # type:ignore
 
     # TODO: Investigate why this raises an [override] type error and read_dataset doesn't
     def save_dataset(  # type:ignore[override]
         self,
-        file_name: str,
+        file_name: str | PathLike[str],
         dataset: xr.Dataset | xr.DataArray,
         *,
         result_container: dict[str, Any],
@@ -171,7 +174,7 @@ def test_load_dataset(tmp_path: Path):
     file_path = tmp_path / "dummy.mock"
     file_path.write_text("mock")
 
-    result = load_dataset(str(file_path), dummy_arg="baz")
+    result = load_dataset(file_path, dummy_arg="baz")
 
     assert result == {"file_name": str(file_path), "dummy_arg": "baz"}
 
@@ -195,7 +198,7 @@ def test_write_dataset(tmp_path: Path):
     result: dict[str, Any] = {}
     save_dataset(
         "no_dataset",  # type:ignore
-        str(file_path),
+        file_path,
         result_container=result,
         dummy_arg="baz",
     )

--- a/glotaran/plugin_system/test/test_data_io_registration.py
+++ b/glotaran/plugin_system/test/test_data_io_registration.py
@@ -240,11 +240,27 @@ def test_data_io_plugin_table():
     """Plugin foo supports no function and mock supports all"""
     expected = dedent(
         """\
-        |  __Plugin__  |  __load_dataset__  |  __save_dataset__  |
-        |--------------|--------------------|--------------------|
-        |    `foo`     |         /          |         /          |
-        |    `mock`    |         *          |         *          |
+        |  __Format name__  |  __load_dataset__  |  __save_dataset__  |
+        |-------------------|--------------------|--------------------|
+        |       `foo`       |         /          |         /          |
+        |      `mock`       |         *          |         *          |
         """
     )
 
     assert f"{data_io_plugin_table()}\n" == expected
+
+
+@pytest.mark.usefixtures("mocked_registry")
+def test_data_io_plugin_table_full():
+    """Full Table with all extras"""
+    expected = dedent(
+        """\
+        |            __Format name__             |  __load_dataset__  |  __save_dataset__  |             __Plugin name__             |
+        |----------------------------------------|--------------------|--------------------|-----------------------------------------|
+        |                 `foo`                  |         /          |         /          | `glotaran.io.interface.DataIoInterface` |
+        |                 `mock`                 |         *          |         *          | `test_data_io_registration.MockDataIO`  |
+        | `test_data_io_registration.MockDataIO` |         *          |         *          | `test_data_io_registration.MockDataIO`  |
+        """  # noqa: E501
+    )
+
+    assert f"{data_io_plugin_table(plugin_names=True,full_names=True)}\n" == expected

--- a/glotaran/plugin_system/test/test_model_registration.py
+++ b/glotaran/plugin_system/test/test_model_registration.py
@@ -4,12 +4,14 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from glotaran.builtin.models.kinetic_image import KineticImageModel
 from glotaran.model import Model
 from glotaran.plugin_system.base_registry import __PluginRegistry
 from glotaran.plugin_system.model_registration import get_model
 from glotaran.plugin_system.model_registration import is_known_model
 from glotaran.plugin_system.model_registration import known_model_names
 from glotaran.plugin_system.model_registration import register_model
+from glotaran.plugin_system.model_registration import set_model_plugin
 
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
@@ -17,25 +19,64 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def mocked_registry(monkeypatch: MonkeyPatch):
-    monkeypatch.setattr(__PluginRegistry, "model", {"foo": Model, "bar": Model})
+    monkeypatch.setattr(
+        __PluginRegistry,
+        "model",
+        {
+            "foo": Model,
+            "bar": KineticImageModel,
+            "glotaran.builtin.models.kinetic_image.KineticImageModel": KineticImageModel,
+        },
+    )
 
 
 def test_register_model(mocked_registry):
+    """Register new model."""
     register_model("base-model", Model)
 
     assert "base-model" in __PluginRegistry.model
     assert __PluginRegistry.model["base-model"] == Model
+    assert "glotaran.model.base_model.Model" in __PluginRegistry.model
+    assert __PluginRegistry.model["glotaran.model.base_model.Model"] == Model
+    assert known_model_names(full_names=True) == sorted(
+        [
+            "foo",
+            "bar",
+            "glotaran.builtin.models.kinetic_image.KineticImageModel",
+            "base-model",
+            "glotaran.model.base_model.Model",
+        ]
+    )
 
 
-def test_known_model(mocked_registry):
+def test_is_known_model(mocked_registry):
+    """Check if models are in registry"""
     assert is_known_model("foo")
     assert is_known_model("bar")
     assert not is_known_model("baz")
 
 
 def test_get_model(mocked_registry):
+    """Get model from registry"""
     assert get_model("foo") == Model
 
 
 def test_known_model_names(mocked_registry):
-    assert known_model_names() == ["foo", "bar"]
+    """Get model names from registry"""
+    assert known_model_names() == sorted(["foo", "bar"])
+
+
+def test_known_set_model_plugin(mocked_registry):
+    """Overwrite foo model"""
+    assert get_model("foo") == Model
+    set_model_plugin("foo", "glotaran.builtin.models.kinetic_image.KineticImageModel")
+    assert get_model("foo") == KineticImageModel
+
+
+def test_known_set_model_plugin_dot_in_model_name(mocked_registry):
+    """Raise error if model_name contains '.'"""
+    with pytest.raises(
+        ValueError,
+        match=r"The value of 'model_name' isn't allowed to contain the character '\.' \.",
+    ):
+        set_model_plugin("foo.bar", "glotaran.builtin.models.kinetic_image.KineticImageModel")

--- a/glotaran/plugin_system/test/test_project_io_registration.py
+++ b/glotaran/plugin_system/test/test_project_io_registration.py
@@ -46,7 +46,7 @@ class MockProjectIo(ProjectIoInterface):
         return {"file_name": file_name, **kwargs}  # type:ignore[return-value]
 
     def save_model(  # type:ignore[override]
-        self, file_name: str, model: Model, *, result_container: dict[str, Any], **kwargs: Any
+        self, model: Model, file_name: str, *, result_container: dict[str, Any], **kwargs: Any
     ):
         result_container.update(
             **{
@@ -61,8 +61,8 @@ class MockProjectIo(ProjectIoInterface):
 
     def save_parameters(  # type:ignore[override]
         self,
-        file_name: str,
         parameters: ParameterGroup,
+        file_name: str,
         *,
         result_container: dict[str, Any],
         **kwargs: Any,
@@ -79,7 +79,7 @@ class MockProjectIo(ProjectIoInterface):
         return {"file_name": file_name, **kwargs}  # type:ignore[return-value]
 
     def save_scheme(  # type:ignore[override]
-        self, file_name: str, scheme: Scheme, *, result_container: dict[str, Any], **kwargs: Any
+        self, scheme: Scheme, file_name: str, *, result_container: dict[str, Any], **kwargs: Any
     ):
         result_container.update(
             **{
@@ -94,8 +94,8 @@ class MockProjectIo(ProjectIoInterface):
 
     def save_result(  # type:ignore[override]
         self,
-        result_path: str,
         result: Result,
+        result_path: str,
         *,
         result_container: dict[str, Any],
         **kwargs: Any,
@@ -209,8 +209,8 @@ def test_write_functions(tmp_path: Path, save_function: Callable[..., Any]):
     result: dict[str, Any] = {}
 
     save_function(
-        str(file_path),
         "data_object",  # type:ignore
+        str(file_path),
         "mock",
         result_container=result,
         dummy_arg="baz",
@@ -260,7 +260,7 @@ def test_save_functions_value_error(
     file_path = tmp_path / "dummy.foo"
 
     with pytest.raises(ValueError, match=f"Cannot {error_regex} with format 'foo'"):
-        save_function(str(file_path), "bar")
+        save_function("bar", str(file_path))
 
 
 @pytest.mark.parametrize(
@@ -275,7 +275,7 @@ def test_protect_from_overwrite_save_functions(tmp_path: Path, function: Callabl
     file_path.touch()
 
     with pytest.raises(FileExistsError, match="The file .+? already exists"):
-        function(str(file_path), "foo", "bar")
+        function("foo", str(file_path), "bar")
 
 
 @pytest.mark.usefixtures("mocked_registry")

--- a/glotaran/plugin_system/test/test_project_io_registration.py
+++ b/glotaran/plugin_system/test/test_project_io_registration.py
@@ -325,11 +325,27 @@ def test_project_io_plugin_table():
     """Plugin foo supports no function and mock supports all"""
     expected = dedent(
         """\
-        |  __Plugin__  |  __load_model__  |  __save_model__  |  __load_parameters__  |  __save_parameters__  |  __load_scheme__  |  __save_scheme__  |  __load_result__  |  __save_result__  |
-        |--------------|------------------|------------------|-----------------------|-----------------------|-------------------|-------------------|-------------------|-------------------|
-        |    `foo`     |        /         |        /         |           /           |           /           |         /         |         /         |         /         |         /         |
-        |    `mock`    |        *         |        *         |           *           |           *           |         *         |         *         |         *         |         *         |
+        |  __Format name__  |  __load_model__  |  __save_model__  |  __load_parameters__  |  __save_parameters__  |  __load_scheme__  |  __save_scheme__  |  __load_result__  |  __save_result__  |
+        |-------------------|------------------|------------------|-----------------------|-----------------------|-------------------|-------------------|-------------------|-------------------|
+        |       `foo`       |        /         |        /         |           /           |           /           |         /         |         /         |         /         |         /         |
+        |      `mock`       |        *         |        *         |           *           |           *           |         *         |         *         |         *         |         *         |
         """  # noqa: E501
     )
 
     assert f"{project_io_plugin_table()}\n" == expected
+
+
+@pytest.mark.usefixtures("mocked_registry")
+def test_project_io_plugin_table_full():
+    """Full Table with all extras"""
+    expected = dedent(
+        """\
+        |               __Format name__                |  __load_model__  |  __save_model__  |  __load_parameters__  |  __save_parameters__  |  __load_scheme__  |  __save_scheme__  |  __load_result__  |  __save_result__  |               __Plugin name__                |
+        |----------------------------------------------|------------------|------------------|-----------------------|-----------------------|-------------------|-------------------|-------------------|-------------------|----------------------------------------------|
+        |                    `foo`                     |        /         |        /         |           /           |           /           |         /         |         /         |         /         |         /         |  `glotaran.io.interface.ProjectIoInterface`  |
+        |                    `mock`                    |        *         |        *         |           *           |           *           |         *         |         *         |         *         |         *         | `test_project_io_registration.MockProjectIo` |
+        | `test_project_io_registration.MockProjectIo` |        *         |        *         |           *           |           *           |         *         |         *         |         *         |         *         | `test_project_io_registration.MockProjectIo` |
+        """  # noqa: E501
+    )
+
+    assert f"{project_io_plugin_table(plugin_names=True,full_names=True)}\n" == expected

--- a/glotaran/plugin_system/test/test_project_io_registration.py
+++ b/glotaran/plugin_system/test/test_project_io_registration.py
@@ -130,7 +130,7 @@ def mocked_registry(monkeypatch: MonkeyPatch):
         {
             "foo": ProjectIoInterface("foo"),
             "mock": MockProjectIo("bar"),
-            "test_project_io_registration.MockProjectIo": MockProjectIo("bar"),
+            "test_project_io_registration.MockProjectIo_bar": MockProjectIo("bar"),
         },
     )
 
@@ -151,7 +151,9 @@ def test_register_project_io():
         assert format_name in __PluginRegistry.project_io
         assert isinstance(__PluginRegistry.project_io[format_name], plugin_class)
         assert isinstance(
-            __PluginRegistry.project_io[f"test_project_io_registration.{plugin_class.__name__}"],
+            __PluginRegistry.project_io[
+                f"test_project_io_registration.{plugin_class.__name__}_{format_name}"
+            ],
             plugin_class,
         )
         assert __PluginRegistry.project_io[format_name].format == format_name
@@ -189,8 +191,10 @@ def test_known_project_format_actual_register():
     assert is_known_project_format("yaml")
     assert is_known_project_format("yml_str")
     assert is_known_project_format("csv")
-    assert is_known_project_format("glotaran.builtin.io.yml.yml.YmlProjectIo")
-    assert is_known_project_format("glotaran.builtin.io.csv.csv.CsvProjectIo")
+    assert is_known_project_format("glotaran.builtin.io.yml.yml.YmlProjectIo_yml")
+    assert is_known_project_format("glotaran.builtin.io.yml.yml.YmlProjectIo_yaml")
+    assert is_known_project_format("glotaran.builtin.io.yml.yml.YmlProjectIo_yml_str")
+    assert is_known_project_format("glotaran.builtin.io.csv.csv.CsvProjectIo_csv")
 
 
 @pytest.mark.parametrize(
@@ -218,7 +222,7 @@ def test_known_project_formats():
 def test_set_project_plugin():
     """Set Change Plugin used for format foo"""
     assert isinstance(get_project_io("foo"), ProjectIoInterface)
-    set_project_plugin("foo", "test_project_io_registration.MockProjectIo")
+    set_project_plugin("foo", "test_project_io_registration.MockProjectIo_bar")
     assert isinstance(get_project_io("foo"), MockProjectIo)
 
 
@@ -370,11 +374,11 @@ def test_project_io_plugin_table_full():
     """Full Table with all extras"""
     expected = dedent(
         """\
-        |               __Format name__                |  __load_model__  |  __save_model__  |  __load_parameters__  |  __save_parameters__  |  __load_scheme__  |  __save_scheme__  |  __load_result__  |  __save_result__  |               __Plugin name__                |
-        |----------------------------------------------|------------------|------------------|-----------------------|-----------------------|-------------------|-------------------|-------------------|-------------------|----------------------------------------------|
-        |                    `foo`                     |        /         |        /         |           /           |           /           |         /         |         /         |         /         |         /         |  `glotaran.io.interface.ProjectIoInterface`  |
-        |                    `mock`                    |        *         |        *         |           *           |           *           |         *         |         *         |         *         |         *         | `test_project_io_registration.MockProjectIo` |
-        | `test_project_io_registration.MockProjectIo` |        *         |        *         |           *           |           *           |         *         |         *         |         *         |         *         | `test_project_io_registration.MockProjectIo` |
+        |                 __Format name__                  |  __load_model__  |  __save_model__  |  __load_parameters__  |  __save_parameters__  |  __load_scheme__  |  __save_scheme__  |  __load_result__  |  __save_result__  |                  __Plugin name__                  |
+        |--------------------------------------------------|------------------|------------------|-----------------------|-----------------------|-------------------|-------------------|-------------------|-------------------|---------------------------------------------------|
+        |                      `foo`                       |        /         |        /         |           /           |           /           |         /         |         /         |         /         |         /         |  `glotaran.io.interface.ProjectIoInterface_foo`   |
+        |                      `mock`                      |        *         |        *         |           *           |           *           |         *         |         *         |         *         |         *         | `test_project_io_registration.MockProjectIo_mock` |
+        | `test_project_io_registration.MockProjectIo_bar` |        *         |        *         |           *           |           *           |         *         |         *         |         *         |         *         | `test_project_io_registration.MockProjectIo_bar`  |
         """  # noqa: E501
     )
 


### PR DESCRIPTION
This PR removes the issues I found with the new plugin system.

- `save` functions for IO plugins now have a natural python argument order ( (`<object>`, `<path>`) instead of (`<path>`, `<object>`))
- register functions don't trow a `PluginOverwriteWarning` if the plugin overwrites itself
- plugins now register at least twice, once as the developer intended and once under their full name (import path+instance postfix if it is an instantiated plugin like the IO plugins)
- new `set_plugin` functionality allowing to pin plugins and thus allowing reproducible analysis no matter which plugins have conflicts
- `project_io_plugin_table` and `data_io_plugin_table` now also show the plugin names if wanted, which helps to identify which plugin is used for which format
- `save` and `load` IO functions now also accept `PathLike` paths and convert them to strings before passing them to the plugins
- `PluginOverwriteWarning`s now point to the plugin trying to register

Since we didn't have a release with the new plugin system yet, IMHO there shouldn't be a need for proper deprecation of changed argument order of the `save` functions.

**Testing**

Passing the tests is mandatory.

**Closing issues**

closes #664 
