### PR TITLE
👌 Ensure Parameter.label is str or None

### DIFF
--- a/glotaran/deprecation/modules/test/test_glotaran_root.py
+++ b/glotaran/deprecation/modules/test/test_glotaran_root.py
@@ -98,7 +98,7 @@ def test_read_parameters_from_yaml():
 
     assert isinstance(result, ParameterGroup)
     assert isinstance(result["foo"], ParameterGroup)
-    assert result["foo"].get(1) == 123
+    assert result["foo"].get("1") == 123
 
 
 def test_read_parameters_from_yaml_file(tmp_path: Path):
@@ -111,4 +111,4 @@ def test_read_parameters_from_yaml_file(tmp_path: Path):
 
     assert isinstance(result, ParameterGroup)
     assert isinstance(result["foo"], ParameterGroup)
-    assert result["foo"].get(1) == 123
+    assert result["foo"].get("1") == 123

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -258,7 +258,7 @@ class ParameterGroup(dict):
         Parameters
         ----------
         label :
-            The label of the parameter.
+            The label of the parameter, with its path in a parameter group prepended.
         """
 
         try:
@@ -273,7 +273,7 @@ class ParameterGroup(dict):
         Parameters
         ----------
         label :
-            The label of the parameter.
+            The label of the parameter, with its path in a parameter group prepended.
         """
 
         # sometimes the spec parser delivers the labels as int


### PR DESCRIPTION
- Ensure that Paremeter.label always is a str or None
- Improve Parameter typing (no more mypy error in parameter.py)
- Fix error message on invalid group label
- Improved test coverage
- Improved docstrings

Typing error reduction from [268](https://github.com/glotaran/pyglotaran/pull/444#issuecomment-850829451) to [253](https://github.com/s-weigand/pyglotaran/runs/2700885616?check_suite_focus=true)

**Testing**

Passing the tests is mandatory.

**Closing issues**

closes #634 
