### PR TITLE
🩹 Fix calculation of skewed-gaussian in spectral model

### DIFF
--- a/glotaran/analysis/simulation.py
+++ b/glotaran/analysis/simulation.py
@@ -55,10 +55,10 @@ def simulate(
     model_dimension = axes[model.model_dimension]
     global_dimension = axes[model.global_dimension]
 
-    dim1 = model_dimension.size
+    # dim1 = model_dimension.size
     dim2 = global_dimension.size
     result = xr.DataArray(
-        np.empty((dim1, dim2), dtype=np.float64),
+        data=0.0,
         coords=[
             (model.model_dimension, model_dimension),
             (model.global_dimension, global_dimension),

--- a/glotaran/builtin/models/kinetic_image/kinetic_image_result.py
+++ b/glotaran/builtin/models/kinetic_image/kinetic_image_result.py
@@ -37,7 +37,7 @@ def retrieve_species_associated_data(model, dataset, dataset_descriptor, name):
             model.global_dimension,
             "species",
         ),
-        dataset.clp.sel(clp_label=compartments),
+        dataset.clp.sel(clp_label=compartments).data,
     )
 
     if len(dataset.matrix.shape) == 3:
@@ -142,5 +142,5 @@ def retrieve_irf(model, dataset, dataset_descriptor, name):
                 index=0,
                 global_axis=dataset.coords[model.global_dimension],
                 model_axis=dataset.coords[model.model_dimension],
-            ),
+            ).data,
         )

--- a/glotaran/builtin/models/kinetic_spectrum/spectral_shape.py
+++ b/glotaran/builtin/models/kinetic_spectrum/spectral_shape.py
@@ -24,7 +24,7 @@ class SpectralShapeGaussian:
         Parameters
         ----------
         axis: np.ndarray
-            The axies to calculate the shape on.
+            The axis to calculate the shape on.
 
         Returns
         -------

--- a/glotaran/builtin/models/kinetic_spectrum/test/test_coherent_artifact.py
+++ b/glotaran/builtin/models/kinetic_spectrum/test/test_coherent_artifact.py
@@ -77,7 +77,7 @@ def test_coherent_artifact():
             ),
         ],
     )
-    axis = {"time": time, "spectral": clp.spectral}
+    axis = {"time": time, "spectral": clp.spectral.data}
     data = simulate(model, "dataset1", parameters, axis, clp)
 
     dataset = {"dataset1": data}

--- a/glotaran/builtin/models/spectral/shape.py
+++ b/glotaran/builtin/models/spectral/shape.py
@@ -17,46 +17,136 @@ from glotaran.parameter import Parameter
     has_type=True,
 )
 class SpectralShapeLorentzianBandshape:
-    """A gaussian spectral shape"""
+    """A lorentzian spectral shape"""
 
     def calculate(self, axis: np.ndarray) -> np.ndarray:
-        """calculate calculates the shape.
+        r"""Calculate the lorentzian shape over ``axis``.
+
+        If ``skew`` parameter was added and isn't close to zero
+        :func:`calculate_skewed` will be used.
+        Else it will use :func:`calculate_unskewed`.
 
         Parameters
         ----------
         axis: np.ndarray
-            The axies to calculate the shape on.
+            The axis to calculate the shape for.
 
         Returns
         -------
         shape: numpy.ndarray
