### PR TITLE
🧪🚇 Add integration test result validation (maintain/0.4.1)

### DIFF
--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -1,0 +1,148 @@
+""""Tests to ensure result consistency."""
+from __future__ import annotations
+
+import os
+import subprocess
+from collections import defaultdict
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING
+from warnings import warn
+
+import numpy as np
+import pytest
+import xarray as xr
+
+if TYPE_CHECKING:
+    from xarray.core.coordinates import DataArrayCoordinates
+
+
+REPO_ROOT = Path(__file__).parent.parent
+RUN_EXAMPLES_MSG = (
+    "run 'python scripts/run_examples.py run-all' in the 'pyglotaran-examples' repo root."
+)
+
+
+def get_compare_results_path() -> Path:
+    """Ensure that the comparison-results exist, are up to date and return their path."""
+    compare_result_folder = REPO_ROOT / "comparison-results"
+    if not compare_result_folder.exists():
+        example_repo = "git@github.com:glotaran/pyglotaran-examples.git"
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "-b",
+                "comparison-results",
+                example_repo,
+                compare_result_folder,
+            ]
+        )
+    if "GITHUB" not in os.environ:
+        subprocess.run(
+            ["git", "fetch", "--depth", "1", "origin", "comparison-results"],
+            cwd=compare_result_folder,
+        )
+        subprocess.run(
+            ["git", "reset", "--hard", "origin/comparison-results"], cwd=compare_result_folder
+        )
+    return compare_result_folder
+
+
+def get_current_result_path() -> Path:
+    """Get the path of the current results."""
+    local_path = Path.home() / "pyglotaran_examples_results"
+    ci_path = REPO_ROOT / "comparison-results-current"
+    if local_path.exists():
+        return local_path
+    elif ci_path.exists():
+        return ci_path
+    else:
+        raise ValueError(f"No current results present, {RUN_EXAMPLES_MSG}")
+
+
+def coord_test(
+    compare_coords: DataArrayCoordinates,
+    current_coords: DataArrayCoordinates,
+    exact_match=False,
+):
+    """Tests that coordinates are exactly equal if exact match or string coords or close."""
+    for compare_coord_name, compare_coord_value in compare_coords.items():
+        assert (
+            compare_coord_name in current_coords.keys()
+        ), f"Missing coordinate: {compare_coord_name!r}"
+
+        if exact_match or compare_coord_value.data.dtype == object:
+            assert np.array_equal(
+                compare_coord_value, current_coords[compare_coord_name]
+            ), "Coordinate value mismatch"
+        else:
+            assert np.allclose(
+                compare_coord_value, current_coords[compare_coord_name], rtol=1e-5
+            ), "Coordinate value mismatch"
+
+
+@lru_cache(maxsize=1)
+def map_result_files() -> dict[str, list[tuple[xr.Dataset, xr.Dataset]]]:
+    """Load all datasets and map them in a dict."""
+    result_map = defaultdict(list)
+    compare_results_path = get_compare_results_path()
+    current_result_path = get_current_result_path()
+    for result_file in compare_results_path.rglob("*.nc"):
+        key = result_file.relative_to(compare_results_path).parent.as_posix().replace("/", "_")
+        current_result_file = current_result_path / result_file.relative_to(compare_results_path)
+        if current_result_file.exists():
+            result_map[key].append(
+                (xr.open_dataset(result_file), xr.open_dataset(current_result_file))
+            )
+        else:
+            warn(
+                UserWarning(f"No current result for: {result_file.as_posix()}, {RUN_EXAMPLES_MSG}")
+            )
+    return result_map
+
+
+@pytest.mark.parametrize("result_name", map_result_files().keys())
+def test_original_data_exact_consistency(result_name):
+    """The original data need to be exactly the same."""
+    for compare_result, current_result in map_result_files()[result_name]:
+        assert np.array_equal(
+            compare_result.data.data, current_result.data.data
+        ), f"Original data mismatch: {result_name!r}"
+        coord_test(compare_result.data.coords, current_result.data.coords, exact_match=True)
+
+
+@pytest.mark.parametrize("result_name", map_result_files().keys())
+def test_result_attr_consistency(result_name):
+    """Resultdataset attributes need to be approximately the same."""
+    for compare_result, current_result in map_result_files()[result_name]:
+        for compare_attr_name, compare_attr_value in compare_result.attrs.items():
+
+            assert (
+                compare_attr_name in current_result.attrs.keys()
+            ), f"Missing result attribute: {compare_attr_name!r}"
+
+            assert np.allclose(
+                compare_attr_value, current_result.attrs[compare_attr_name], rtol=1e-4
+            ), f"Result attr value mismatch: {compare_attr_name!r}"
+
+
+@pytest.mark.parametrize("result_name", map_result_files().keys())
+def test_result_data_var_consistency(result_name):
+    """Result dataset data variables need to be approximately the same."""
+    for compare_result, current_result in map_result_files()[result_name]:
+        for compare_var_name, compare_var_value in compare_result.data_vars.items():
+            if compare_var_name != "data":
+
+                assert (
+                    compare_var_name in current_result.data_vars
+                ), f"Missing data_var: {compare_var_name!r}"
+                current_data = current_result.data_vars[compare_var_name]
+
+                assert np.allclose(
+                    compare_var_value.data, current_data.data, rtol=1e-4
+                ), f"Result data_var data mismatch: {compare_var_name!r}"
+
+                coord_test(compare_var_value.coords, current_data.coords)

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -113,7 +113,7 @@ def coord_test(
             ), "Coordinate value mismatch"
         else:
             assert allclose(
-                expected_coord_value, current_coords[expected_coord_name], rtol=1e-5
+                expected_coord_value, current_coords[expected_coord_name], rtol=1e-5, print_fail=20
             ), "Coordinate value mismatch"
 
 
