### PR TITLE
Improve ordering in k_matrix involved_compartments function

### DIFF
--- a/glotaran/builtin/megacomplexes/decay/k_matrix.py
+++ b/glotaran/builtin/megacomplexes/decay/k_matrix.py
@@ -39,12 +39,16 @@ class KMatrix:
 
     def involved_compartments(self) -> list[str]:
         """A list of all compartments in the Matrix."""
+        # TODO: find a better way that preserves ordering as defined in initial_concentrations
         compartments = []
         for index in self.matrix:
-            compartments.append(index[0])
-            compartments.append(index[1])
+            if index[0] not in compartments:
+                compartments.append(index[0])
+            if index[1] not in compartments:
+                compartments.append(index[1])
 
-        compartments = list(set(compartments))
+        # Don't use set, it randomly reorders the compartments.
+        # compartments = list(set(compartments))
         return compartments
 
     def combine(self, k_matrix: KMatrix) -> KMatrix:


### PR DESCRIPTION
Avoiding the use of set to improve ordering

Refactor at least guarantees better than random ordering using list(set(x))

TODO: further improve ordering to use initial_concentrations ordering

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
<!--
- [ ] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 📚 Adds documentation of the feature
-->

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #787 