+            Skewed or unskewed lorentzian shape.
+
+        See Also
+        --------
+        calculate_unskewed
+        calculate_skewed
+
+        Note
+        ----
+        Internally ``axis`` is converted from :math:`\mbox{nm}` to
+        :math:`1/\mbox{cm}`, thus ``location`` and ``width`` also need to
+        be provided in :math:`1/\mbox{cm}` (``1e7/value_in_nm``).
 
         """
         return (
-            self._calculate_skewed(axis)
+            self.calculate_skewed(axis)
             if self.skew is not None and not np.allclose(self.skew, 0)
-            else self._calculate_unskewed(axis)
+            else self.calculate_unskewed(axis)
         )
 
-    def _calculate_unskewed(self, axis: np.ndarray) -> np.ndarray:
+    def calculate_unskewed(self, axis: np.ndarray) -> np.ndarray:
+        r"""Calcute the unskewed lorentzian shape for ``axis``.
+
+        The following equation is used for the calculation:
+
+        .. math::
+            f(x, A, x_0, \sigma) = A \exp \left({-
+            \frac{
+                \log{\left(2 \right)
+                \left(2(x - x_{0})\right)^{2}
+            }}{\sigma^{2}}}\right)
+
+        The parameters of the equation represent the following attributes of the shape:
+
+        - :math:`x` :       ``axis``
+
+        - :math:`A` :       ``amplitude``
+
+        - :math:`x_0` :     ``location``
+
+        - :math:`\sigma` :  ``width``
+
+        Parameters
+        ----------
+        axis : np.ndarray
+            The axis to calculate the shape for.
+
+        Returns
+        -------
+        np.ndarray
+            Unskewed lorentzian shape.
+        """
         return self.amplitude * np.exp(
-            -np.log(2) * np.square(2 * ((10 ** 7 / axis) - self.location) / self.width)
+            -np.log(2) * np.square(2 * ((1e7 / axis) - self.location) / self.width)
         )
 
-    def _calculate_skewed(self, axis: np.ndarray) -> np.ndarray:
-        arg = 1 + (2 * self.skew * ((10 ** 7 / axis) - self.location) / self.width)
-        result = arg
-        result[np.where(arg > 0)] = np.exp(
-            -np.log(2) * np.square(np.log(arg[np.where(arg > 0)]) / self.skew)
+    def calculate_skewed(self, axis: np.ndarray) -> np.ndarray:
+        r"""Calcute the skewed lorentzian shape for ``axis``.
+
+        The following equation is used for the calculation:
+
+        .. math::
+            f(x, x_0, A, \sigma, b) =
+            \left\{
+                \begin{array}{ll}
+                    0                                               & \mbox{if } \theta \leq 0 \\
+                    A \exp \left({- \dfrac{\log{\left(2 \right)}
+                    \log{\left(\theta(x, x_0, \sigma, b) \right)}^{2}}{b^{2}}}\right)
+                                                                    & \mbox{if } \theta > 0
+                \end{array}
+            \right.
+
+        With:
+
+        .. math::
+            \theta(x, x_0, \sigma, b) = \frac{2 b \left(x - x_{0}\right) + \sigma}{\sigma}
+
+        The parameters of the equation represent the following attributes of the shape:
+
+        - :math:`x` :       ``axis``
+
+        - :math:`A` :       ``amplitude``
+
+        - :math:`x_0` :     ``location``
+
+        - :math:`\sigma` :  ``width``
+
+        - :math:`b` :       ``skew``
+
+        Parameters
+        ----------
+        axis : np.ndarray
+            The axis to calculate the shape for.
+
+
+        Returns
+        -------
+        np.ndarray
+            Skewed lorentzian shape.
+        """
+        log_args = 1 + (2 * self.skew * ((1e7 / axis) - self.location) / self.width)
+        result = np.zeros(log_args.shape)
+        valid_arg_mask = np.where(log_args > 0)
+        result[valid_arg_mask] = self.amplitude * np.exp(
+            -np.log(2) * np.square(np.log(log_args[valid_arg_mask]) / self.skew)
         )
-        result[np.where(arg <= 0)] = 0
 
         return result
 
 
 @model_attribute(properties={}, has_type=True)
 class SpectralShapeOne:
-    """A gaussian spectral shape"""
+    """A constant spectral shape with value 1"""
 
     def calculate(self, axis: np.ndarray) -> np.ndarray:
         """calculate calculates the shape.
@@ -64,7 +154,7 @@ class SpectralShapeOne:
         Parameters
         ----------
         axis: np.ndarray
-            The axies to calculate the shape on.
+            The axis to calculate the shape on.
 
         Returns
         -------
@@ -76,17 +166,17 @@ class SpectralShapeOne:
 
 @model_attribute(properties={}, has_type=True)
 class SpectralShapeZero:
-    """A gaussian spectral shape"""
+    """A constant spectral shape with value 0"""
 
     def calculate(self, axis: np.ndarray) -> np.ndarray:
         """calculate calculates the shape.
 
-        Only works after calling calling 'fill'.
+        Only works after calling ``fill``.
 
         Parameters
         ----------
         axis: np.ndarray
-            The axies to calculate the shape on.
+            The axis to calculate the shape on.
 
         Returns
         -------

--- a/glotaran/builtin/models/spectral/shape.py
+++ b/glotaran/builtin/models/spectral/shape.py
@@ -77,7 +77,8 @@ class SpectralShapeSkewedGaussian:
         - :math:`\Delta` :  ``width``
 
         In this formalism, :math:`\Delta` represents the full width at half maximum (FWHM).
-        Compared to the more common definition :math:`\exp \left(- (x-\mu )^{2}/(2\sigma^{2})\right)`
+        Compared to the more common definition
+        :math:`\exp \left(- (x-\mu )^{2}/(2\sigma^{2})\right)`
         we have :math:`\sigma = \Delta/(2\sqrt{2\ln(2)})=\Delta/2.35482`
 
         Parameters
@@ -127,10 +128,13 @@ class SpectralShapeSkewedGaussian:
 
         - :math:`b` :       ``skewness``
 
-        Where :math:`\Delta` represents the full width at half maximum (FWHM), see :func:`calculate_gaussian`.
+        Where :math:`\Delta` represents the full width at half maximum (FWHM),
+        see :func:`calculate_gaussian`.
 
-        Note that in the limit of skewness parameter :math:`b` equal to zero :math:`f(x, x_0, A, \Delta, b)` simplifies to a normal gaussian
-        (since :math:`\lim_{b \to 0} \frac{\ln(1+bx)}{b}=x`), see the defintion in :func:`calculate_gaussian`.
+        Note that in the limit of skewness parameter :math:`b` equal to zero
+        :math:`f(x, x_0, A, \Delta, b)` simplifies to a normal gaussian
+        (since :math:`\lim_{b \to 0} \frac{\ln(1+bx)}{b}=x`),
+        see the definition in :func:`calculate_gaussian`.
 
         Parameters
         ----------

--- a/glotaran/builtin/models/spectral/shape.py
+++ b/glotaran/builtin/models/spectral/shape.py
@@ -16,7 +16,7 @@ from glotaran.parameter import Parameter
     },
     has_type=True,
 )
-class SpectralShapeLorentzianBandshape:
+class SpectralShapeLorentzian:
     """A lorentzian spectral shape"""
 
     def calculate(self, axis: np.ndarray) -> np.ndarray:
@@ -188,7 +188,7 @@ class SpectralShapeZero:
 
 @model_attribute_typed(
     types={
-        "lorentzian-bandshape": SpectralShapeLorentzianBandshape,
+        "lorentzian": SpectralShapeLorentzian,
         "one": SpectralShapeOne,
         "zero": SpectralShapeZero,
     }

--- a/glotaran/builtin/models/spectral/shape.py
+++ b/glotaran/builtin/models/spectral/shape.py
@@ -34,22 +34,24 @@ class SpectralShapeLorentzianBandshape:
         """
         return (
             self._calculate_skewed(axis)
-            if self.skew is not None
+            if self.skew is not None and not np.allclose(self.skew, 0)
             else self._calculate_unskewed(axis)
         )
 
     def _calculate_unskewed(self, axis: np.ndarray) -> np.ndarray:
         return self.amplitude * np.exp(
-            -np.log(2) * np.square(2 * (axis - self.location) / self.width)
+            -np.log(2) * np.square(2 * ((10 ** 7 / axis) - self.location) / self.width)
         )
 
     def _calculate_skewed(self, axis: np.ndarray) -> np.ndarray:
-        return self.amplitude * np.exp(
-            -np.log(2)
-            * np.square(
-                np.log(1 + 2 * self.skew * (axis - self.location) / self.width) / self.skew
-            )
+        arg = 1 + (2 * self.skew * ((10 ** 7 / axis) - self.location) / self.width)
+        result = arg
+        result[np.where(arg > 0)] = np.exp(
+            -np.log(2) * np.square(np.log(arg[np.where(arg > 0)]) / self.skew)
         )
+        result[np.where(arg <= 0)] = 0
+
+        return result
 
 
 @model_attribute(properties={}, has_type=True)

--- a/glotaran/builtin/models/spectral/spectral_result.py
+++ b/glotaran/builtin/models/spectral/spectral_result.py
@@ -38,5 +38,5 @@ def retrieve_spectral_data(model, dataset, dataset_descriptor):
             model.global_dimension,
             "species",
         ),
-        dataset.clp.sel(clp_label=spectral_compartments),
+        dataset.clp.sel(clp_label=spectral_compartments).data,
     )

