### PR TITLE
🧪 Test depreciation of Model.simulate

### DIFF
--- a/glotaran/deprecation/modules/test/test_model_base_model.py
+++ b/glotaran/deprecation/modules/test/test_model_base_model.py
@@ -1,0 +1,10 @@
+"""Test deprecated functionality in 'glotaran.model.base_model'."""
+from __future__ import annotations
+
+from glotaran.deprecation.modules.test import deprecation_warning_on_call_test_helper
+from glotaran.model.base_model import Model
+
+
+def test_model_simulate_method():
+    """Model.simulate raises deperecation warning"""
+    deprecation_warning_on_call_test_helper(Model().simulate)


### PR DESCRIPTION
Follow up on #671 
This test is mainly used for the tests to fail when we make a new release and the deprecation is overdue.

**Testing**

Passing the tests is mandatory.

