### PR TITLE
🚧 Set version to 0.5.0.dev0

### DIFF
--- a/glotaran/__init__.py
+++ b/glotaran/__init__.py
@@ -8,7 +8,7 @@ from glotaran.plugin_system.base_registry import load_plugins
 
 load_plugins()
 
-__version__ = "0.4.0"
+__version__ = "0.5.0.dev0"
 
 
 def __getattr__(attribute_name: str):


### PR DESCRIPTION
For tests to pass you will need to reinstall glotaran
```
pip install -e .
```
since the metainformation get written at install time.


### Change summary

- Changed version from `0.4.0` to `0.5.0.dev0`

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)