### PR TITLE
[Backport] Improve ordering in k_matrix involved_compartments function

### DIFF
--- a/glotaran/builtin/models/kinetic_image/k_matrix.py
+++ b/glotaran/builtin/models/kinetic_image/k_matrix.py
@@ -38,12 +38,16 @@ class KMatrix:
 
     def involved_compartments(self) -> list[str]:
         """A list of all compartments in the Matrix."""
+        # TODO: find a better way that preserves ordering as defined in initial_concentrations
         compartments = []
         for index in self.matrix:
-            compartments.append(index[0])
-            compartments.append(index[1])
+            if index[0] not in compartments:
+                compartments.append(index[0])
+            if index[1] not in compartments:
+                compartments.append(index[1])
 
-        compartments = list(set(compartments))
+        # Don't use set, it randomly reorders the compartments.
+        # compartments = list(set(compartments))
         return compartments
 
     def combine(self, k_matrix: KMatrix) -> KMatrix:


### PR DESCRIPTION
Avoiding the use of set to improve ordering

Refactor at least guarantees better than random ordering using list(set(x))

Backport of a6a5a510cc2e95b8d81b32413824a59093ad5522 for improved consistency between v0.4.1 maintenance branch and staging-to-become-v0.5.0


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)

