### PR TITLE
🗑️ Deprecate Scheme yaml spec replaced - with _

### DIFF
--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import yaml
 
 from glotaran.deprecation.modules.builtin_io_yml import model_spec_deprecations
+from glotaran.deprecation.modules.builtin_io_yml import scheme_spec_deprecations
 from glotaran.io import ProjectIoInterface
 from glotaran.io import register_project_io
 from glotaran.io import save_result
@@ -97,6 +98,7 @@ class YmlProjectIo(ProjectIoInterface):
 
     def load_scheme(self, file_name: str) -> Scheme:
         spec = self._load_yml(file_name)
+        scheme_spec_deprecations(spec)
         file_path = Path(file_name)
         return fromdict(Scheme, spec, folder=file_path.parent)
 

--- a/glotaran/deprecation/modules/builtin_io_yml.py
+++ b/glotaran/deprecation/modules/builtin_io_yml.py
@@ -133,3 +133,32 @@ def model_spec_deprecations(spec: MutableMapping[Any, Any]) -> None:
                 swap_keys=("width_dispersion", "width_dispersion_coefficients"),
                 stacklevel=load_model_stack_level,
             )
+
+
+def scheme_spec_deprecations(spec: MutableMapping[Any, Any]) -> None:
+    """Check deprecations in the scheme specification ``spec`` dict.
+
+    Parameters
+    ----------
+    spec : MutableMapping[Any, Any]
+        Scheme specification dictionary
+    """
+    load_scheme_stack_level = 7
+
+    deprecate_dict_entry(
+        dict_to_check=spec,
+        deprecated_usage="maximum-number-function-evaluations: <number>",
+        new_usage="maximum_number_function_evaluations: <number>",
+        to_be_removed_in_version="0.7.0",
+        swap_keys=("maximum-number-function-evaluations", "maximum_number_function_evaluations"),
+        stacklevel=load_scheme_stack_level,
+    )
+
+    deprecate_dict_entry(
+        dict_to_check=spec,
+        deprecated_usage="non-negative-least-squares",
+        new_usage=("<model_file>dataset_groups.default.residual_function"),
+        to_be_removed_in_version="0.7.0",
+        swap_keys=("non-negative-least-squares", "non_negative_least_squares"),
+        stacklevel=load_scheme_stack_level,
+    )

--- a/glotaran/deprecation/modules/test/test_builtin_io_yml.py
+++ b/glotaran/deprecation/modules/test/test_builtin_io_yml.py
@@ -8,6 +8,7 @@ import pytest
 import glotaran.builtin.io.yml.yml as yml_module
 from glotaran.deprecation.modules.test import deprecation_warning_on_call_test_helper
 from glotaran.io import load_model
+from glotaran.io import load_scheme
 
 if TYPE_CHECKING:
     from typing import Any
@@ -143,3 +144,34 @@ def test_model_spec_deprecations(
         assert return_dict[expected_key] == expected_value
 
         assert len(record) == expected_nr_of_warnings
+
+
+@pytest.mark.parametrize(
+    "scheme_yml_str, expected_key, expected_value",
+    (
+        ("maximum-number-function-evaluations: 12", "maximum_number_function_evaluations", 12),
+        ("non-negative-least-squares: true", "non_negative_least_squares", True),
+    ),
+)
+def test_scheme_spec_deprecations(
+    monkeypatch: MonkeyPatch,
+    scheme_yml_str: str,
+    expected_key: str,
+    expected_value: Any,
+):
+    """Warning gets emitted by load_model"""
+    return_dicts = []
+    with monkeypatch.context() as m:
+        m.setattr(
+            yml_module, "fromdict", lambda _, spec, *args, **kwargs: return_dicts.append(spec)
+        )
+        record, _ = deprecation_warning_on_call_test_helper(
+            load_scheme, args=(scheme_yml_str,), kwargs={"format_name": "yml_str"}
+        )
+
+        return_dict = return_dicts[0]
+
+        assert expected_key in return_dict
+        assert return_dict[expected_key] == expected_value
+
+        assert len(record) == 1


### PR DESCRIPTION
Deprecate Scheme yaml spec replaced `-` with `_`.
In the case of `non-negative-least-squares` this will warn twice.
Once for using `non-negative-least-squares` and the second time for using `non_negative_least_squares` in `Scheme`.
https://github.com/glotaran/pyglotaran/blob/385006cf64949ac03ca68e46d07cc4e054fd9e7b/glotaran/project/scheme.py#L59-L77

### Change summary

- 🗑️ Deprecate Scheme yaml spec replaced - with _

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #857