@@ -195,7 +195,7 @@ def test_result_parameter_consistency(
 ):
     """Optimized parameters need to be approximately the same"""
     for compare_df in map_result_parameters()[result_name]:
-        assert allclose(compare_df["expected"].values, compare_df["current"].values)
+        assert allclose(compare_df["expected"].values, compare_df["current"].values, print_fail=20)
 
 
 @pytest.mark.parametrize("result_name", map_result_data().keys())
@@ -212,7 +212,7 @@ def test_result_attr_consistency(
             ), f"Missing result attribute: {cexpected_attr_name!r}"
 
             assert allclose(
-                expected_attr_value, current.attrs[cexpected_attr_name], rtol=1e-4
+                expected_attr_value, current.attrs[cexpected_attr_name], rtol=1e-4, print_fail=20
             ), f"Result attr value mismatch: {cexpected_attr_name!r}"
 
 
@@ -232,7 +232,7 @@ def test_result_data_var_consistency(
                 current_data = current_result.data_vars[expected_var_name]
 
                 assert allclose(
-                    expected_var_value.data, current_data.data, rtol=1e-4
+                    expected_var_value.data, current_data.data, rtol=1e-4, print_fail=20
                 ), f"Result data_var data mismatch: {expected_var_name!r}"
 
                 coord_test(expected_var_value.coords, current_data.coords, allclose)

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -284,9 +284,8 @@ def test_result_data_var_consistency(
                 expected_values = expected_var_value
                 current_values = current_data
 
-                rtol = 1e-8
-
-                eps = np.finfo(float).eps
+                eps = np.finfo(np.float64).eps
+                rtol = np.finfo(np.float32).eps
                 if "singular_vectors" in expected_var_name:  # type:ignore[operator]
                     rtol = 1e-5
                     pre_fix = SVD_PATTERN.match(expected_var_name).group(  # type:ignore[operator]

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -25,6 +25,9 @@ RUN_EXAMPLES_MSG = (
     "in the 'pyglotaran-examples' repo root."
 )
 
+# in general this list should be empty, but for none stable examples this might be needed
+EXAMPLE_BLOCKLIST = ["study_transient_absorption_two_dataset_analysis_result_2d_co_co2"]
+
 
 class AllCloseFixture(Protocol):
     def __call__(
@@ -142,6 +145,8 @@ def map_result_files(file_glob_pattern: str) -> dict[str, list[tuple[Path, Path]
             .parent.as_posix()
             .replace("/", "_")
         )
+        if key in EXAMPLE_BLOCKLIST:
+            continue
         current_result_file = current_result_path / expected_result_file.relative_to(
             compare_results_path
         )

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -26,7 +26,10 @@ RUN_EXAMPLES_MSG = (
 )
 
 # in general this list should be empty, but for none stable examples this might be needed
-EXAMPLE_BLOCKLIST = ["study_transient_absorption_two_dataset_analysis_result_2d_co_co2"]
+EXAMPLE_BLOCKLIST = [
+    "study_transient_absorption_two_dataset_analysis_result_2d_co_co2",
+    "ex_spectral_guidance",
+]
 
 
 class AllCloseFixture(Protocol):

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -228,7 +228,9 @@ def test_result_parameter_consistency(
 ):
     """Optimized parameters need to be approximately the same"""
     for compare_df in map_result_parameters()[result_name]:
-        assert allclose(compare_df["expected"].values, compare_df["current"].values, print_fail=20)
+        assert allclose(
+            compare_df["expected"].values, compare_df["current"].values, print_fail=20
+        ), f"Parameter Mismatch: {compare_df.index}"
 
 
 @pytest.mark.parametrize("result_name", map_result_data().keys())
@@ -260,7 +262,10 @@ def test_result_data_var_consistency(
             if expected_var_name != "data":
 
                 # weighted_data were always calculated and now will only be calculated when weights are applied
-                if expected_var_name == "weighted_data" and expected_var_name not in current_result.data_vars:
+                if (
+                    expected_var_name == "weighted_data"
+                    and expected_var_name not in current_result.data_vars
+                ):
                     continue
 
                 assert (

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -232,7 +232,7 @@ def test_result_data_var_consistency(
                 current_data = current_result.data_vars[expected_var_name]
 
                 assert allclose(
-                    expected_var_value.data, current_data.data, rtol=1e-4, print_fail=20
+                    expected_var_value.data, current_data.data, atol=1e-6, rtol=1e-3, print_fail=20
                 ), f"Result data_var data mismatch: {expected_var_name!r}"
 
                 coord_test(expected_var_value.coords, current_data.coords, allclose)

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -317,8 +317,8 @@ def test_result_data_var_consistency(
                 abs_diff = np.abs(expected_values - current_values)
 
                 assert allclose(
-                    abs_diff,
                     float_resolution,
+                    abs_diff,
                     atol=rtol,  # we compare the difference so atol -> rtol
                     print_fail=20,
                 ), (

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -323,7 +323,9 @@ def test_result_data_var_consistency(
                 ), (
                     f"Result data_var data mismatch: {expected_var_name!r} in {file_name!r}.\n"
                     "With sum of absolute difference: "
-                    f"{float(np.sum(abs_diff))} and shape: {expected_var_value.shape}"
+                    f"{float(np.sum(abs_diff))} and shape: {expected_var_value.shape}\n"
+                    "Mean difference: "
+                    f"{float(np.sum(abs_diff))/np.prod(expected_var_value.shape)}\n"
                 )
 
                 coord_test(

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -250,8 +250,19 @@ def test_result_data_var_consistency(
                 ), f"Missing data_var: {expected_var_name!r}"
                 current_data = current_result.data_vars[expected_var_name]
 
+                abs_tol = 1e-8  # default value
+
+                # due to platform specific differences in the low level code that generates the SVD
+                # the values might differ from expected which were generated on linux
+                if "singular_vectors" in expected_var_name:  # type:ignore[operator]
+                    abs_tol = 1e-5
+
                 assert allclose(
-                    expected_var_value.data, current_data.data, atol=1e-6, rtol=1e-3, print_fail=20
+                    expected_var_value.data,
+                    current_data.data,
+                    atol=abs_tol,
+                    rtol=1e-3,
+                    print_fail=20,
                 ), f"Result data_var data mismatch: {expected_var_name!r}"
 
                 coord_test(expected_var_value.coords, current_data.coords, allclose)

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -259,6 +259,10 @@ def test_result_data_var_consistency(
         for expected_var_name, expected_var_value in expected_result.data_vars.items():
             if expected_var_name != "data":
 
+                # weighted_data were always calculated and now will only be calculated when weights are applied
+                if expected_var_name == "weighted_data" and expected_var_name not in current_result.data_vars:
+                    continue
+
                 assert (
                     expected_var_name in current_result.data_vars
                 ), f"Missing data_var: {expected_var_name!r} in {file_name!r}"

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -171,8 +171,8 @@ def data_var_test(
 
     eps = np.finfo(np.float32).eps
     rtol = 1e-5
-    # if "residual" in expected_var_name:  # type:ignore[operator]
-    #     eps = 1e-5
+    if expected_var_name.endswith("residual"):  # type:ignore[operator]
+        eps = expected_result["data"].values.max() * 1e-8
 
     if "singular_vectors" in expected_var_name:  # type:ignore[operator]
         rtol = 1e-4

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -183,6 +183,18 @@ def data_var_test(
         eps = expected_result["data"].values.max() * 1e-8
 
     if "singular_vectors" in expected_var_name:  # type:ignore[operator]
+        # Sometimes the coords in the (right) singular vectors are swapped
+        if expected_values.dims != current_values.dims:
+            warn(
+                dedent(
+                    f"""\n
+                    Dimensions transposed for {expected_var_name!r} in {file_name!r}.
+                    - expected: {expected_values.dims}
+                    - current:  {current_values.dims}
+                    """
+                )
+            )
+            expected_values = expected_values.transpose(*current_values.dims)
         rtol = 1e-4  # instead of 1e-5
         eps = 1e-5  # instead of ~1.2e-7
         pre_fix = SVD_PATTERN.match(expected_var_name).group(  # type:ignore[operator]

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -121,21 +121,22 @@ def coord_test(
     file_name: str,
     allclose: AllCloseFixture,
     exact_match=False,
+    data_var_name: str = "unknown",
 ):
     """Tests that coordinates are exactly equal if exact match or string coords or close."""
     for expected_coord_name, expected_coord_value in expected_coords.items():
         assert (
             expected_coord_name in current_coords.keys()
-        ), f"Missing coordinate: {expected_coord_name!r} in {file_name!r}"
+        ), f"Missing coordinate: {expected_coord_name!r} in {file_name!r}, data_var {data_var_name!r}"
 
         if exact_match or expected_coord_value.data.dtype == object:
             assert np.array_equal(
                 expected_coord_value, current_coords[expected_coord_name]
-            ), f"Coordinate value mismatch in {file_name!r}"
+            ), f"Coordinate value mismatch in {file_name!r}, data_var {data_var_name!r}"
         else:
             assert allclose(
                 expected_coord_value, current_coords[expected_coord_name], rtol=1e-5, print_fail=20
-            ), f"Coordinate value mismatch in {file_name!r}"
+            ), f"Coordinate value mismatch in {file_name!r}, data_var {data_var_name!r}"
 
 
 def map_result_files(file_glob_pattern: str) -> dict[str, list[tuple[Path, Path]]]:
@@ -216,6 +217,7 @@ def test_original_data_exact_consistency(
             file_name,
             allclose,
             exact_match=True,
+            data_var_name="data",
         )
 
 
@@ -236,15 +238,15 @@ def test_result_attr_consistency(
 ):
     """Resultdataset attributes need to be approximately the same."""
     for expected, current, file_name in map_result_data()[result_name]:
-        for cexpected_attr_name, expected_attr_value in expected.attrs.items():
+        for expected_attr_name, expected_attr_value in expected.attrs.items():
 
             assert (
-                cexpected_attr_name in current.attrs.keys()
-            ), f"Missing result attribute: {cexpected_attr_name!r} in {file_name!r}"
+                expected_attr_name in current.attrs.keys()
+            ), f"Missing result attribute: {expected_attr_name!r} in {file_name!r}"
 
             assert allclose(
-                expected_attr_value, current.attrs[cexpected_attr_name], rtol=1e-4, print_fail=20
-            ), f"Result attr value mismatch: {cexpected_attr_name!r} in {file_name!r}"
+                expected_attr_value, current.attrs[expected_attr_name], rtol=1e-4, print_fail=20
+            ), f"Result attr value mismatch: {expected_attr_name!r} in {file_name!r}"
 
 
 @pytest.mark.parametrize("result_name", map_result_data().keys())
@@ -277,4 +279,10 @@ def test_result_data_var_consistency(
                     print_fail=20,
                 ), f"Result data_var data mismatch: {expected_var_name!r} in {file_name!r}"
 
-                coord_test(expected_var_value.coords, current_data.coords, file_name, allclose)
+                coord_test(
+                    expected_var_value.coords,
+                    current_data.coords,
+                    file_name,
+                    allclose,
+                    data_var_name=expected_var_name,
+                )

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -125,9 +125,10 @@ def coord_test(
 ):
     """Tests that coordinates are exactly equal if exact match or string coords or close."""
     for expected_coord_name, expected_coord_value in expected_coords.items():
-        assert (
-            expected_coord_name in current_coords.keys()
-        ), f"Missing coordinate: {expected_coord_name!r} in {file_name!r}, data_var {data_var_name!r}"
+        assert expected_coord_name in current_coords.keys(), (
+            f"Missing coordinate: {expected_coord_name!r} in {file_name!r}, "
+            f"data_var {data_var_name!r}"
+        )
 
         if exact_match or expected_coord_value.data.dtype == object:
             assert np.array_equal(
@@ -261,7 +262,8 @@ def test_result_data_var_consistency(
         for expected_var_name, expected_var_value in expected_result.data_vars.items():
             if expected_var_name != "data":
 
-                # weighted_data were always calculated and now will only be calculated when weights are applied
+                # weighted_data were always calculated and now will only be calculated
+                # when weights are applied
                 if (
                     expected_var_name == "weighted_data"
                     and expected_var_name not in current_result.data_vars

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -67,15 +67,29 @@ def get_compare_results_path() -> Path:
             raise GitError(f"Error cloning {example_repo}:\n{proc_clone.stderr.decode()}")
     if "GITHUB" not in os.environ:
         proc_fetch = subprocess.run(
-            ["git", "fetch", "--depth", "1", "origin", "comparison-results"],
-            cwd=compare_result_folder,
+            [
+                "git",
+                "-C",
+                compare_result_folder.as_posix(),
+                "fetch",
+                "--depth",
+                "1",
+                "origin",
+                "comparison-results",
+            ],
             capture_output=True,
         )
         if proc_fetch.returncode != 0:
             raise GitError(f"Error fetching {example_repo}:\n{proc_fetch.stderr.decode()}")
         proc_reset = subprocess.run(
-            ["git", "reset", "--hard", "origin/comparison-results"],
-            cwd=compare_result_folder,
+            [
+                "git",
+                "-C",
+                compare_result_folder.as_posix(),
+                "reset",
+                "--hard",
+                "origin/comparison-results",
+            ],
             capture_output=True,
         )
         if proc_reset.returncode != 0:

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -32,6 +32,7 @@ EXAMPLE_BLOCKLIST = [
     "study_transient_absorption_two_dataset_analysis_result_2d_co_co2",
     "ex_spectral_guidance",
 ]
+ALLOW_MISSING_COORDS = {"spectral": ("matrix", "species_concentration")}
 
 SVD_PATTERN = re.compile(r"(?P<pre_fix>.+?)(right|left)_singular_vectors")
 
@@ -129,6 +130,12 @@ def coord_test(
 ) -> None:
     """Run tests that coordinates are exactly equal if string coords or close."""
     for expected_coord_name, expected_coord_value in expected_coords.items():
+        if (
+            expected_coord_name in ALLOW_MISSING_COORDS
+            and data_var_name in ALLOW_MISSING_COORDS[expected_coord_name]
+        ):
+            print(f"- allow missing coordinate: {expected_coord_name} in variable {data_var_name}")
+            continue
         assert expected_coord_name in current_coords.keys(), (
             f"Missing coordinate: {expected_coord_name!r} in {file_name!r}, "
             f"data_var {data_var_name!r}"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,12 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        example_name: [
+        example_name:
+          [
             quick-start,
             fluorescence,
-            # transient-absorption,  # Not working with 0.3.2
+            transient-absorption,
+            transient-absorption-two-datasets,
             spectral-constraints,
-            # spectral-guidance,  # Not working with 0.3.2
+            spectral-guidance,
             two-datasets,
             sim-3d-disp,
             sim-3d-nodisp,

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,5 +41,45 @@ jobs:
       - name: Upload Example Plots Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: example-results
+          name: example-plots
           path: ${{ steps.example-run.outputs.plots-path }}
+
+      - name: Upload Example Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: example-results
+          path: ~/pyglotaran_examples_results
+
+  compare-results:
+    name: Compare Results
+    runs-on: ubuntu-latest
+    needs: [run-examples]
+    steps:
+      - name: Checkout glotaran
+        uses: actions/checkout@v2
+
+      - name: Checkout compare results
+        uses: actions/checkout@v2
+        with:
+          repository: "glotaran/pyglotaran-examples"
+          ref: comparison-results
+          path: comparison-results
+
+      - name: Download result artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: example-results
+          path: comparison-results-current
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          pip install xarray pytest netCDF4
+
+      - name: Compare Results
+        run: |
+          python -m pytest .github/test_result_consistency.py -vv

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,6 +73,16 @@ jobs:
           name: example-results
           path: comparison-results-current
 
+      - name: Show used versions for result creation
+        run: |
+          echo "::group:: ✔️ Compare-Results"
+          echo "✔️ pyglotaran-examples commit: $(< comparison-results/example_commit_sha.txt)"
+          echo "✔️ pyglotaran commit: $(< comparison-results/pyglotaran_commit_sha.txt)"
+          echo "::endgroup::"
+          echo "::group:: ♻️ Current-Results"
+          echo "♻️ pyglotaran-examples commit: $(< comparison-results-current/example_commit_sha.txt)"
+          echo "::endgroup::"
+
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install xarray pytest netCDF4
+          pip install xarray pytest pytest-allclose netCDF4
 
       - name: Compare Results
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -84,4 +84,4 @@ jobs:
 
       - name: Compare Results
         run: |
-          python -m pytest .github/test_result_consistency.py -vv
+          python -m pytest --color=yes .github/test_result_consistency.py

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,8 @@ _summary.ps
 
 # benchmark results
 benchmark/.asv
+
+# results to validate result consistency
+# https://github.com/glotaran/pyglotaran-examples/tree/comparison-results
+comparison-results
+comparison-results-current

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -300,6 +300,32 @@ as an attribute to the parent package.
         to_be_removed_in_version="0.6.0",
     )
 
+
+Testing Result consistency
+--------------------------
+To test the consistency of results  locally you need to clone the
+`pyglotaran-examples <https://github.com/glotaran/pyglotaran-examples>`_
+and run them::
+
+    $ git clone https://github.com/glotaran/pyglotaran-examples
+    $ cd pyglotaran-examples
+    $ python scripts/run_examples.py run-all --headless
+
+.. note::
+    Make sure you got the the latest version (``git pull``) and are
+    on the correct branch for both ``pyglotaran`` and ``pyglotaran-examples``.
+
+The results from the examples will be saved in you home folder under ``pyglotaran_examples_results``.
+Those results than will be compared to the 'gold standard' defined by the maintainers.
+
+To test the result consistency run::
+
+    $ pytest .github/test_result_consistency.py
+
+If needed this will clone the `'gold standard' results <https://github.com/glotaran/pyglotaran-examples/tree/comparison-results>`_
+to the folder ``comparison-results``, update them and test your current results against them.
+
+
 Deploying
 ---------
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -30,6 +30,7 @@ pytest-cov>=2.5.1
 pytest-env>=0.6.2
 pytest-runner>=2.11.1
 pytest-benchmark>=3.1.1
+pytest-allclose>=1.0.0
 
 # code quality assurance
 flake8>=3.8.3

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,13 @@ envlist = py{38}, pre-commit, docs, docs-notebooks, docs-links
 [pytest]
 ; Uncomment the following lines to deactivate pyglotaran all plugins
 ; env =
-;     DEACTIVATE_GTA_PLUGINS=1
+    ; DEACTIVATE_GTA_PLUGINS=1
+; Uncomment "env =" and "COMPARE_RESULTS_LOCAL" and set it to a local folder
+; with results to use as a reference in lieu of the comparison-results branch
+; in the pyglotaran-examples git repository
+    ; COMPARE_RESULTS_LOCAL=~/local_results/ ; On *nix
+    ; COMPARE_RESULTS_LOCAL=%USERPROFILE%/local_results/ ; On Windows
+
 
 [flake8]
 extend-ignore = E231, E203


### PR DESCRIPTION
Right now the integration tests only show breaking API changes, but checking validity is still a manual task.
This PR adds a way to compare the results to a "gold standard" (tag, branch, commit) set by [this workflow](https://github.com/glotaran/pyglotaran-examples/actions/workflows/update_compare_results.yml) on the `pyglotaran-examples` repo.

### Change summary

- Adds numerical comparison to "gold standard" results defined by `pyglotaran-examples`

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)