### PR TITLE
👌 ParameterNotFoundException doesn't preprend '.' if path is empty

### DIFF
--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -18,7 +18,7 @@ class ParameterNotFoundException(Exception):
     """Raised when a Parameter is not found in the Group."""
 
     def __init__(self, path, label):
-        super().__init__(f"Cannot find parameter {'.'.join(path)}.{label}")
+        super().__init__(f"Cannot find parameter {'.'.join(path+[label])!r}")
 
 
 class ParameterGroup(dict):


### PR DESCRIPTION
Just a mico change for better error messages I found when writing #687 .

For the error of the dummy example in #687 
Before:
`Cannot find parameter .bar`
After:
`Cannot find parameter 'bar'`

**Testing**

Passing the tests is mandatory.