### PR TITLE
🚇Fixed starting point of benchamrks to include the 0.4.0 release

### DIFF
--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -48,7 +48,7 @@ jobs:
           git remote add upstream https://github.com/glotaran/pyglotaran
           git fetch upstream
           pushd benchmark
-          asv run v0.4.0..HEAD --machine gh_action
+          asv run v0.4.0^..HEAD --machine gh_action
           asv publish
 
       - name: Checkout benchmark result repo


### PR DESCRIPTION
Looks like the starting point of `asv` is exclusive so to benchmark the `0.4.0` release commit as well as the following commits we need to start at `v0.4.0^`.

### Change summary

- `pr_benchmark`workflow now includes the `0.4.0` release commit


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
