### PR TITLE
🩹 Use a context manager when opening a nc dataset

### DIFF
--- a/glotaran/builtin/io/netCDF/netCDF.py
+++ b/glotaran/builtin/io/netCDF/netCDF.py
@@ -11,7 +11,8 @@ from glotaran.project import default_data_filters
 @register_data_io("nc")
 class NetCDFDataIo(DataIoInterface):
     def load_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
-        return xr.open_dataset(file_name)
+        with xr.open_dataset(file_name) as ds:
+            return ds.load()
 
     def save_dataset(
         self,


### PR DESCRIPTION
avoid file locking when calling xarray.open_dataset

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
<!--
- [ ] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 📚 Adds documentation of the feature
-->

### Closes issues

closes #847 
