### PR TITLE
🩹 Fix wrong deprecation replacement for spectral-model spec

### DIFF
--- a/glotaran/deprecation/modules/builtin_io_yml.py
+++ b/glotaran/deprecation/modules/builtin_io_yml.py
@@ -30,10 +30,10 @@ def model_spec_deprecations(spec: MutableMapping[Any, Any]) -> None:
 
     deprecate_dict_entry(
         dict_to_check=spec,
-        deprecated_usage="type: spectrum",
+        deprecated_usage="type: spectral-model",
         new_usage="default-megacomplex: spectral",
         to_be_removed_in_version="0.7.0",
-        replace_rules=({"type": "spectrum"}, {"default-megacomplex": "spectral"}),
+        replace_rules=({"type": "spectral-model"}, {"default-megacomplex": "spectral"}),
         stacklevel=load_model_stack_level,
     )
 

--- a/glotaran/deprecation/modules/test/test_builtin_io_yml.py
+++ b/glotaran/deprecation/modules/test/test_builtin_io_yml.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     "model_yml_str, expected_nr_of_warnings, expected_key, expected_value",
     (
         ("type: kinetic-spectrum", 1, "default-megacomplex", "decay"),
-        ("type: spectrum", 1, "default-megacomplex", "spectral"),
+        ("type: spectral-model", 1, "default-megacomplex", "spectral"),
         (
             dedent(
                 """


### PR DESCRIPTION
Follow-up PR for #775 .
The replacement wor backward compatibility (`type: spectrum` -> `default-megacomplex: spectral`) in #775 was wrong, since the old way (`v0.4.0`) to define a spectral model was `type: spectral-model`.
This error slipped since we do not yet have integration tests for spectral models/megacomplexes.

### Change summary

- Fixes broken backward compatibility for `0.4.0` spectral model specs.

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
