### PR TITLE
👌 Fix pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,5 +124,6 @@ repos:
     rev: v2.1.0
     hooks:
       - id: codespell
-        files: ".py|.rst|.ipynb"
+        types: [file]
+        types_or: [python, pyi, markdown, rst]
         args: [-L doas]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,5 +125,5 @@ repos:
     hooks:
       - id: codespell
         types: [file]
-        types_or: [python, pyi, markdown, rst]
+        types_or: [python, pyi, markdown, rst, jupyter]
         args: [-L doas]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,7 +113,7 @@ repos:
     rev: "3f92957478422df87bd730abde66f089cc1ee19b"
     hooks:
       - id: rstcheck
-        additional_dependencies: [rstcheck, sphinx]
+        additional_dependencies: [sphinx]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0


### PR DESCRIPTION
 False usage of the regex might lead to false-positive matching. 'types_or' is the proper way to use pre-commit.

To get `type` of a file you have to use (identify)[https://github.com/pre-commit/identify] (dependency of `pre-commit` so it is already installed)
```console
$ identify-cli <file>
```

### Change summary

- All hooks now use `types_or` to match files

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)

