### PR TITLE
🩹 Fix spectral-model crashing on SVD calculation

### DIFF
--- a/glotaran/analysis/problem.py
+++ b/glotaran/analysis/problem.py
@@ -11,6 +11,7 @@ import xarray as xr
 from glotaran.analysis.nnls import residual_nnls
 from glotaran.analysis.util import get_min_max_from_interval
 from glotaran.analysis.variable_projection import residual_variable_projection
+from glotaran.io.prepare_dataset import add_svd_to_dataset
 from glotaran.model import DatasetDescriptor
 from glotaran.model import Model
 from glotaran.parameter import ParameterGroup
@@ -296,14 +297,7 @@ class Problem:
             if isinstance(dataset, xr.DataArray):
                 dataset = dataset.to_dataset(name="data")
 
-            # TODO: avoid computation if not requested
-            l, s, r = np.linalg.svd(dataset.data, full_matrices=False)
-            dataset["data_left_singular_vectors"] = (("time", "left_singular_value_index"), l)
-            dataset["data_singular_values"] = (("singular_value_index"), s)
-            dataset["data_right_singular_vectors"] = (
-                ("right_singular_value_index", "spectral"),
-                r,
-            )
+            add_svd_to_dataset(dataset)
 
             dataset = self._transpose_dataset(dataset)
             self._add_weight(label, dataset)

--- a/glotaran/analysis/problem.py
+++ b/glotaran/analysis/problem.py
@@ -296,9 +296,6 @@ class Problem:
             if isinstance(dataset, xr.DataArray):
                 dataset = dataset.to_dataset(name="data")
 
-            dataset = self._transpose_dataset(dataset)
-            self._add_weight(label, dataset)
-
             # TODO: avoid computation if not requested
             l, s, r = np.linalg.svd(dataset.data, full_matrices=False)
             dataset["data_left_singular_vectors"] = (("time", "left_singular_value_index"), l)
@@ -308,6 +305,8 @@ class Problem:
                 r,
             )
 
+            dataset = self._transpose_dataset(dataset)
+            self._add_weight(label, dataset)
             self._data[label] = dataset
 
     def _transpose_dataset(self, dataset):

--- a/glotaran/io/prepare_dataset.py
+++ b/glotaran/io/prepare_dataset.py
@@ -1,13 +1,13 @@
-import typing
+from __future__ import annotations
 
 import numpy as np
 import xarray as xr
 
 
 def prepare_time_trace_dataset(
-    dataset: typing.Union[xr.DataArray, xr.Dataset],
+    dataset: xr.DataArray | xr.Dataset,
     weight: np.ndarray = None,
-    irf: typing.Union[np.ndarray, xr.DataArray] = None,
+    irf: np.ndarray | xr.DataArray = None,
 ) -> xr.Dataset:
     """Prepares a time trace for global analysis.
 
@@ -24,11 +24,7 @@ def prepare_time_trace_dataset(
     if isinstance(dataset, xr.DataArray):
         dataset = dataset.to_dataset(name="data")
 
-    if "data_singular_values" not in dataset:
-        l, s, r = np.linalg.svd(dataset.data, full_matrices=False)
-        dataset["data_left_singular_vectors"] = (("time", "left_singular_value_index"), l)
-        dataset["data_singular_values"] = (("singular_value_index"), s)
-        dataset["data_right_singular_vectors"] = (("right_singular_value_index", "spectral"), r)
+    add_svd_to_dataset(dataset)
 
     if weight is not None:
         dataset["weight"] = (dataset.data.dims, weight)
@@ -43,3 +39,21 @@ def prepare_time_trace_dataset(
             dataset["irf"] = irf
 
     return dataset
+
+
+def add_svd_to_dataset(dataset: xr.Dataset):
+    """Add the SVD of a dataset.data inplace as Data variables to the dataset.
+
+    The SVD is only computed if it doesn't already exist on the dataset.
+
+    Parameters
+    ----------
+    dataset : xr.Dataset
+        Dataset the SVD values should be added to.
+    """
+
+    if "data_singular_values" not in dataset:
+        l, s, r = np.linalg.svd(dataset.data, full_matrices=False)
+        dataset["data_left_singular_vectors"] = (("time", "left_singular_value_index"), l)
+        dataset["data_singular_values"] = (("singular_value_index"), s)
+        dataset["data_right_singular_vectors"] = (("right_singular_value_index", "spectral"), r)


### PR DESCRIPTION
Since the SVD is independent of the model, we can calculate it before transposing `model_dimension` and `global_dimension`.
I also refactored `glotaran.io.prepare_dataset` to reduce code duplication and prevent recalculation of the SVD, since data readers like `ascii` already calculate the SVD when reading the dataset.

**Testing**

Passing the tests is mandatory.

**Closing issues**

closes #683
