### PR TITLE
🔧 Fix interrogate usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
     rev: 1.4.0
     hooks:
       - id: interrogate
-        args: [-vv, --config=pyproject.toml]
+        args: [-vv, --config=pyproject.toml, glotaran]
         pass_filenames: false
 
   - repo: https://github.com/asottile/yesqa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ remove_redundant_aliases = true
 [tool.interrogate]
 exclude = ["setup.py", "docs", "*test/*", "benchmark/*"]
 ignore-init-module = true
-fail-under = 52
+fail-under = 55
 
 [tool.nbqa.addopts]
 flake8 = [


### PR DESCRIPTION
Currently the way `interrogate` is run by `pre-commit` it auto-discovers `*.py` files in the repo root.
This can lead to errors with venvs.

### Change summary

- 🩹🔧  Changed interrogate hook to only run on glotaran folder
- 👌🚧 Raised interrogate threshold for 52% to 55% (current value 56.1%)


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
