### PR TITLE
👌 More robust covariance_matrix calculation

### DIFF
--- a/benchmark/benchmarks/integration/ex_two_datasets/benchmark.py
+++ b/benchmark/benchmarks/integration/ex_two_datasets/benchmark.py
@@ -1,6 +1,11 @@
+import pickle
 from pathlib import Path
 
+from scipy.optimize import OptimizeResult
+
+from glotaran.analysis.optimize import _create_result
 from glotaran.analysis.optimize import optimize
+from glotaran.analysis.problem_grouped import GroupedProblem
 from glotaran.io import load_dataset
 from glotaran.io import load_model
 from glotaran.io import load_parameters
@@ -30,9 +35,37 @@ class IntegrationTwoDatasets:
             non_negative_least_squares=True,
             optimization_method="TrustRegionReflection",
         )
+        # Values extracted from a previous run of IntegrationTwoDatasets.time_optimize()
+        self.problem = GroupedProblem(self.scheme)
+        # pickled OptimizeResult
+        with open(SCRIPT_DIR / "data/ls_result.pcl", "rb") as ls_result_file:
+            self.ls_result: OptimizeResult = pickle.load(ls_result_file)
+        self.free_parameter_labels = [
+            "inputs.2",
+            "inputs.3",
+            "inputs.7",
+            "inputs.8",
+            "scale.2",
+            "rates.k1",
+            "rates.k2",
+            "rates.k3",
+            "irf.center",
+            "irf.width",
+        ]
+        self.termination_reason = "The maximum number of function evaluations is exceeded."
 
     def time_optimize(self):
         optimize(self.scheme)
 
     def peakmem_optimize(self):
         optimize(self.scheme)
+
+    def time_create_result(self):
+        _create_result(
+            self.problem, self.ls_result, self.free_parameter_labels, self.termination_reason
+        )
+
+    def peakmem_create_result(self):
+        _create_result(
+            self.problem, self.ls_result, self.free_parameter_labels, self.termination_reason
+        )

--- a/glotaran/builtin/models/kinetic_spectrum/test/test_spectral_constraints.py
+++ b/glotaran/builtin/models/kinetic_spectrum/test/test_spectral_constraints.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 import xarray as xr
 
 from glotaran.analysis.optimize import optimize
@@ -100,9 +99,7 @@ def test_spectral_constraint():
         maximum_number_function_evaluations=20,
     )
 
-    # the resulting jacobian is singular
-    with pytest.warns(UserWarning):
-        result = optimize(scheme)
+    result = optimize(scheme)
 
     result_data = result.data["dataset1"]
     print(result_data.clp_label)


### PR DESCRIPTION
Follow up PR for #704 , which implements a more robust calculation of the `covariance_matrix` for results.

### Change summary

- 🧪 Adds benchmarks for `glotaran.analysis.optimize._create_result`
- 👌 Uses SVD of the estimated jacobian to calculate `covariance_matrix`

Not sure what was up with the calculation of the mask in the [original StackOverflow answer](https://stackoverflow.com/a/67023688/3990615)

```python
tol = np.finfo(float).eps*s[0]*max(res.jac.shape)
w = s > tol
```

So I changed it to
```python
w = s**2 > np.finfo(float).eps
```
which should be sufficient to prevent `ZeroDivisionError`.

If any of you can think of a reason why the biggest singular value and the shape of the jacobian might be of importance to create a filter mask please tell me 😄 

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

