### PR TITLE
🚇 Speedup PR benchmark

### DIFF
--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -48,7 +48,8 @@ jobs:
           git remote add upstream https://github.com/glotaran/pyglotaran
           git fetch upstream
           pushd benchmark
-          asv run v0.4.0^..HEAD --machine gh_action
+          asv run v0.4.0^..v0.4.0 --machine gh_action
+          asv run HEAD^..HEAD --machine gh_action
           asv publish
 
       - name: Checkout benchmark result repo

--- a/.github/workflows/pr_benchmark_reaction.yml
+++ b/.github/workflows/pr_benchmark_reaction.yml
@@ -72,7 +72,6 @@ jobs:
           number: ${{ steps.bench_diff.outputs.pr_nr }}
           id: benchmark-comment
           message: ${{ steps.bench_diff.outputs.comment }}
-          recreate: true
 
       - name: Commit PR results
         env:


### PR DESCRIPTION
Running benchmarks on PRs takes forever to get feedback (~1h e.g. [here](https://github.com/glotaran/pyglotaran/runs/3382108255)) since it benchmarks each commit in between.
The most important information are the benchmark of the last release and the current commit before merging.
Thus we can omit running the benchmarks for all steps in between.
If more insight is needed at which specific commit in a PR a performance regression occurred it can always be run locally.


### Change summary

- Only run base compare commit (`v0.4.0`) and last `HEAD` commit on PR benchmark


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)