### PR TITLE
🩹 Scale StdError of estimated parameters with RMSE

### DIFF
--- a/glotaran/analysis/optimize.py
+++ b/glotaran/analysis/optimize.py
@@ -110,7 +110,7 @@ def _create_result(
     if success:
         try:
             covariance_matrix = np.linalg.inv(jacobian.T.dot(jacobian))
-            standard_errors = np.sqrt(np.diagonal(covariance_matrix))
+            standard_errors = root_mean_square_error * np.sqrt(np.diagonal(covariance_matrix))
             for label, error in zip(free_parameter_labels, standard_errors):
                 parameters.get(label).standard_error = error
         except np.linalg.LinAlgError:


### PR DESCRIPTION
In today's meeting with @ism200 we found and solved the problem with the StdError of estimated parameters.

That said following [this StackOverflow aswer](https://stackoverflow.com/a/67023688/3990615) we might want to use a different implementation for cases "when the Jacobian is close to degenerate", but this would need benchmarking first.

Currently we use pretty much use the same as:
```python
chi2dof = np.sum(res.fun**2)/(res.fun.size - res.x.size)
cov *= chi2dof
perr = np.sqrt(np.diag(cov))    # 1sigma uncertainty on fitted parameters
```

Our code (reduced  version):
```python
chi_square = np.sum(ls_result.fun ** 2)
reduced_chi_square = chi_square / degrees_of_freedom
jacobian = ls_result.jac
covariance_matrix = np.linalg.inv(jacobian.T.dot(jacobian))
standard_errors = np.sqrt(np.diagonal(covariance_matrix))
```

The more robust implementation would be:
```python
U, s, Vh = linalg.svd(res.jac, full_matrices=False)
tol = np.finfo(float).eps*s[0]*max(res.jac.shape)
w = s > tol
cov = (Vh[w].T/s[w]**2) @ Vh[w]  # robust covariance matrix
perr = np.sqrt(np.diag(cov))     # 1sigma uncertainty on fitted parameters
```

That might also allow us to get rid of the try-except case [when calculating the `covariance_matrix`](https://github.com/glotaran/pyglotaran/blob/828710e4187bae53709f6bbfe5cc144695d1beed/glotaran/analysis/optimize.py#L112).

### Change summary

- StdError gets scaled with RMSE

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 📚 Adds documentation of the feature

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #703 
