### PR TITLE
🩹 Fix parameter expression parsing

### DIFF
--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -374,7 +374,7 @@ class ParameterGroup(dict):
                 value = self._evaluator(parameter.transformed_expression)
                 if not isinstance(value, (int, float)):
                     raise ValueError(
-                        f"Expression '{parameter.expression}' of parameter '{label}' evaluates to"
+                        f"Expression '{parameter.expression}' of parameter '{label}' evaluates to "
                         f"non numeric value '{value}'."
                     )
                 parameter.value = value

--- a/glotaran/parameter/test/test_parameter.py
+++ b/glotaran/parameter/test/test_parameter.py
@@ -336,6 +336,11 @@ def test_update_parameter_group_from_array():
         ("$1", "group.get('1').value"),
         ("$1-$2", "group.get('1').value-group.get('2').value"),
         ("$1-$5", "group.get('1').value-group.get('5').value"),
+        (
+            "100 - $inputs1.s1 - $inputs1.s3 - $inputs1.s8 - $inputs1.s12",
+            "100 - group.get('inputs1.s1').value - group.get('inputs1.s3').value "
+            "- group.get('inputs1.s8').value - group.get('inputs1.s12').value",
+        ),
     ],
 )
 def test_transform_expression(case):


### PR DESCRIPTION
The naive approach using `expression.replace` lead to problems when an expression for a parameter was part of another expression for a parameter.

Example:
The expression:
`"100 - $inputs1.s1 - $inputs1.s3 - $inputs1.s8 - $inputs1.s12"`
should have been transformed to:
`"100 - group.get('inputs1.s1').value - group.get('inputs1.s3').value - group.get('inputs1.s8').value - group.get('inputs1.s12').value"`
but instead was transformed to:
`"100 - group.get('inputs1.s1').value - group.get('inputs1.s3').value - group.get('inputs1.s8').value - group.get('inputs1.s1').value2"`

Since `"inputs1.s1"` partially matches `"inputs1.s12"`

I also moved the regex compiling out of the class, so it only gets executed when the module is loaded.

### Change summary

- 🩹♻️🧪 Fixed Parameter expression transformation
- 👌 Added missing space in exception text of update_parameter_expression

<!-- Documentation changes, only needed if bigger changes were made  -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
