### PR TITLE
🩹 Ensure that the PR number is present in the pr_benchmark_reaction workflow

### DIFF
--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -93,6 +93,7 @@ jobs:
           comment = comment.replace("%", "%25").replace("\n", "%0A").replace("\r", "%0D")
 
           Path("benchmark/.asv/html/pr-diff-comment.txt").write_text(comment)
+          Path("benchmark/.asv/html/origin_pr_nr.txt").write_text(pr_nr)
 
       - name: Upload PR html results
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pr_benchmark_reaction.yml
+++ b/.github/workflows/pr_benchmark_reaction.yml
@@ -54,22 +54,29 @@ jobs:
           comment_file_path = Path("pr-diff-comment.txt")
           print(f"::set-output name=comment::{comment_file_path.read_text()}")
           comment_file_path.unlink()
+          origin_pr_nr_file_path = Path("origin_pr_nr.txt")
+          print(f"::set-output name=pr_nr::{origin_pr_nr_file_path.read_text()}")
+          origin_pr_nr_file_path.unlink()
 
-      - name: Show comment
-        run: echo "${{ steps.bench_diff.outputs.comment }}"
+      - name: Show PR Number and Comment
+        shell: python
+        run: |
+          print(f"PR Number:\n{ ${{ steps.bench_diff.outputs.pr_nr }} }")
+          print("Comment Body:")
+          print("""${{ steps.bench_diff.outputs.comment }}""")
       - name: Comment on PR
         uses: hasura/comment-progress@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: "glotaran/pyglotaran"
-          number: ${{github.event.workflow_run.pull_requests[0].number }}
+          number: ${{ steps.bench_diff.outputs.pr_nr }}
           id: benchmark-comment
           message: ${{ steps.bench_diff.outputs.comment }}
           recreate: true
 
       - name: Commit PR results
         env:
-          PR_RESULT_BRANCH: pr-${{github.event.workflow_run.pull_requests[0].number}}
+          PR_RESULT_BRANCH: pr-${{steps.bench_diff.outputs.pr_nr}}
         run: |
           git init
           git checkout --orphan $PR_RESULT_BRANCH
@@ -83,5 +90,5 @@ jobs:
         with:
           github_token: ${{ secrets.BENCHMARK_PUSH_TOKEN }}
           repository: "glotaran/pyglotaran-benchmarks"
-          branch: pr-${{github.event.workflow_run.pull_requests[0].number}}
+          branch: pr-${{steps.bench_diff.outputs.pr_nr}}
           force: true


### PR DESCRIPTION
Instead of relying on `github.event.workflow_run.pull_requests[0].number` being the proper PR number the workflow ran on, we write it in a file and read it out, the same way we do it with the comment.


### Change summary

- Ensure that the correct PR number is present in the `pr_benchmark_reaction` workflow
- Fixed printing of comment body in the workflow (the problem was the multiline comment string is evaluated before executing the command, which resulted in a syntax error, now it gets wrapped in a python multiline string)


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 📚 Adds documentation of the feature
