### PR TITLE
🚇🩹 Use pinned versions of dependencies to run integration CI tests 

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,6 +41,10 @@ jobs:
         uses: glotaran/pyglotaran-examples@main
         with:
           example_name: ${{ matrix.example_name }}
+      - name: Installed packages
+        if: always()
+        run: |
+          pip freeze
       - name: Upload Example Plots Artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install pyglotaran
         run: |
           pip install wheel
+          pip install -r requirements_dev.txt
           pip install .
       - name: ${{ matrix.example_name }}
         id: example-run


### PR DESCRIPTION
Currently, the integration tests CI installs the latest versions available and allowed by `pyglotaran`s `setup.cfg`. I case of a breaking update in a dependency this breaks all CI workflows, thus it is better to use the pinned versions from 'requirements_dev.txt' so only breaking changes break the CI.

An example can be seen in PR #890 and [this CI run](https://github.com/glotaran/pyglotaran/runs/4119745211?check_suite_focus=true), where the CI breaks because of a new version of `xarray` which is unrelated to the PR itself.

### Change summary

- 🚇🩹 Use pinned version of dependencies to run integration tests 
- 🚇👌 Add step to show installed packages for debugging purposes

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
