### PR TITLE
🩹 Compare benchmarks to 0.4.0 instead if upstream/main

### DIFF
--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -73,7 +73,7 @@ jobs:
 
           pr_nr = os.environ.get("PR_NR")
           diff_result = subprocess.run(
-              ["asv", "--config=benchmark/asv.conf.json", "compare", "upstream/main", "HEAD"],
+              ["asv", "--config=benchmark/asv.conf.json", "compare", "v0.4.0", "HEAD"],
               capture_output=True,
           )
           comment = f"""\


### PR DESCRIPTION
Follow up PR for #723 

### Change summary

- The benchmark comment bot now compares against 0.4.0

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)