### PR TITLE
🚧 Disallow xarray versions breaking plotting in integration tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     setuptools>=41.2
     tabulate>=0.8.8
     typing_inspect>=0.7.1
-    xarray>=0.16.2
+    xarray!=0.20.0,!=0.20.1,>=0.16.2
 python_requires = >=3.8, <3.10
 setup_requires =
     setuptools>=41.2


### PR DESCRIPTION
The `0.20.0` release introduced a bug breaking plotting in integration tests (see also #892 ).
By now this [bug has been fixed](https://github.com/pydata/xarray/pull/5948) but no new version of `xarray` has yet been released, so we should disallow the breaking versions.
If a fixed version has been released we can think of raising the minimal version.

### Change summary

- 🚧 Disallow xarray versions breaking plotting in integration tests

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