--- a/glotaran/builtin/models/spectral/test/test_spectral_model.py
+++ b/glotaran/builtin/models/spectral/test/test_spectral_model.py
@@ -47,7 +47,7 @@ class OneCompartmentModel:
             },
             "shape": {
                 "sh1": {
-                    "type": "lorentzian",
+                    "type": "skewed-gaussian",
                     "amplitude": "1",
                     "location": "2",
                     "width": "3",
@@ -61,10 +61,10 @@ class OneCompartmentModel:
         }
     )
 
-    spectral_parameters = ParameterGroup.from_list([7, 100, 50])
+    spectral_parameters = ParameterGroup.from_list([7, 20000, 800])
 
     time = np.arange(-10, 50, 1.5)
-    spectral = np.arange(0, 200, 5)
+    spectral = np.arange(400, 600, 5)
     axis = {"time": time, "spectral": spectral}
 
     dataset = kinetic_model.dataset["dataset1"].fill(kinetic_model, kinetic_parameters)
@@ -118,23 +118,23 @@ class ThreeCompartmentModel:
             },
             "shape": {
                 "sh1": {
-                    "type": "lorentzian",
+                    "type": "skewed-gaussian",
                     "amplitude": "1",
                     "location": "2",
                     "width": "3",
                 },
                 "sh2": {
-                    "type": "lorentzian",
+                    "type": "skewed-gaussian",
                     "amplitude": "4",
                     "location": "5",
                     "width": "6",
                 },
                 "sh3": {
-                    "type": "lorentzian",
+                    "type": "skewed-gaussian",
                     "amplitude": "7",
                     "location": "8",
                     "width": "9",
-                    "skew": "10",
+                    "skewness": "10",
                 },
             },
             "dataset": {
@@ -148,20 +148,20 @@ class ThreeCompartmentModel:
     spectral_parameters = ParameterGroup.from_list(
         [
             7,
-            100,
-            50,
+            20000,
+            800,
             20,
-            150,
+            22000,
+            500,
             10,
-            15,
-            50,
-            20,
+            18000,
+            650,
             0.1,
         ]
     )
 
     time = np.arange(-10, 50, 1.5)
-    spectral = np.arange(0, 200, 5)
+    spectral = np.arange(400, 600, 5)
     axis = {"time": time, "spectral": spectral}
 
     dataset = kinetic_model.dataset["dataset1"].fill(kinetic_model, kinetic_parameters)

--- a/glotaran/builtin/models/spectral/test/test_spectral_model.py
+++ b/glotaran/builtin/models/spectral/test/test_spectral_model.py
@@ -47,7 +47,7 @@ class OneCompartmentModel:
             },
             "shape": {
                 "sh1": {
-                    "type": "lorentzian-bandshape",
+                    "type": "lorentzian",
                     "amplitude": "1",
                     "location": "2",
                     "width": "3",
@@ -118,19 +118,19 @@ class ThreeCompartmentModel:
             },
             "shape": {
                 "sh1": {
-                    "type": "lorentzian-bandshape",
+                    "type": "lorentzian",
                     "amplitude": "1",
                     "location": "2",
                     "width": "3",
                 },
                 "sh2": {
-                    "type": "lorentzian-bandshape",
+                    "type": "lorentzian",
                     "amplitude": "4",
                     "location": "5",
                     "width": "6",
                 },
                 "sh3": {
-                    "type": "lorentzian-bandshape",
+                    "type": "lorentzian",
                     "amplitude": "7",
                     "location": "8",
                     "width": "9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ remove_redundant_aliases = true
 [tool.interrogate]
 exclude = ["setup.py", "docs", "*test/*"]
 ignore-init-module = true
-fail-under = 49
+fail-under = 52
 
 [tool.nbqa.addopts]
 flake8 = [


### PR DESCRIPTION
This PR changes the implementation of the ~~lorentzian-bandshape~~ skewed-gaussian calculation to use a `1/cm` instead of an `nm` axis.

Thus the `location` and `width` now also need to be provided in `1/cm`.

Also, this adds [proper docstrings with the equations.

**Testing**

Passing the tests is mandatory.

**Closing issues**

closes #685 
completes implementation of spectral model #674 