### PR TITLE
🩹Fix check_deprecations not showing deprecation warnings

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -196,7 +196,7 @@ provides the test helper functions ``deprecation_warning_on_call_test_helper`` a
 Since the tests for deprecation are mainly for maintainability and not to test the
 functionality (those tests should be in the appropriate place)
 ``deprecation_warning_on_call_test_helper`` will by default just test that a
-``DeprecationWarning`` was raised and ignore all raise ``Exception`` s.
+``GlotaranApiDeprecationWarning`` was raised and ignore all raise ``Exception`` s.
 An exception to this rule is when adding back removed functionality
 (which shouldn't happen in the first place but might), which should be
 implemented in a file under ``glotaran/deprecation/modules`` and filenames should be like the

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -175,12 +175,15 @@ To make deprecations as robust as possible and give users all needed information
 to adjust their code, we provide helper functions inside the module
 :mod:`glotaran.deprecation`.
 
+.. currentmodule:: glotaran.deprecation.deprecation_utils
+
 The functions you most likely want to use are
 
 *   :func:`deprecate` for functions, methods and classes
 *   :func:`warn_deprecated` for call arguments
 *   :func:`deprecate_module_attribute` for module attributes
 *   :func:`deprecate_submodule` for modules
+*   :func:`deprecate_dict_entry` for dict entries
 
 
 Those functions not only make it easier to deprecate something, but they also check that
@@ -299,6 +302,17 @@ as an attribute to the parent package.
         new_module_name="glotaran.new_package.new_module_name",
         to_be_removed_in_version="0.6.0",
     )
+
+Deprecating dict entries
+~~~~~~~~~~~~~~~~~~~~~~~~
+The possible dict deprecation actions are:
+
+- Swapping of keys ``{"foo": 1} -> {"bar": 1}`` (done via ``swap_keys=("foo", "bar")``)
+- Replacing of matching values ``{"foo": 1} -> {"foo": 2}`` (done via ``replace_rules=({"foo": 1}, {"foo": 2})``)
+- Replacing of matching values and swapping of keys ``{"foo": 1} -> {"bar": 2}`` (done via ``replace_rules=({"foo": 1}, {"bar": 2})``)
+
+For full examples have a look at the examples from the docstring (:func:`deprecate_dict_entry`).
+
 
 Deploying
 ---------

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from glotaran.deprecation.modules.builtin_io_yml import model_spec_deprecations
 from glotaran.io import ProjectIoInterface
 from glotaran.io import load_dataset
 from glotaran.io import load_model
@@ -19,7 +20,6 @@ from glotaran.model import get_megacomplex
 from glotaran.parameter import ParameterGroup
 from glotaran.project import SavingOptions
 from glotaran.project import Scheme
-from glotaran.utils.sanitize import check_deprecations
 from glotaran.utils.sanitize import sanitize_yaml
 
 if TYPE_CHECKING:
@@ -49,7 +49,7 @@ class YmlProjectIo(ProjectIoInterface):
             with open(file_name) as f:
                 spec = yaml.safe_load(f)
 
-        check_deprecations(spec)
+        model_spec_deprecations(spec)
 
         spec = sanitize_yaml(spec)
 

--- a/glotaran/deprecation/__init__.py
+++ b/glotaran/deprecation/__init__.py
@@ -1,5 +1,6 @@
 """Deprecation helpers and place to put deprecated implementations till removing."""
 from glotaran.deprecation.deprecation_utils import deprecate
