### PR TITLE
📚fixed deprecated model in quickstart

### DIFF
--- a/docs/source/notebooks/quickstart/model.yaml
+++ b/docs/source/notebooks/quickstart/model.yaml
@@ -1,4 +1,4 @@
-type: kinetic-spectrum
+default-megacomplex: decay
 
 initial_concentration:
  input:


### PR DESCRIPTION
In  [quickstartdocs](https://pyglotaran.readthedocs.io/en/latest/notebooks/quickstart/quickstart.html#) this error was displayed:
```
/tmp/ipykernel_502/993879133.py:1: GlotaranApiDeprecationWarning: Usage of 'type: kinetic-spectrum' was deprecated, use 'default-megacomplex: decay' instead.
This usage will be an error in version: '0.7.0'.
  model = load_model("model.yaml")
````

### Change summary

- 📚fixed deprecated model in quickstart

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR) -->


### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 📚 Adds documentation of the feature

