### PR TITLE
Update calls to clp_area_penalties where deprecated func is called

### DIFF
--- a/glotaran/model/clp_penalties.py
+++ b/glotaran/model/clp_penalties.py
@@ -60,7 +60,7 @@ class EqualAreaPenalty:
 
 
 def has_spectral_penalties(model: Model) -> bool:
-    return len(model.equal_area_penalties) != 0
+    return len(model.clp_area_penalties) != 0
 
 
 def apply_spectral_penalties(
@@ -74,7 +74,7 @@ def apply_spectral_penalties(
 ) -> np.ndarray:
 
     penalties = []
-    for penalty in model.equal_area_penalties:
+    for penalty in model.clp_area_penalties:
 
         penalty = penalty.fill(model, parameters)
         source_area = _get_area(


### PR DESCRIPTION
The deprecated equal_area_penalties would be called in lieu of the new clp_area_penalties function

The pyglotaran-examples have in their model still equal_area_penalties which is correctly swapped with clp_area_penalties but them model.equal_area_penalties  was still called in some places instead of model.clp_area_penalties

<!-- You can skip this if you're fixing a typo or adding an example to the showcase. -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
<!-- 
- [ ] 📚 Adds documentation of the feature
-->

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #789 
