### PR TITLE
🩹 Split up pr_benchmark workflow into two workflows

### DIFF
--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -63,12 +63,12 @@ jobs:
           ls -lah benchmark/.asv/html
 
       - name: Create PR comment body
-        id: bench_diff
         shell: python
         env:
           PR_NR: ${{github.event.number}}
         run: |
           import os
+          from pathlib import Path
           import subprocess
 
           pr_nr = os.environ.get("PR_NR")
@@ -92,55 +92,10 @@ jobs:
 
           comment = comment.replace("%", "%25").replace("\n", "%0A").replace("\r", "%0D")
 
-          print(f"::set-output name=comment::{comment}")
-
-      - name: Show comment
-        run: echo "${{ steps.bench_diff.outputs.comment }}"
-      - name: Comment on PR
-        uses: hasura/comment-progress@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: "glotaran/pyglotaran"
-          number: ${{ github.event.number }}
-          id: benchmark-comment
-          message: ${{ steps.bench_diff.outputs.comment }}
-          recreate: true
+          Path("benchmark/.asv/html/pr-diff-comment.txt").write_text(comment)
 
       - name: Upload PR html results
         uses: actions/upload-artifact@v2
         with:
           name: benchmark-pr-html
           path: benchmark/.asv/html
-
-  upload_results:
-    name: "Upload Results"
-    needs: [run_benchmark]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download result artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: benchmark-pr-html
-          path: .
-
-      - name: Show tree
-        run: tree -a .
-
-      - name: Commit PR results
-        env:
-          PR_RESULT_BRANCH: pr-${{github.event.number}}
-        run: |
-          git init
-          git checkout --orphan $PR_RESULT_BRANCH
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git config user.name 'github-actions[bot]'
-          git add .
-          git commit -m "🧪 PR benchmark"
-
-      - name: Push result repo
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-          github_token: ${{ secrets.BENCHMARK_PUSH_TOKEN }}
-          repository: "glotaran/pyglotaran-benchmarks"
-          branch: pr-${{github.event.number}}
-          force: true

--- a/.github/workflows/pr_benchmark_reaction.yml
+++ b/.github/workflows/pr_benchmark_reaction.yml
@@ -1,0 +1,87 @@
+name: PR Benchmark reaction
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ["PR Benchmarks"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    name: Comment and upload
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "benchmark-pr-html"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/benchmark-pr-html.zip', Buffer.from(download.data));
+
+      - name: Unzip PR Benchmark results
+        run: |
+          unzip benchmark-pr-html.zip
+          rm benchmark-pr-html.zip
+
+      - name: Show tree
+        run: tree -a .
+
+      - name: Set PR comment
+        id: bench_diff
+        shell: python
+        run: |
+          from pathlib import Path
+
+          comment_file_path = Path("pr-diff-comment.txt")
+          print(f"::set-output name=comment::{comment_file_path.read_text()}")
+          comment_file_path.unlink()
+
+      - name: Show comment
+        run: echo "${{ steps.bench_diff.outputs.comment }}"
+      - name: Comment on PR
+        uses: hasura/comment-progress@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: "glotaran/pyglotaran"
+          number: ${{github.event.workflow_run.pull_requests[0].number }}
+          id: benchmark-comment
+          message: ${{ steps.bench_diff.outputs.comment }}
+          recreate: true
+
+      - name: Commit PR results
+        env:
+          PR_RESULT_BRANCH: pr-${{github.event.workflow_run.pull_requests[0].number}}
+        run: |
+          git init
+          git checkout --orphan $PR_RESULT_BRANCH
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git add .
+          git commit -m "🧪 PR benchmark"
+
+      - name: Push result repo
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.BENCHMARK_PUSH_TOKEN }}
+          repository: "glotaran/pyglotaran-benchmarks"
+          branch: pr-${{github.event.workflow_run.pull_requests[0].number}}
+          force: true


### PR DESCRIPTION
Currently, the new `pr_benchmark` workflow is broken since workflows on the event `pull_request` from forks don't have access to secrets.
I missed this while testing since target and source repo were both my fork, and thus the PRs had privileged rights.

We don't want the benchmarks to run in a runner privileged rights (i.e. `pull_request_target`) but commenting and pushing need access to the secrets.
Thus commenting and pushing to the benchmarks repo need to be done in a privileged workflow.
Ref:
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

### Change summary

- The `pr_benchmark` workflow takes care of benchmarking and creation the comment body
- The `pr_benchmark_reaction` workflow comments on the PR and upload the HTML to a branch in `pyglotaran-benchmarks`

This PR still might not create a comment since the workflow with `workflow_run` first needs to exist on the repos default branch.

Basically `pr_benchmark_reaction` waits for `pr_benchmark` to finish, downloads the artifact, extracts the comment that was saved to a file, comments on the PR, and uploads the benchmark results `pyglotaran-benchmarks`.

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 📚 Adds documentation of the feature