+from glotaran.deprecation.deprecation_utils import deprecate_dict_entry
 from glotaran.deprecation.deprecation_utils import deprecate_module_attribute
 from glotaran.deprecation.deprecation_utils import deprecate_submodule
 from glotaran.deprecation.deprecation_utils import warn_deprecated

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -171,8 +171,8 @@ def warn_deprecated(
         will import ``package.module.class`` and check if ``class`` has an attribute
         ``mapping``.
 
-    Warns
-    -----
+    Raises
+    ------
     OverDueDeprecation
         If the current version is greater or equal to ``end_of_life_version``.
 
@@ -270,8 +270,8 @@ def deprecate(
     DecoratedCallable
         Original function or class throwing a Deprecation warning when used.
 
-    Warns
-    -----
+    Raises
+    ------
     OverDueDeprecation
         If the current version is greater or equal to ``end_of_life_version``.
 
@@ -437,7 +437,6 @@ def deprecate_dict_entry(
     {"default-megacomplex": "decay"}
 
 
-
     .. # noqa: DAR402
     """
     dict_changed = False
@@ -519,6 +518,11 @@ def deprecate_module_attribute(
     Any
         Module attribute from its new location.
 
+    Raises
+    ------
+    OverDueDeprecation
+        If the current version is greater or equal to ``end_of_life_version``.
+
     See Also
     --------
     deprecate
@@ -547,6 +551,8 @@ def deprecate_module_attribute(
 
             raise AttributeError(f"module {__name__} has no attribute {attribute_name}")
 
+
+    .. # noqa: DAR402
     """
     module_name = ".".join(new_qual_name.split(".")[:-1])
     attribute_name = new_qual_name.split(".")[-1]
@@ -592,6 +598,11 @@ def deprecate_submodule(
     ModuleType
         Module containing
 
+    Raises
+    ------
+    OverDueDeprecation
+        If the current version is greater or equal to ``end_of_life_version``.
+
     See Also
     --------
     deprecate
@@ -613,6 +624,9 @@ def deprecate_submodule(
             new_module_name="glotaran.project.result",
             to_be_removed_in_version="0.6.0",
         )
+
+
+    .. # noqa: DAR402
     """
     new_module = import_module(new_module_name)
     deprecated_module = ModuleType(

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -37,6 +37,20 @@ class OverDueDeprecation(Exception):
     warn_deprecated
     deprecate_module_attribute
     deprecate_submodule
+    deprecate_dict_entry
+    """
+
+
+class GlotaranApiDeprecationWarning(UserWarning):
+    """Warning to give users about API changes.
+
+    See Also
+    --------
+    deprecate
+    warn_deprecated
+    deprecate_module_attribute
+    deprecate_submodule
+    deprecate_dict_entry
     """
 
 
@@ -217,7 +231,7 @@ def warn_deprecated(
     selected_indices = importable_indices[: len(selected_qual_names)]
     check_qualnames_in_tests(qual_names=selected_qual_names, importable_indices=selected_indices)
     warn(
-        DeprecationWarning(
+        GlotaranApiDeprecationWarning(
             f"Usage of {deprecated_qual_name_usage!r} was deprecated, "
             f"use {new_qual_name_usage!r} instead.\n"
             f"This usage will be an error in version: {to_be_removed_in_version!r}."

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -383,15 +383,14 @@ def deprecate_dict_entry(
     OverDueDeprecation
         If the current version is greater or equal to ``end_of_life_version``.
 
+    See Also
+    --------
+    warn_deprecated
 
     Notes
     -----
     To prevent confusion exactly one of ``replace_rules`` and ``swap_keys``
     needs to be passed.
-
-    See Also
-    --------
-    warn_deprecated
 
     Examples
     --------

--- a/glotaran/deprecation/modules/builtin_io_yml.py
+++ b/glotaran/deprecation/modules/builtin_io_yml.py
@@ -1,0 +1,87 @@
+"""Deprecation functions for the yaml parser."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from glotaran.deprecation import deprecate_dict_entry
+
+if TYPE_CHECKING:
+    from typing import Any
+    from typing import MutableMapping
+
+
+def model_spec_deprecations(spec: MutableMapping[Any, Any]) -> None:
+    """Check deprecations in the model specification ``spec`` dict.
+
+    Parameters
+    ----------
+    spec : MutableMapping[Any, Any]
+        Model specification dictionary
+    """
+    load_model_stack_level = 7
+    deprecate_dict_entry(
+        dict_to_check=spec,
+        deprecated_usage="type: kinetic-spectrum",
+        new_usage="default-megacomplex: decay",
+        to_be_removed_in_version="0.7.0",
+        replace_rules=({"type": "kinetic-spectrum"}, {"default-megacomplex": "decay"}),
+        stacklevel=load_model_stack_level,
+    )
+
+    deprecate_dict_entry(
+        dict_to_check=spec,
+        deprecated_usage="type: spectrum",
+        new_usage="default-megacomplex: spectral",
+        to_be_removed_in_version="0.7.0",
+        replace_rules=({"type": "spectrum"}, {"default-megacomplex": "spectral"}),
+        stacklevel=load_model_stack_level,
+    )
+
+    deprecate_dict_entry(
+        dict_to_check=spec,
+        deprecated_usage="spectral_relations",
+        new_usage="relations",
+        to_be_removed_in_version="0.7.0",
+        swap_keys=("spectral_relations", "relations"),
+        stacklevel=load_model_stack_level,
+    )
+
+    if "relations" in spec:
+        for relation in spec["relations"]:
+            deprecate_dict_entry(
+                dict_to_check=relation,
+                deprecated_usage="compartment",
+                new_usage="source",
+                to_be_removed_in_version="0.7.0",
+                swap_keys=("compartment", "source"),
+                stacklevel=load_model_stack_level,
+            )
+
+    deprecate_dict_entry(
+        dict_to_check=spec,
+        deprecated_usage="spectral_constraints",
+        new_usage="constraints",
+        to_be_removed_in_version="0.7.0",
+        swap_keys=("spectral_constraints", "constraints"),
+        stacklevel=load_model_stack_level,
+    )
+
+    if "constraints" in spec:
+        for constraint in spec["constraints"]:
+            deprecate_dict_entry(
+                dict_to_check=constraint,
+                deprecated_usage="constraint.compartment",
+                new_usage="constraint.target",
+                to_be_removed_in_version="0.7.0",
+                swap_keys=("compartment", "target"),
+                stacklevel=load_model_stack_level,
+            )
+
+    deprecate_dict_entry(
+        dict_to_check=spec,
+        deprecated_usage="equal_area_penalties",
+        new_usage="clp_area_penalties",
+        to_be_removed_in_version="0.7.0",
+        swap_keys=("equal_area_penalties", "clp_area_penalties"),
+        stacklevel=load_model_stack_level,
+    )

--- a/glotaran/deprecation/modules/test/__init__.py
+++ b/glotaran/deprecation/modules/test/__init__.py
@@ -1,6 +1,7 @@
 """Package with deprecation tests and helper functions."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -11,6 +12,8 @@ if TYPE_CHECKING:
     from typing import Mapping
     from typing import Sequence
 
+    from _pytest.recwarn import WarningsRecorder
+
 
 def deprecation_warning_on_call_test_helper(
     deprecated_callable: Callable[..., Any],
@@ -18,7 +21,7 @@ def deprecation_warning_on_call_test_helper(
     raise_exception=False,
     args: Sequence[Any] = [],
     kwargs: Mapping[str, Any] = {},
-) -> Any:
+) -> tuple[WarningsRecorder, Any]:
     """Helperfunction to quickly test that a deprecated class or function warns.
 
     By default this ignores error when calling the function/class,
@@ -41,17 +44,24 @@ def deprecation_warning_on_call_test_helper(
 
     Returns
     -------
-    Any
-        Return value of deprecated_callable
+    tuple[WarningsRecorder, Any]
+        Tuple of the WarningsRecorder and return value of deprecated_callable
 
     Raises
     ------
     Exception
         Exception caused by deprecated_callable if raise_exception is True.
     """
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning) as record:
         try:
-            return deprecated_callable(*args, **kwargs)
-        except Exception:
+            result = deprecated_callable(*args, **kwargs)
+
+            assert len(record) >= 1
+            assert Path(record[0].filename) == Path(__file__)
+
+            return record, result
+
+        except Exception as e:
             if raise_exception:
-                raise
+                raise e
+            return record, None

--- a/glotaran/deprecation/modules/test/__init__.py
+++ b/glotaran/deprecation/modules/test/__init__.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from glotaran.deprecation.deprecation_utils import GlotaranApiDeprecationWarning
+
 if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
@@ -52,7 +54,7 @@ def deprecation_warning_on_call_test_helper(
     Exception
         Exception caused by deprecated_callable if raise_exception is True.
     """
-    with pytest.warns(DeprecationWarning) as record:
+    with pytest.warns(GlotaranApiDeprecationWarning) as record:
         try:
             result = deprecated_callable(*args, **kwargs)
 

--- a/glotaran/deprecation/modules/test/test_builtin_io_yml.py
+++ b/glotaran/deprecation/modules/test/test_builtin_io_yml.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from textwrap import dedent
+from typing import TYPE_CHECKING
+
+import pytest
+
+import glotaran.builtin.io.yml.yml as yml_module
+from glotaran.io import load_model
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+@pytest.mark.parametrize(
+    "model_yml_str, expected_nr_of_warnings, expected_key, expected_value",
+    (
+        ("type: kinetic-spectrum", 1, "default-megacomplex", "decay"),
+        ("type: spectrum", 1, "default-megacomplex", "spectral"),
+        (
+            dedent(
+                """
+                spectral_relations:
+                    - compartment: s1
+                    - compartment: s2
+                """
+            ),
+            3,
+            "relations",
+            [{"source": "s1"}, {"source": "s2"}],
+        ),
+        (
+            dedent(
+                """
+                equal_area_penalties:
+                    - type: equal_area
+                """
+            ),
+            1,
+            "clp_area_penalties",
+            [{"type": "equal_area"}],
+        ),
+    ),
+    ids=("type: kinetic-spectrum", "type: spectrum", "spectral_relations", "equal_area_penalties"),
+)
+def test_model_spec_deprecations(
+    monkeypatch: MonkeyPatch,
+    model_yml_str: str,
+    expected_nr_of_warnings: int,
+    expected_key: str,
+    expected_value: Any,
+):
+    """Warning gets emitted by load_model"""
+    warnings.simplefilter("always", DeprecationWarning)
+    return_dicts = []
+    with monkeypatch.context() as m:
+        m.setattr(yml_module, "sanitize_yaml", lambda spec: return_dicts.append(spec))
+        with pytest.warns(DeprecationWarning) as record:
+            try:
+                load_model(model_yml_str, format_name="yml_str")
+            except Exception:
+                pass
+
+            return_dict = return_dicts[0]
+
+            assert expected_key in return_dict
+            assert return_dict[expected_key] == expected_value
+
+            assert len(record) == expected_nr_of_warnings
+            assert Path(record[0].filename) == Path(__file__)

--- a/glotaran/deprecation/modules/test/test_builtin_io_yml.py
+++ b/glotaran/deprecation/modules/test/test_builtin_io_yml.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import warnings
-from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
 
 import glotaran.builtin.io.yml.yml as yml_module
+from glotaran.deprecation.modules.test import deprecation_warning_on_call_test_helper
 from glotaran.io import load_model
 
 if TYPE_CHECKING:
@@ -59,16 +59,13 @@ def test_model_spec_deprecations(
     return_dicts = []
     with monkeypatch.context() as m:
         m.setattr(yml_module, "sanitize_yaml", lambda spec: return_dicts.append(spec))
-        with pytest.warns(DeprecationWarning) as record:
-            try:
-                load_model(model_yml_str, format_name="yml_str")
-            except Exception:
-                pass
+        record, _ = deprecation_warning_on_call_test_helper(
+            load_model, args=(model_yml_str,), kwargs={"format_name": "yml_str"}
+        )
 
-            return_dict = return_dicts[0]
+        return_dict = return_dicts[0]
 
-            assert expected_key in return_dict
-            assert return_dict[expected_key] == expected_value
+        assert expected_key in return_dict
+        assert return_dict[expected_key] == expected_value
 
-            assert len(record) == expected_nr_of_warnings
-            assert Path(record[0].filename) == Path(__file__)
+        assert len(record) == expected_nr_of_warnings

--- a/glotaran/deprecation/modules/test/test_builtin_io_yml.py
+++ b/glotaran/deprecation/modules/test/test_builtin_io_yml.py
@@ -36,6 +36,18 @@ if TYPE_CHECKING:
         (
             dedent(
                 """
+                spectral_constraints:
+                    - compartment: s1
+                    - compartment: s2
+                """
+            ),
+            3,
+            "constraints",
+            [{"target": "s1"}, {"target": "s2"}],
+        ),
+        (
+            dedent(
+                """
                 equal_area_penalties:
                     - type: equal_area
                 """
@@ -45,7 +57,13 @@ if TYPE_CHECKING:
             [{"type": "equal_area"}],
         ),
     ),
-    ids=("type: kinetic-spectrum", "type: spectrum", "spectral_relations", "equal_area_penalties"),
+    ids=(
+        "type: kinetic-spectrum",
+        "type: spectrum",
+        "spectral_relations",
+        "spectral_constraints",
+        "equal_area_penalties",
+    ),
 )
 def test_model_spec_deprecations(
     monkeypatch: MonkeyPatch,

--- a/glotaran/deprecation/modules/test/test_builtin_io_yml.py
+++ b/glotaran/deprecation/modules/test/test_builtin_io_yml.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
@@ -73,7 +72,6 @@ def test_model_spec_deprecations(
     expected_value: Any,
 ):
     """Warning gets emitted by load_model"""
-    warnings.simplefilter("always", DeprecationWarning)
     return_dicts = []
     with monkeypatch.context() as m:
         m.setattr(yml_module, "sanitize_yaml", lambda spec: return_dicts.append(spec))

--- a/glotaran/deprecation/modules/test/test_changed_imports.py
+++ b/glotaran/deprecation/modules/test/test_changed_imports.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from glotaran.deprecation.deprecation_utils import GlotaranApiDeprecationWarning
 from glotaran.deprecation.deprecation_utils import module_attribute
 from glotaran.io import load_dataset
 from glotaran.parameter import ParameterGroup
@@ -24,7 +25,7 @@ def check_recwarn(records: WarningsRecorder, warn_nr=1):
         print(record)
 
     assert len(records) == warn_nr
-    assert records[0].category == DeprecationWarning
+    assert records[0].category == GlotaranApiDeprecationWarning
 
     records.clear()
 

--- a/glotaran/deprecation/modules/test/test_glotaran_root.py
+++ b/glotaran/deprecation/modules/test/test_glotaran_root.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 def dummy_warn(foo, bar=False):
-    warn(DeprecationWarning("foo"))
+    warn(DeprecationWarning("foo"), stacklevel=2)
     if not isinstance(bar, bool):
         raise ValueError("not a bool")
     return foo, bar
@@ -32,10 +32,10 @@ def dummy_no_warn(foo, bar=False):
 
 def test_deprecation_warning_on_call_test_helper():
     """Correct result passed on"""
-    result = deprecation_warning_on_call_test_helper(
+    record, result = deprecation_warning_on_call_test_helper(
         dummy_warn, args=["foo"], kwargs={"bar": True}
     )
-
+    assert len(record) == 1
     assert result == ("foo", True)
 
 
@@ -60,7 +60,7 @@ def test_read_model_from_yaml():
     type: kinetic-spectrum
     megacomplex: {}
     """
-    result = deprecation_warning_on_call_test_helper(
+    _, result = deprecation_warning_on_call_test_helper(
         read_model_from_yaml, args=[yaml], raise_exception=True
     )
 
@@ -75,7 +75,7 @@ def test_read_model_from_yaml_file(tmp_path: Path):
     """
     model_file = tmp_path / "model.yaml"
     model_file.write_text(yaml)
-    result = deprecation_warning_on_call_test_helper(
+    _, result = deprecation_warning_on_call_test_helper(
         read_model_from_yaml_file, args=[str(model_file)], raise_exception=True
     )
 
@@ -86,7 +86,7 @@ def test_read_parameters_from_csv_file(tmp_path: Path):
     """read_parameters_from_csv_file raises warning"""
     parameters_file = tmp_path / "parameters.csv"
     parameters_file.write_text("label,value\nfoo,123")
-    result = deprecation_warning_on_call_test_helper(
+    _, result = deprecation_warning_on_call_test_helper(
         read_parameters_from_csv_file,
         args=[str(parameters_file)],
         raise_exception=True,
@@ -98,7 +98,7 @@ def test_read_parameters_from_csv_file(tmp_path: Path):
 
 def test_read_parameters_from_yaml():
     """read_parameters_from_yaml raises warning"""
-    result = deprecation_warning_on_call_test_helper(
+    _, result = deprecation_warning_on_call_test_helper(
         read_parameters_from_yaml, args=["foo:\n  - 123"], raise_exception=True
     )
 
@@ -111,7 +111,7 @@ def test_read_parameters_from_yaml_file(tmp_path: Path):
     """read_parameters_from_yaml_file raises warning"""
     parameters_file = tmp_path / "parameters.yaml"
     parameters_file.write_text("foo:\n  - 123")
-    result = deprecation_warning_on_call_test_helper(
+    _, result = deprecation_warning_on_call_test_helper(
         read_parameters_from_yaml_file, args=[str(parameters_file)], raise_exception=True
     )
 

--- a/glotaran/deprecation/modules/test/test_glotaran_root.py
+++ b/glotaran/deprecation/modules/test/test_glotaran_root.py
@@ -11,6 +11,7 @@ from glotaran import read_model_from_yaml_file
 from glotaran import read_parameters_from_csv_file
 from glotaran import read_parameters_from_yaml
 from glotaran import read_parameters_from_yaml_file
+from glotaran.deprecation.deprecation_utils import GlotaranApiDeprecationWarning
 from glotaran.deprecation.modules.test import deprecation_warning_on_call_test_helper
 from glotaran.model import Model
 from glotaran.parameter import ParameterGroup
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 
 
 def dummy_warn(foo, bar=False):
-    warn(DeprecationWarning("foo"), stacklevel=2)
+    warn(GlotaranApiDeprecationWarning("foo"), stacklevel=2)
     if not isinstance(bar, bool):
         raise ValueError("not a bool")
     return foo, bar

--- a/glotaran/deprecation/modules/test/test_project_result.py
+++ b/glotaran/deprecation/modules/test/test_project_result.py
@@ -33,7 +33,7 @@ def test_Result_save_method(tmpdir: LocalPath, dummy_result: Result):  # noqa: F
 def test_Result_get_dataset_method(dummy_result: Result):  # noqa: F811
     """Result.get_dataset(dataset_label) gives correct dataset."""
 
-    record, result = deprecation_warning_on_call_test_helper(
+    _, result = deprecation_warning_on_call_test_helper(
         dummy_result.get_dataset, args=["dataset1"], raise_exception=True
     )
 

--- a/glotaran/deprecation/modules/test/test_project_result.py
+++ b/glotaran/deprecation/modules/test/test_project_result.py
@@ -33,7 +33,7 @@ def test_Result_save_method(tmpdir: LocalPath, dummy_result: Result):  # noqa: F
 def test_Result_get_dataset_method(dummy_result: Result):  # noqa: F811
     """Result.get_dataset(dataset_label) gives correct dataset."""
 
-    result = deprecation_warning_on_call_test_helper(
+    record, result = deprecation_warning_on_call_test_helper(
         dummy_result.get_dataset, args=["dataset1"], raise_exception=True
     )
 

--- a/glotaran/deprecation/modules/test/test_project_sheme.py
+++ b/glotaran/deprecation/modules/test/test_project_sheme.py
@@ -46,7 +46,7 @@ def test_Scheme_from_yaml_file_method(tmp_path: Path):
             dataset1: {dataset_path}"""
     )
 
-    result = deprecation_warning_on_call_test_helper(
+    record, result = deprecation_warning_on_call_test_helper(
         Scheme.from_yaml_file, args=[str(scheme_path)], raise_exception=True
     )
 

--- a/glotaran/deprecation/modules/test/test_project_sheme.py
+++ b/glotaran/deprecation/modules/test/test_project_sheme.py
@@ -46,7 +46,7 @@ def test_Scheme_from_yaml_file_method(tmp_path: Path):
             dataset1: {dataset_path}"""
     )
 
-    record, result = deprecation_warning_on_call_test_helper(
+    _, result = deprecation_warning_on_call_test_helper(
         Scheme.from_yaml_file, args=[str(scheme_path)], raise_exception=True
     )
 

--- a/glotaran/deprecation/test/test_deprecation_utils.py
+++ b/glotaran/deprecation/test/test_deprecation_utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import glotaran
+from glotaran.deprecation.deprecation_utils import GlotaranApiDeprecationWarning
 from glotaran.deprecation.deprecation_utils import OverDueDeprecation
 from glotaran.deprecation.deprecation_utils import deprecate
 from glotaran.deprecation.deprecation_utils import deprecate_dict_entry
@@ -84,7 +85,7 @@ def test_parse_version_errors(version_str: str):
 @pytest.mark.usefixtures("glotaran_0_3_0")
 def test_warn_deprecated():
     """Warning gets shown when all is in order."""
-    with pytest.warns(DeprecationWarning) as record:
+    with pytest.warns(GlotaranApiDeprecationWarning) as record:
         warn_deprecated(
             deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
             new_qual_name_usage=NEW_QUAL_NAME,
@@ -174,7 +175,7 @@ def test_warn_deprecated_broken_qualname_no_check(
     deprecated_qual_name_usage: str, new_qual_name_usage: str, check_qualnames: tuple[bool, bool]
 ):
     """Not checking broken imports."""
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(GlotaranApiDeprecationWarning):
         warn_deprecated(
             deprecated_qual_name_usage=deprecated_qual_name_usage,
             new_qual_name_usage=new_qual_name_usage,
@@ -186,7 +187,7 @@ def test_warn_deprecated_broken_qualname_no_check(
 @pytest.mark.usefixtures("glotaran_0_3_0")
 def test_warn_deprecated_sliced_method():
     """Slice away method for importing and check class for attribute"""
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(GlotaranApiDeprecationWarning):
         warn_deprecated(
             deprecated_qual_name_usage=(
                 "glotaran.deprecation.test.test_deprecation_utils.DummyClass.foo()"
@@ -200,7 +201,7 @@ def test_warn_deprecated_sliced_method():
 @pytest.mark.usefixtures("glotaran_0_3_0")
 def test_warn_deprecated_sliced_mapping():
     """Slice away mapping for importing and check class for attribute"""
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(GlotaranApiDeprecationWarning):
         warn_deprecated(
             deprecated_qual_name_usage=(
                 "glotaran.deprecation.test.test_deprecation_utils.DummyClass.foo['bar']"
@@ -243,7 +244,7 @@ def test_deprecated_decorator_function(recwarn: WarningsRecorder):
 
     assert dummy.__doc__ == "Dummy docstring for testing."
     assert len(recwarn) == 1
-    assert recwarn[0].category == DeprecationWarning
+    assert recwarn[0].category == GlotaranApiDeprecationWarning
     assert recwarn[0].message.args[0] == DEPRECATION_WARN_MESSAGE  # type: ignore [union-attr]
     assert Path(recwarn[0].filename) == Path(__file__)
 
@@ -274,7 +275,7 @@ def test_deprecated_decorator_class(recwarn: WarningsRecorder):
 
     assert Foo.__doc__ == "Foo class docstring for testing."
     assert len(recwarn) == 1
-    assert recwarn[0].category == DeprecationWarning
+    assert recwarn[0].category == GlotaranApiDeprecationWarning
     assert recwarn[0].message.args[0] == DEPRECATION_WARN_MESSAGE  # type: ignore [union-attr]
     assert Path(recwarn[0].filename) == Path(__file__)
 
@@ -287,7 +288,9 @@ def test_deprecated_decorator_class(recwarn: WarningsRecorder):
 def test_deprecate_dict_key_swap_keys():
     """Replace old with new key while keeping the value."""
     test_dict = {"foo": 123}
-    with pytest.warns(DeprecationWarning, match="'foo'.+was deprecated, use 'bar'") as record:
+    with pytest.warns(
+        GlotaranApiDeprecationWarning, match="'foo'.+was deprecated, use 'bar'"
+    ) as record:
         deprecate_dict_entry(
             dict_to_check=test_dict,
             deprecated_usage="foo",
@@ -309,7 +312,7 @@ def test_deprecate_dict_key_replace_rules_only_values():
     """Replace old value for key with new value."""
     test_dict = {"foo": 123}
     with pytest.warns(
-        DeprecationWarning, match="'foo: 123'.+was deprecated, use 'foo: 321'"
+        GlotaranApiDeprecationWarning, match="'foo: 123'.+was deprecated, use 'foo: 321'"
     ) as record:
         deprecate_dict_entry(
             dict_to_check=test_dict,
@@ -331,7 +334,7 @@ def test_deprecate_dict_key_replace_rules_keys_and_values():
     """Replace old with new key AND replace old value for key with new value."""
     test_dict = {"foo": 123}
     with pytest.warns(
-        DeprecationWarning, match="'foo: 123'.+was deprecated, use 'bar: 321'"
+        GlotaranApiDeprecationWarning, match="'foo: 123'.+was deprecated, use 'bar: 321'"
     ) as record:
         deprecate_dict_entry(
             dict_to_check=test_dict,
@@ -354,7 +357,9 @@ def test_deprecate_dict_key_replace_rules_keys_and_values():
 def test_deprecate_dict_key_does_not_apply_swap_keys():
     """Don't warn if the dict doesn't change because old_key didn't match"""
 
-    with pytest.warns(DeprecationWarning, match="'foo: 123'.+was deprecated, use 'foo: 321'"):
+    with pytest.warns(
+        GlotaranApiDeprecationWarning, match="'foo: 123'.+was deprecated, use 'foo: 321'"
+    ):
         deprecate_dict_entry(
             dict_to_check={"foo": 123},
             deprecated_usage="foo: 123",
@@ -377,7 +382,9 @@ def test_deprecate_dict_key_does_not_apply(
     replace_rules: tuple[Mapping[Hashable, Any], Mapping[Hashable, Any]]
 ):
     """Don't warn if the dict doesn't change because old_key or old_value didn't match"""
-    with pytest.warns(DeprecationWarning, match="'foo: 123'.+was deprecated, use 'foo: 321'"):
+    with pytest.warns(
+        GlotaranApiDeprecationWarning, match="'foo: 123'.+was deprecated, use 'foo: 321'"
+    ):
         deprecate_dict_entry(
             dict_to_check={"foo": 123},
             deprecated_usage="foo: 123",
@@ -428,7 +435,7 @@ def test_module_attribute():
 def test_deprecate_module_attribute():
     """Same code as the original import and warning"""
 
-    with pytest.warns(DeprecationWarning) as record:
+    with pytest.warns(GlotaranApiDeprecationWarning) as record:
 
         from glotaran.deprecation.test.dummy_package.deprecated_module_attribute import (
             deprecated_attribute,
@@ -450,7 +457,7 @@ def test_deprecate_submodule(recwarn: WarningsRecorder):
     )
 
     assert len(recwarn) == 1
-    assert recwarn[0].category == DeprecationWarning
+    assert recwarn[0].category == GlotaranApiDeprecationWarning
 
 
 @pytest.mark.usefixtures("glotaran_0_3_0")
@@ -462,7 +469,7 @@ def test_deprecate_submodule_from_import(recwarn: WarningsRecorder):
     )
 
     assert len(recwarn) == 1
-    assert recwarn[0].category == DeprecationWarning
+    assert recwarn[0].category == GlotaranApiDeprecationWarning
     assert Path(recwarn[0].filename) == Path(__file__)
 
 

--- a/glotaran/utils/sanitize.py
+++ b/glotaran/utils/sanitize.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from glotaran.deprecation import warn_deprecated
 from glotaran.utils.regex import RegexPattern as rp
 
 
@@ -216,83 +215,3 @@ def sanitize_parameter_list(parameter_list: list[str | float]) -> list[str | flo
             parameter_list[i] = convert_scientific_to_float(value)
 
     return parameter_list
-
-
-def check_deprecations(spec: dict):
-    """Check deprecations in a `spec` dict.
-
-    Parameters
-    ----------
-    spec : dict
-        A specification dictionary
-    """
-    if "type" in spec:
-        if spec["type"] == "kinetic-spectrum":
-            warn_deprecated(
-                deprecated_qual_name_usage="type: kinectic-spectrum",
-                new_qual_name_usage="default-megacomplex: decay",
-                to_be_removed_in_version="0.6.0",
-                check_qual_names=(False, False),
-            )
-            spec["default-megacomplex"] = "decay"
-        elif spec["type"] == "spectral":
-            warn_deprecated(
-                deprecated_qual_name_usage="type: spectral",
-                new_qual_name_usage="default-megacomplex: spectral",
-                to_be_removed_in_version="0.6.0",
-                check_qual_names=(False, False),
-            )
-            spec["default-megacomplex"] = "spectral"
-        del spec["type"]
-
-    if "spectral_relations" in spec:
-        warn_deprecated(
-            deprecated_qual_name_usage="spectral_relations",
-            new_qual_name_usage="relations",
-            to_be_removed_in_version="0.6.0",
-            check_qual_names=(False, False),
-        )
-        spec["relations"] = spec["spectral_relations"]
-        del spec["spectral_relations"]
-
-        for i, relation in enumerate(spec["relations"]):
-            if "compartment" in relation:
-                warn_deprecated(
-                    deprecated_qual_name_usage="relation.compartment",
-                    new_qual_name_usage="relation.source",
-                    to_be_removed_in_version="0.6.0",
-                    check_qual_names=(False, False),
-                )
-                relation["source"] = relation["compartment"]
-                del relation["compartment"]
-
-    if "spectral_constraints" in spec:
-        warn_deprecated(
-            deprecated_qual_name_usage="spectral_constraints",
-            new_qual_name_usage="constraints",
-            to_be_removed_in_version="0.6.0",
-            check_qual_names=(False, False),
-        )
-        spec["constraints"] = spec["spectral_constraints"]
-        del spec["spectral_constraints"]
-
-        for i, constraint in enumerate(spec["constraints"]):
-            if "compartment" in constraint:
-                warn_deprecated(
-                    deprecated_qual_name_usage="constraint.compartment",
-                    new_qual_name_usage="constraint.target",
-                    to_be_removed_in_version="0.6.0",
-                    check_qual_names=(False, False),
-                )
-                constraint["target"] = constraint["compartment"]
-                del constraint["compartment"]
-
-    if "equal_area_penalties" in spec:
-        warn_deprecated(
-            deprecated_qual_name_usage="equal_area_penalties",
-            new_qual_name_usage="clp_area_penalties",
-            to_be_removed_in_version="0.6.0",
-            check_qual_names=(False, False),
-        )
-        spec["clp_area_penalties"] = spec["equal_area_penalties"]
-        del spec["equal_area_penalties"]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist = py{38}, pre-commit, docs, docs-notebooks, docs-links
 ; Uncomment to ignore deprecation warnings coming from pyglotaran
 ; (this helps to see the warnings from dependencies)
 ; filterwarnings =
-;     ignore:.+glotaran:DeprecationWarning
+;     ignore:.+glotaran:GlotaranApiDeprecationWarning
 
 [flake8]
 extend-ignore = E231, E203


### PR DESCRIPTION
To have a smooth transition for users the changes in the model specs were facilitated by `check_deprecations`
https://github.com/glotaran/pyglotaran/blob/bef7262348b9385b5abd1b2edf260b35ebaccc8a/glotaran/utils/sanitize.py#L221
which replaces the deprecated dict keys and values of the old spec with the new ones internally and should warn the user about the changed usage.
But the deprecation warnings were [filtered by python since the stack level didn't reach "usercode" (`load_model`)](https://docs.python.org/3/library/warnings.html#default-warning-filter).

This PR fixes this and adds tests that the warning originates from `load_model`, so users will see it.

Also, instead of `DeprecationWarning` we now raise `GlotaranApiDeprecationWarning` which is a subclass of `UserWarning` so it won't be filtered by python.

### Change summary

- ✨ Added 'deprecate_dict_entry' to deprecate dict keys and/or values
- 🧹📚 Changed Warns OverDueDeprecation to Raises and added missing 
- 🩹🧪 Reimplemented check_deprecations and with deprecate_dict_entry 
- ♻️🧪 Changed deprecation_warning_on_call_test_helper to test for file 
- 📚 Added docs for deprecate_dict_entry ([link](https://pyglotaran--775.org.readthedocs.build/en/775/contributing.html#deprecating-dict-entries))
- 👌 Changed DeprecationWarning to GlotaranApiDeprecationWarning


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 📚 Adds documentation of the feature
