### PR TITLE
🔧 Remove the schedule from autoupdate-pre-commit-config

### DIFF
--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -5,8 +5,6 @@ name: "Update pre-commit config"
 # If you don't want the PR to trigger the CI (NOT RECOMMENDED), comment out the GITHUB_TOKEN line.
 
 on:
-  schedule:
-    - cron: "0 20 * * 5" # At 20:00 on each Friday.
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
pre-commit-ci will do the scheduled autoupdates from now on.
But in case we manually want to trigger it we still got this workflow to start an update PR from the actions tab on github.


**Testing**

Passing the tests is mandatory.
