### PR TITLE
👌 Monkeypatch 'scheme.group = True' in benchmark

### DIFF
--- a/benchmark/benchmarks/integration/ex_two_datasets/benchmark.py
+++ b/benchmark/benchmarks/integration/ex_two_datasets/benchmark.py
@@ -37,6 +37,8 @@ class IntegrationTwoDatasets:
             non_negative_least_squares=True,
             optimization_method="TrustRegionReflection",
         )
+        # monkey patch for consistent behavior after PR730
+        self.scheme.group = True  # type:ignore
         # Values extracted from a previous run of IntegrationTwoDatasets.time_optimize()
         self.problem = GroupedProblem(self.scheme)
         # pickled OptimizeResult


### PR DESCRIPTION
With the changed default behavior in PR730 , forcing `scheme.group = True` allows the benchmark to run consistently.

### Change summary

- Benchmarks will consistently do the same optimization after #730 got merged

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
