### PR TITLE
🗑️ Deprecate Model properties model_dimension and global_dimension

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -184,7 +184,7 @@ The functions you most likely want to use are
 *   :func:`deprecate_module_attribute` for module attributes
 *   :func:`deprecate_submodule` for modules
 *   :func:`deprecate_dict_entry` for dict entries
-*   :func:`raise_deprecation_error` if the original behavior can't be kept intact
+*   :func:`raise_deprecation_error` if the original behavior cannot be maintained
 
 
 Those functions not only make it easier to deprecate something, but they also check that
@@ -318,9 +318,9 @@ For full examples have a look at the examples from the docstring (:func:`depreca
 
 Deprecation Errors
 ~~~~~~~~~~~~~~~~~~
-In some cases deprecations can't have a replacement with the original behavior being kept intact.
-This will be mostly the case when at this point in time and in the object hierarchy there aren't
-enough information about the whole system available to calculate the appropriate values.
+In some cases deprecations cannot have a replacement with the original behavior maintained.
+This will be mostly the case when at this point in time and in the object hierarchy there isn't
+enough information available to calculate the appropriate values.
 Rather than using a 'dummy' value not to break the API, which could cause undefined behavior
 down the line, those cases should throw an error which informs the users about the new usage.
 In general this should only be used if it is unavoidable due to massive refactoring of the

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -184,6 +184,7 @@ The functions you most likely want to use are
 *   :func:`deprecate_module_attribute` for module attributes
 *   :func:`deprecate_submodule` for modules
 *   :func:`deprecate_dict_entry` for dict entries
+*   :func:`raise_deprecation_error` if the original behavior can't be kept intact
 
 
 Those functions not only make it easier to deprecate something, but they also check that
@@ -314,6 +315,18 @@ The possible dict deprecation actions are:
 
 For full examples have a look at the examples from the docstring (:func:`deprecate_dict_entry`).
 
+
+Deprecation Errors
+~~~~~~~~~~~~~~~~~~
+In some cases deprecations can't have a replacement with the original behavior being kept intact.
+This will be mostly the case when at this point in time and in the object hierarchy there aren't
+enough information about the whole system available to calculate the appropriate values.
+Rather than using a 'dummy' value not to break the API, which could cause undefined behavior
+down the line, those cases should throw an error which informs the users about the new usage.
+In general this should only be used if it is unavoidable due to massive refactoring of the
+internal structure and tried to avoid by any means in a reasonable context.
+
+If you have one of those rare cases you can use :func:`raise_deprecation_error`.
 
 
 Testing Result consistency

--- a/glotaran/deprecation/__init__.py
+++ b/glotaran/deprecation/__init__.py
@@ -3,4 +3,5 @@ from glotaran.deprecation.deprecation_utils import deprecate
 from glotaran.deprecation.deprecation_utils import deprecate_dict_entry
 from glotaran.deprecation.deprecation_utils import deprecate_module_attribute
 from glotaran.deprecation.deprecation_utils import deprecate_submodule
+from glotaran.deprecation.deprecation_utils import raise_deprecation_error
 from glotaran.deprecation.deprecation_utils import warn_deprecated

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -175,7 +175,7 @@ def check_overdue(deprecated_qual_name_usage: str, to_be_removed_in_version: str
     ):
         raise OverDueDeprecation(
             f"Support for {deprecated_qual_name_usage.partition('(')[0]!r} was "
-            f"supposed to be dropped in version: {to_be_removed_in_version!r}\n"
+            f"supposed to be dropped in version: {to_be_removed_in_version!r}.\n"
             f"Current version is: {glotaran_version()!r}"
         )
 

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -154,7 +154,7 @@ def check_qualnames_in_tests(qual_names: Sequence[str], importable_indices: Sequ
 
 
 def check_overdue(deprecated_qual_name_usage: str, to_be_removed_in_version: str) -> None:
-    """Check if a deprecation  is overdue being removed.
+    """Check if a deprecation is overdue for removal.
 
     Parameters
     ----------

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -25,11 +25,25 @@ DecoratedCallable = TypeVar(
 )  # decorated function or class
 
 if TYPE_CHECKING:
+    from typing import NoReturn
     from typing import Sequence
 
 
 class OverDueDeprecation(Exception):
     """Error thrown when a deprecation should have been removed.
+
+    See Also
+    --------
+    deprecate
+    warn_deprecated
+    deprecate_module_attribute
+    deprecate_submodule
+    deprecate_dict_entry
+    """
+
+
+class GlotaranDeprectedApiError(Exception):
+    """Exception raised when a deprecation has no replacement.
 
     See Also
     --------
@@ -164,6 +178,51 @@ def check_overdue(deprecated_qual_name_usage: str, to_be_removed_in_version: str
             f"supposed to be dropped in version: {to_be_removed_in_version!r}\n"
             f"Current version is: {glotaran_version()!r}"
         )
+
+
+def raise_deprecation_error(
+    *,
+    deprecated_qual_name_usage: str,
+    new_qual_name_usage: str,
+    to_be_removed_in_version: str,
+) -> NoReturn:
+    """Raise :class:`GlotaranDeprectedApiError` error, with formatted message.
+
+    This should only be used if there is no reasonable way to keep the deprecated
+    usage functional!
+
+    Parameters
+    ----------
+    deprecated_qual_name_usage : str
+        Old usage with fully qualified name e.g.:
+        ``'glotaran.read_model_from_yaml(model_yml_str)'``
+    new_qual_name_usage : str
+        New usage as fully qualified name e.g.:
+        ``'glotaran.io.load_model(model_yml_str, format_name="yml_str")'``
+    to_be_removed_in_version : str
+        Version the support for this usage will be removed.
+
+    Raises
+    ------
+    OverDueDeprecation
+        If the current version is greater or equal to ``to_be_removed_in_version``.
+    GlotaranDeprectedApiError
+        If :class:`OverDueDeprecation` wasn't raised before.
+
+
+    .. # noqa: DAR402 OverDueDeprecation
+    .. # noqa: DAR401 GlotaranDeprectedApiError
+    """
+    check_overdue(deprecated_qual_name_usage, to_be_removed_in_version)
+    message = (
+        f"Usage of {deprecated_qual_name_usage!r} was deprecated, "
+        f"use {new_qual_name_usage!r} instead.\n"
+        "It wasn't possible to restore the original behavior of this usage "
+        "(mostlikely due to an object hierarchy change)."
+        "This usage change message won't be show as of version: "
+        f"{to_be_removed_in_version!r}."
+    )
+    raise GlotaranDeprectedApiError(message)
 
 
 def warn_deprecated(

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -91,7 +91,7 @@ def parse_version(version_str: str) -> tuple[int, int, int]:
         If ``version_str`` 's first three elements can not be casted to int.
     """
     error_message = (
-        "version_str need to be a fully qualified version consisting of "
+        "version_str needs to be a fully qualified version consisting of "
         f"int parts (e.g. '0.0.1'), got {version_str!r}"
     )
     split_version = version_str.partition("-")[0].split(".")
@@ -215,7 +215,7 @@ def warn_deprecated(
     Raises
     ------
     OverDueDeprecation
-        If the current version is greater or equal to ``end_of_life_version``.
+        If the current version is greater or equal to ``to_be_removed_in_version``.
 
     See Also
     --------
@@ -308,7 +308,7 @@ def deprecate(
     Raises
     ------
     OverDueDeprecation
-        If the current version is greater or equal to ``end_of_life_version``.
+        If the current version is greater or equal to ``to_be_removed_in_version``.
 
     See Also
     --------
@@ -416,7 +416,7 @@ def deprecate_dict_entry(
     ValueError
         If both ``swap_keys`` and ``replace_rules`` are None (default) or not None.
     OverDueDeprecation
-        If the current version is greater or equal to ``end_of_life_version``.
+        If the current version is greater or equal to ``to_be_removed_in_version``.
 
     See Also
     --------
@@ -555,7 +555,7 @@ def deprecate_module_attribute(
     Raises
     ------
     OverDueDeprecation
-        If the current version is greater or equal to ``end_of_life_version``.
+        If the current version is greater or equal to ``to_be_removed_in_version``.
 
     See Also
     --------
@@ -635,7 +635,7 @@ def deprecate_submodule(
     Raises
     ------
     OverDueDeprecation
-        If the current version is greater or equal to ``end_of_life_version``.
+        If the current version is greater or equal to ``to_be_removed_in_version``.
 
     See Also
     --------

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -139,6 +139,33 @@ def check_qualnames_in_tests(qual_names: Sequence[str], importable_indices: Sequ
                 hasattr(item, qual_name_parts[-slice_index + 1])
 
 
+def check_overdue(deprecated_qual_name_usage: str, to_be_removed_in_version: str) -> None:
+    """Check if a deprecation  is overdue being removed.
+
+    Parameters
+    ----------
+    deprecated_qual_name_usage : str
+        Old usage with fully qualified name e.g.:
+        ``'glotaran.read_model_from_yaml(model_yml_str)'``
+    to_be_removed_in_version : str
+        Version the support for this usage will be removed.
+
+    Raises
+    ------
+    OverDueDeprecation
+        If the current version is greater or equal to ``to_be_removed_in_version``.
+    """
+    if (
+        parse_version(glotaran_version()) >= parse_version(to_be_removed_in_version)
+        and "dev" not in glotaran_version()
+    ):
+        raise OverDueDeprecation(
+            f"Support for {deprecated_qual_name_usage.partition('(')[0]!r} was "
+            f"supposed to be dropped in version: {to_be_removed_in_version!r}\n"
+            f"Current version is: {glotaran_version()!r}"
+        )
+
+
 def warn_deprecated(
     *,
     deprecated_qual_name_usage: str,
@@ -214,16 +241,10 @@ def warn_deprecated(
             )
             return load_model(model_path)
 
+
+    .. # noqa: DAR402
     """
-    if (
-        parse_version(glotaran_version()) >= parse_version(to_be_removed_in_version)
-        and "dev" not in glotaran_version()
-    ):
-        raise OverDueDeprecation(
-            f"Support for {deprecated_qual_name_usage.partition('(')[0]!r} was "
-            f"supposed to be dropped in version: {to_be_removed_in_version!r}\n"
-            f"Current version is: {glotaran_version()!r}"
-        )
+    check_overdue(deprecated_qual_name_usage, to_be_removed_in_version)
     qual_names = (deprecated_qual_name_usage, new_qual_name_usage)
     selected_qual_names = [
         qual_name for qual_name, check in zip(qual_names, check_qual_names) if check

--- a/glotaran/deprecation/modules/test/test_model_model.py
+++ b/glotaran/deprecation/modules/test/test_model_model.py
@@ -1,0 +1,54 @@
+"""Tests for deprecated methods in ``glotaran.model.model``."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from glotaran.deprecation.deprecation_utils import GlotaranDeprectedApiError
+from glotaran.testing.model_generators import SimpleModelGenerator
+
+if TYPE_CHECKING:
+    from glotaran.model import Model
+
+
+@pytest.fixture(scope="module")
+def dummy_model() -> Model:
+    """Minimal model instance for testing."""
+    generator = SimpleModelGenerator(
+        rates=[300e-3],
+        k_matrix="parallel",
+    )
+    return generator.model
+
+
+def test_model_model_dimension(dummy_model: Model):
+    """Raise ``GlotaranApiDeprecationWarning``."""
+    expected = (
+        "Usage of 'Model.model_dimension' was deprecated, "
+        "use \"Scheme.model_dimensions['<dataset_name>']\" instead.\n"
+        "It wasn't possible to restore the original behavior of this usage "
+        "(mostlikely due to an object hierarchy change)."
+        "This usage change message won't be show as of version: '0.7.0'."
+    )
+
+    with pytest.raises(GlotaranDeprectedApiError) as excinfo:
+        dummy_model.model_dimension
+
+    assert str(excinfo.value) == expected
+
+
+def test_model_global_dimension(dummy_model: Model):
+    """Raise ``GlotaranApiDeprecationWarning``."""
+    expected = (
+        "Usage of 'Model.global_dimension' was deprecated, "
+        "use \"Scheme.global_dimensions['<dataset_name>']\" instead.\n"
+        "It wasn't possible to restore the original behavior of this usage "
+        "(mostlikely due to an object hierarchy change)."
+        "This usage change message won't be show as of version: '0.7.0'."
+    )
+
+    with pytest.raises(GlotaranDeprectedApiError) as excinfo:
+        dummy_model.global_dimension
+
+    assert str(excinfo.value) == expected

--- a/glotaran/deprecation/test/test_deprecation_utils.py
+++ b/glotaran/deprecation/test/test_deprecation_utils.py
@@ -40,15 +40,15 @@ DEPRECATION_WARN_MESSAGE = (
     "instead.\nThis usage will be an error in version: '0.6.0'."
 )
 DEPRECATION_ERROR_MESSAGE = (
-    "Usage of 'glotaran.deprecation.deprecation_utils' was deprecated, "
+    "Usage of 'glotaran.deprecation.deprecation_utils.parse_version(version_str)' was deprecated, "
     "use 'glotaran.deprecation.deprecation_utils.check_qualnames_in_tests(qualnames)' instead.\n"
     "It wasn't possible to restore the original behavior of this usage "
     "(mostlikely due to an object hierarchy change)."
     "This usage change message won't be show as of version: '0.6.0'."
 )
 OVERDUE_ERROR_MESSAGE = (
-    "Support for 'glotaran.read_model_from_yaml' was supposed "
-    "to be dropped in version: '0.6.0'.\n"
+    "Support for 'glotaran.deprecation.deprecation_utils.parse_version' "
+    "was supposed to be dropped in version: '0.6.0'.\n"
     "Current version is: '1.0.0'"
 )
 
@@ -118,49 +118,37 @@ def test_check_overdue_no_raise(monkeypatch: MonkeyPatch):
 @pytest.mark.usefixtures("glotaran_1_0_0")
 def test_check_overdue_raises(monkeypatch: MonkeyPatch):
     """Current version is equal or bigger than drop_version."""
-    with pytest.raises(OverDueDeprecation) as record:
+    with pytest.raises(OverDueDeprecation) as excinfo:
         check_overdue(
             deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
             to_be_removed_in_version="0.6.0",
         )
 
-        assert len(record) == 1  # type: ignore [arg-type]
-        expected = OVERDUE_ERROR_MESSAGE
-
-        assert record[0].message.args[0] == expected  # type: ignore [index]
-        assert Path(record[0].filename) == Path(__file__)  # type: ignore [index]
+    assert str(excinfo.value) == OVERDUE_ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures("glotaran_0_3_0")
 def test_raise_deprecation_error(monkeypatch: MonkeyPatch):
     """Current version smaller then drop_version."""
-    with pytest.raises(GlotaranDeprectedApiError) as record:
+    with pytest.raises(GlotaranDeprectedApiError) as excinfo:
         raise_deprecation_error(
             deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
             new_qual_name_usage=NEW_QUAL_NAME,
             to_be_removed_in_version="0.6.0",
         )
-
-        assert len(record) == 1  # type: ignore [arg-type]
-
-        assert record[0].message.args[0] == DEPRECATION_ERROR_MESSAGE  # type: ignore [index]
-        assert Path(record[0].filename) == Path(__file__)  # type: ignore [index]
+    assert str(excinfo.value) == DEPRECATION_ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures("glotaran_1_0_0")
 def test_raise_deprecation_error_overdue(monkeypatch: MonkeyPatch):
     """Current version is equal or bigger than drop_version."""
-    with pytest.raises(OverDueDeprecation) as record:
+    with pytest.raises(OverDueDeprecation) as excinfo:
         raise_deprecation_error(
             deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
             new_qual_name_usage=NEW_QUAL_NAME,
             to_be_removed_in_version="0.6.0",
         )
-
-        assert len(record) == 1  # type: ignore [arg-type]
-
-        assert record[0].message.args[0] == OVERDUE_ERROR_MESSAGE  # type: ignore [index]
-        assert Path(record[0].filename) == Path(__file__)  # type: ignore [index]
+    assert str(excinfo.value) == OVERDUE_ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures("glotaran_0_3_0")
@@ -182,17 +170,13 @@ def test_warn_deprecated():
 def test_warn_deprecated_overdue_deprecation(monkeypatch: MonkeyPatch):
     """Current version is equal or bigger than drop_version."""
 
-    with pytest.raises(OverDueDeprecation) as record:
+    with pytest.raises(OverDueDeprecation) as excinfo:
         warn_deprecated(
             deprecated_qual_name_usage=DEPRECATION_QUAL_NAME,
             new_qual_name_usage=NEW_QUAL_NAME,
             to_be_removed_in_version="0.6.0",
         )
-
-        assert len(record) == 1  # type: ignore [arg-type]
-
-        assert record[0].message.args[0] == OVERDUE_ERROR_MESSAGE  # type: ignore [index]
-        assert Path(record[0].filename) == Path(__file__)  # type: ignore [index]
+    assert str(excinfo.value) == OVERDUE_ERROR_MESSAGE
 
 
 @pytest.mark.filterwarnings("ignore:Usage")
@@ -551,19 +535,16 @@ def test_deprecate_submodule_from_import(recwarn: WarningsRecorder):
 def test_deprecate_submodule_import_error(recwarn: WarningsRecorder):
     """Raise warning when Attribute of fake module is imported"""
 
-    with pytest.raises(ImportError) as record:
+    with pytest.raises(ImportError) as excinfo:
 
         from glotaran.deprecation.test.dummy_package.deprecated_module import (  # noqa: F401
             does_not_exists,
         )
 
-        assert len(record) == 1  # type:ignore[arg-type]
-        assert record[0].message.args[0] == (  # type:ignore[index]
-            "ImportError: cannot import name 'does_not_exists' from "
-            "'glotaran.deprecation.test.deprecated_module' (unknown location)"
-        )
-        assert len(recwarn) == 0
-        assert Path(record[0].filename) == Path(__file__)  # type:ignore[index]
+    assert str(excinfo.value) == (
+        "cannot import name 'does_not_exists' from "
+        "'glotaran.deprecation.test.dummy_package.deprecated_module' (unknown location)"
+    )
 
 
 @pytest.mark.usefixtures("glotaran_0_3_0")

--- a/glotaran/deprecation/test/test_deprecation_utils.py
+++ b/glotaran/deprecation/test/test_deprecation_utils.py
@@ -53,6 +53,15 @@ def glotaran_0_3_0(monkeypatch: MonkeyPatch):
     yield
 
 
+@pytest.fixture
+def glotaran_1_0_0(monkeypatch: MonkeyPatch):
+    """Mock glotaran version to always be 1.0.0 for the test."""
+    monkeypatch.setattr(
+        glotaran.deprecation.deprecation_utils, "glotaran_version", lambda: "1.0.0"
+    )
+    yield
+
+
 def test_glotaran_version():
     """Versions are the same."""
     assert glotaran_version() == glotaran.__version__
@@ -97,11 +106,9 @@ def test_warn_deprecated():
         assert Path(record[0].filename) == Path(__file__)
 
 
+@pytest.mark.usefixtures("glotaran_1_0_0")
 def test_warn_deprecated_overdue_deprecation(monkeypatch: MonkeyPatch):
     """Current version is equal or bigger than drop_version."""
-    monkeypatch.setattr(
-        glotaran.deprecation.deprecation_utils, "glotaran_version", lambda: "1.0.0"
-    )
 
     with pytest.raises(OverDueDeprecation) as record:
         warn_deprecated(

--- a/glotaran/model/dataset_model.py
+++ b/glotaran/model/dataset_model.py
@@ -61,13 +61,13 @@ class DatasetModel:
         """Returns the dataset model's model dimension."""
         if not hasattr(self, "_model_dimension"):
             if len(self.megacomplex) == 0:
-                raise ValueError(f"No megacomplex set for dataset descriptor '{self.label}'")
+                raise ValueError(f"No megacomplex set for dataset model '{self.label}'")
             if isinstance(self.megacomplex[0], str):
-                raise ValueError(f"Dataset descriptor '{self.label}' was not filled")
+                raise ValueError(f"Dataset model '{self.label}' was not filled")
             self._model_dimension = self.megacomplex[0].dimension
             if any(self._model_dimension != m.dimension for m in self.megacomplex):
                 raise ValueError(
-                    f"Megacomplex dimensions do not match for dataset descriptor '{self.label}'."
+                    f"Megacomplex dimensions do not match for dataset model '{self.label}'."
                 )
         return self._model_dimension
 
@@ -95,7 +95,7 @@ class DatasetModel:
         if not hasattr(self, "_global_dimension"):
             if self.has_global_model():
                 if isinstance(self.global_megacomplex[0], str):
-                    raise ValueError(f"Dataset descriptor '{self.label}' was not filled")
+                    raise ValueError(f"Dataset model '{self.label}' was not filled")
                 self._global_dimension = self.global_megacomplex[0].dimension
                 if any(self._global_dimension != m.dimension for m in self.global_megacomplex):
                     raise ValueError(
@@ -106,7 +106,7 @@ class DatasetModel:
                 return next(dim for dim in self._coords if dim != self.get_model_dimension())
             else:
                 if not hasattr(self, "_data"):
-                    raise ValueError(f"Data not set for dataset descriptor '{self.label}'")
+                    raise ValueError(f"Data not set for dataset model '{self.label}'")
                 self._global_dimension = next(
                     dim for dim in self._data.data.dims if dim != self.get_model_dimension()
                 )

--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -8,6 +8,7 @@ from warnings import warn
 
 import xarray as xr
 
+from glotaran.deprecation import raise_deprecation_error
 from glotaran.model.clp_penalties import EqualAreaPenalty
 from glotaran.model.constraint import Constraint
 from glotaran.model.dataset_model import create_dataset_model_type
@@ -108,6 +109,24 @@ class Model:
                 model._add_dict_items(name, items)
 
         return model
+
+    @property
+    def model_dimension(self):
+        """Deprecated use ``Scheme.model_dimensions['<dataset_name>']`` instead"""
+        raise_deprecation_error(
+            deprecated_qual_name_usage="Model.model_dimension",
+            new_qual_name_usage=("Scheme.model_dimensions['<dataset_name>']"),
+            to_be_removed_in_version="0.7.0",
+        )
+
+    @property
+    def global_dimension(self):
+        """Deprecated use ``Scheme.global_dimensions['<dataset_name>']`` instead"""
+        raise_deprecation_error(
+            deprecated_qual_name_usage="Model.global_dimension",
+            new_qual_name_usage=("Scheme.global_dimensions['<dataset_name>']"),
+            to_be_removed_in_version="0.7.0",
+        )
 
     def _add_dict_items(self, name: str, items: dict):
 

--- a/glotaran/project/scheme.py
+++ b/glotaran/project/scheme.py
@@ -93,6 +93,28 @@ class Scheme:
         """Representation used by print and str."""
         return str(self.markdown())
 
+    @property
+    def model_dimensions(self) -> dict[str, str]:
+        """Returns the dataset model's model dimension."""
+        return {
+            dataset_name: self.model.dataset[dataset_name]
+            .fill(self.model, self.parameters)
+            .set_data(self.data[dataset_name])
+            .get_model_dimension()
+            for dataset_name in self.data
+        }
+
+    @property
+    def global_dimensions(self) -> dict[str, str]:
+        """Returns the dataset model's global dimension."""
+        return {
+            dataset_name: self.model.dataset[dataset_name]
+            .fill(self.model, self.parameters)
+            .set_data(self.data[dataset_name])
+            .get_global_dimension()
+            for dataset_name in self.data
+        }
+
     @staticmethod
     @deprecate(
         deprecated_qual_name_usage="glotaran.project.scheme.Scheme.from_yaml_file(filename)",


### PR DESCRIPTION
Currently (7c5573d4f00cdad70c9a4e4114accb5fab702fe3) the model properties `model_dimension` and `global_dimension` are just removed without any help on what to do.
Since at the scope of a newly created model there isn't enough information to keep the API intact, we will at least throw an error with the appropriate new usage information.

The easiest way to review this PR should be per commit. 🥂 

### Change summary

- ♻️ Factored out glotaran v1.0.0 mocking to a fixture
- ♻️ Factored out overdue deprecation checking to is own function
- 📚🩹 Fixed typo in error message and wrong variable name in docstrings
-  ✨ Added 'raise_deprecation_error' 
- 📚 Added docs on when to use 'raise_deprecation_error'
- 🩹 Fix false positive pytest.raises tests in test_deprecation_utils
- 📚🩹 Fixed mentioning of dataset descriptor in error messages
- ✨ Added 'model_dimensions' and 'global_dimensions' properties to Scheme
- 🗑️ Deprecated Model properties 'model_dimension' and 'global_dimension' 

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 📚 Adds documentation of the feature