### PR TITLE
🩹 Fix ParameterGroup repr when created with 'from_list'

### DIFF
--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -429,14 +429,17 @@ class ParameterGroup(dict):
 
     def __repr__(self):
         """Representation used by repl and tracebacks."""
+
+        parameter_short_notations = [
+            [str(parameter.label), parameter.value] for parameter in self._parameters.values()
+        ]
         if self.label is None:
-            return f"{type(self).__name__}.from_dict({super().__repr__()})"
-        elif len(self._parameters):
-            parameter_short_notations = [
-                f"[{parameter.label!r}, {parameter.value}]"
-                for _, parameter in self._parameters.items()
-            ]
-            return f"[{', '.join(parameter_short_notations)}]"
+            if len(self._parameters) == 0:
+                return f"{type(self).__name__}.from_dict({super().__repr__()})"
+            else:
+                return f"{type(self).__name__}.from_list({parameter_short_notations})"
+        if len(self._parameters):
+            return parameter_short_notations.__repr__()
         else:
             return super().__repr__()
 

--- a/glotaran/parameter/test/test_parameter_group.py
+++ b/glotaran/parameter/test/test_parameter_group.py
@@ -69,7 +69,7 @@ def test_param_group_markdown_is_order_independent():
 
 
 def test_param_group_repr():
-    """Repr creates code to recreate the object."""
+    """Repr creates code to recreate the object with from_dict."""
     result = ParameterGroup.from_dict({"foo": {"bar": [["1", 1.0], ["2", 2.0], ["3", 3.0]]}})
     result_short = ParameterGroup.from_dict({"foo": {"bar": [1, 2, 3]}})
     expected = "ParameterGroup.from_dict({'foo': {'bar': [['1', 1.0], ['2', 2.0], ['3', 3.0]]}})"
@@ -77,6 +77,19 @@ def test_param_group_repr():
     assert result == result_short
     assert result_short.__repr__() == expected
     assert result.__repr__() == expected
+    assert result == eval(result.__repr__())
+
+
+def test_param_group_repr_from_list():
+    """Repr creates code to recreate the object with from_list."""
+    result = ParameterGroup.from_list([["1", 2.3], ["2", 3.0]])
+    result_short = ParameterGroup.from_list([2.3, 3.0])
+    expected = "ParameterGroup.from_list([['1', 2.3], ['2', 3.0]])"
+
+    assert result == result_short
+    assert result.__repr__() == expected
+    assert result_short.__repr__() == expected
+    assert result == eval(result.__repr__())
 
 
 def test_param_group_ipython_rendering():


### PR DESCRIPTION
Currently, the repr of `ParameterGroup` doesn't work properly when it is created with `from_list`.

```python
In [1]: from glotaran.parameter import ParameterGroup

In [2]: ParameterGroup.from_list([2.0,3.0])
Out[2]: ParameterGroup.from_dict({})
```

With this fix in place it looks like this:
```python
In [1]: from glotaran.parameter import ParameterGroup

In [2]: ParameterGroup.from_list([2.0,3.0])
Out[2]: ParameterGroup.from_list([['1', 2.0], ['2', 3.0]])
```

### Change summary

- 🩹 Fix ParameterGroup repr when created with 'from_list'

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 📚 Added change to changelog
