### PR TITLE
🗑️ Deprecate ParameterGroup.to_csv

### DIFF
--- a/glotaran/builtin/io/csv/csv.py
+++ b/glotaran/builtin/io/csv/csv.py
@@ -13,6 +13,6 @@ class CsvProjectIo(ProjectIoInterface):
         df = pd.read_csv(file_name, skipinitialspace=True, na_values=["None", "none"])
         return ParameterGroup.from_dataframe(df, source=file_name)
 
-    def save_parameters(self, parameters: ParameterGroup, file_name: str):
+    def save_parameters(self, parameters: ParameterGroup, file_name: str, *, sep=","):
         """Save a :class:`ParameterGroup` to a CSV file."""
-        parameters.to_dataframe().to_csv(file_name, na_rep="None", index=False)
+        parameters.to_dataframe().to_csv(file_name, na_rep="None", index=False, sep=sep)

--- a/glotaran/deprecation/modules/test/test_parameter_parameter_group.py
+++ b/glotaran/deprecation/modules/test/test_parameter_parameter_group.py
@@ -1,0 +1,29 @@
+"""Tests for deprecated methods in ``glotaran..parameter.ParameterGroup``."""
+from pathlib import Path
+from textwrap import dedent
+
+from glotaran.deprecation.modules.test import deprecation_warning_on_call_test_helper
+from glotaran.examples.sequential import parameter
+
+
+def test_parameter_group_to_csv(tmp_path: Path):
+    """``ParameterGroup.to_csv`` raises deprecation warning and saves file."""
+    parameter_path = tmp_path / "test_parameter.csv"
+    deprecation_warning_on_call_test_helper(
+        parameter.to_csv, args=[parameter_path.as_posix()], raise_exception=True
+    )
+    expected = dedent(
+        """\
+        label,value,minimum,maximum,vary,non-negative,expression
+        j.1,1.0,-inf,inf,False,False,None
+        j.0,0.0,-inf,inf,False,False,None
+        kinetic.1,0.5,-inf,inf,True,False,None
+        kinetic.2,0.3,-inf,inf,True,False,None
+        kinetic.3,0.1,-inf,inf,True,False,None
+        irf.center,0.3,-inf,inf,True,False,None
+        irf.width,0.1,-inf,inf,True,False,None
+        """
+    )
+
+    assert parameter_path.is_file()
+    assert parameter_path.read_text() == expected

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -12,6 +12,8 @@ import numpy as np
 import pandas as pd
 from tabulate import tabulate
 
+from glotaran.deprecation import deprecate
+from glotaran.io import save_parameters
 from glotaran.parameter.parameter import Parameter
 from glotaran.utils.ipython import MarkdownStr
 
@@ -258,6 +260,35 @@ class ParameterGroup(dict):
             parameter_dict["non-negative"].append(parameter.non_negative)
             parameter_dict["expression"].append(parameter.expression)
         return pd.DataFrame(parameter_dict)
+
+    @deprecate(
+        deprecated_qual_name_usage=(
+            "glotaran.parameter.ParameterGroup.to_csv(file_name=<parameters.csv>)"
+        ),
+        new_qual_name_usage=(
+            "glotaran.io.save_parameters(parameters, "
+            'file_name=<parameters.csv>, format_name="csv")'
+        ),
+        to_be_removed_in_version="0.7.0",
+        importable_indices=(2, 1),
+    )
+    def to_csv(self, filename: str, delimiter: str = ",") -> None:
+        """Save a :class:`ParameterGroup` to a CSV file.
+
+        Warning
+        -------
+        Deprecated use
+        ``glotaran.io.save_parameters(parameters, file_name=<parameters.csv>, format_name="csv")``
+        instead.
+
+        Parameters
+        ----------
+        filename : str
+            File to write the parameter specs to.
+        delimiter : str
+            Character to separate columns., by default ","
+        """
+        save_parameters(self, file_name=filename, allow_overwrite=True, sep=delimiter)
 
     def add_parameter(self, parameter: Parameter | list[Parameter]):
         """Add a :class:`Parameter` to the group.


### PR DESCRIPTION
Properly deprecated `ParameterGroup.to_csv` which was removed in #841

### Change summary

- 🗑️ Deprecate ParameterGroup.to_csv

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #854
