### PR TITLE
🧹 Remove deprecated call to Model.simulate

### DIFF
--- a/glotaran/examples/sequential.py
+++ b/glotaran/examples/sequential.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from glotaran.analysis.simulation import simulate
 from glotaran.builtin.models.kinetic_spectrum import KineticSpectrumModel
 from glotaran.parameter import ParameterGroup
 
@@ -97,7 +98,8 @@ parameter = ParameterGroup.from_dict(
 _time = np.arange(-1, 20, 0.01)
 _spectral = np.arange(600, 700, 1.4)
 
-dataset = sim_model.simulate(
+dataset = simulate(
+    sim_model,
     "dataset1",
     wanted_parameter,
     {"time": _time, "spectral": _spectral},

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -179,7 +179,7 @@ class Result:
         deprecated_qual_name_usage="glotaran.project.result.Result.save(result_path)",
         new_qual_name_usage=(
             "glotaran.io.save_result("
-            "result_path=result_path, result=result, "
+            "result=result, result_path=result_path, "
             'format_name="legacy", allow_overwrite=True'
             ")"
         ),


### PR DESCRIPTION
Micro cleanup, of deprecated usage in our code base.

### Change summary

- Change deprecated call to `model.simulate(...)` to `simulate(model, ...)`
- Arguments for `save_result` in the deprecation warning for `Result.save` are in the proper order

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)

