### PR TITLE
♻️ Refactor Result and Scheme loading to to use 'file' fields

### DIFF
--- a/glotaran/builtin/io/folder/folder_plugin.py
+++ b/glotaran/builtin/io/folder/folder_plugin.py
@@ -81,45 +81,39 @@ class FolderProjectIo(ProjectIoInterface):
 
         paths = []
         if saving_options.report:
-            report_file = result_folder / "result.md"
-            report_file.write_text(str(result.markdown()))
-            paths.append(report_file.as_posix())
+            report_path = result_folder / "result.md"
+            report_path.write_text(str(result.markdown()))
+            paths.append(report_path.as_posix())
 
-        result.scheme.model_file = "model.yml"
-        save_model(
-            result.scheme.model, result_folder / result.scheme.model_file, allow_overwrite=True
-        )
-        paths.append((result_folder / result.scheme.model_file).as_posix())
+        model_path = result_folder / "model.yml"
+        save_model(result.scheme.model, model_path, allow_overwrite=True)
+        paths.append(model_path.as_posix())
 
-        result.initial_parameters_file = (
-            result.scheme.parameters_file
-        ) = f"initial_parameters.{saving_options.parameter_format}"
+        initial_parameters_path = f"initial_parameters.{saving_options.parameter_format}"
         save_parameters(
             result.scheme.parameters,
-            result_folder / result.scheme.parameters_file,
+            result_folder / initial_parameters_path,
             format_name=saving_options.parameter_format,
             allow_overwrite=True,
         )
-        paths.append((result_folder / result.scheme.parameters_file).as_posix())
+        paths.append((result_folder / initial_parameters_path).as_posix())
 
-        result.optimized_parameters_file = (
-            f"optimized_parameters.{saving_options.parameter_format}"
-        )
+        optimized_parameters_path = f"optimized_parameters.{saving_options.parameter_format}"
         save_parameters(
             result.optimized_parameters,
-            result_folder / result.optimized_parameters_file,
+            result_folder / optimized_parameters_path,
             format_name=saving_options.parameter_format,
             allow_overwrite=True,
         )
-        paths.append((result_folder / result.optimized_parameters_file).as_posix())
+        paths.append((result_folder / optimized_parameters_path).as_posix())
 
-        result.scheme_file = "scheme.yml"
-        save_scheme(result.scheme, result_folder / result.scheme_file, allow_overwrite=True)
-        paths.append((result_folder / result.scheme_file).as_posix())
+        scheme_path = result_folder / "scheme.yml"
+        save_scheme(result.scheme, scheme_path, allow_overwrite=True)
+        paths.append(scheme_path.as_posix())
 
-        result.parameter_history_file = "parameter_history.csv"
-        result.parameter_history.to_csv(result_folder / result.parameter_history_file)
-        paths.append((result_folder / result.parameter_history_file).as_posix())
+        parameter_history_path = result_folder / "parameter_history.csv"
+        result.parameter_history.to_csv(parameter_history_path)
+        paths.append(parameter_history_path.as_posix())
 
         result.data_files = {
             label: f"{label}.{saving_options.data_format}" for label in result.data

--- a/glotaran/builtin/io/folder/folder_plugin.py
+++ b/glotaran/builtin/io/folder/folder_plugin.py
@@ -115,17 +115,14 @@ class FolderProjectIo(ProjectIoInterface):
         result.parameter_history.to_csv(parameter_history_path)
         paths.append(parameter_history_path.as_posix())
 
-        result.data_files = {
-            label: f"{label}.{saving_options.data_format}" for label in result.data
-        }
-
-        for label, data_file in result.data_files.items():
+        for label, dataset in result.data.items():
+            data_path = result_folder / f"{label}.{saving_options.data_format}"
             save_dataset(
-                result.data[label],
-                result_folder / data_file,
+                dataset,
+                data_path,
                 format_name=saving_options.data_format,
                 allow_overwrite=True,
             )
-            paths.append((result_folder / data_file).as_posix())
+            paths.append(data_path.as_posix())
 
         return paths

--- a/glotaran/builtin/io/yml/test/test_save_result.py
+++ b/glotaran/builtin/io/yml/test/test_save_result.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
+from glotaran import __version__
 from glotaran.io import save_result
 from glotaran.project.test.test_result import dummy_result  # noqa: F401
 
@@ -16,6 +18,25 @@ def test_save_result_yml(
     dummy_result: Result,  # noqa: F811
 ):
     """Check all files exist."""
+    expected = dedent(
+        f"""\
+        number_of_function_evaluations: 1
+        success: true
+        termination_reason: The maximum number of function evaluations is exceeded.
+        glotaran_version: {__version__}
+        free_parameter_labels:
+          - '1'
+          - '2'
+        scheme: scheme.yml
+        initial_parameters: initial_parameters.csv
+        optimized_parameters: optimized_parameters.csv
+        parameter_history: parameter_history.csv
+        data_files:
+          dataset1: dataset1.nc
+          dataset2: dataset2.nc
+          dataset3: dataset3.nc
+        """
+    )
 
     result_dir = tmp_path / "testresult"
     save_result(result_path=result_dir / "result.yml", result=dummy_result)
@@ -28,3 +49,5 @@ def test_save_result_yml(
     assert (result_dir / "dataset1.nc").exists()
     assert (result_dir / "dataset2.nc").exists()
     assert (result_dir / "dataset3.nc").exists()
+    # We can't check equality due to numerical fluctuations
+    assert expected in (result_dir / "result.yml").read_text()

--- a/glotaran/builtin/io/yml/test/test_save_result.py
+++ b/glotaran/builtin/io/yml/test/test_save_result.py
@@ -31,7 +31,7 @@ def test_save_result_yml(
         initial_parameters: initial_parameters.csv
         optimized_parameters: optimized_parameters.csv
         parameter_history: parameter_history.csv
-        data_files:
+        data:
           dataset1: dataset1.nc
           dataset2: dataset2.nc
           dataset3: dataset3.nc

--- a/glotaran/builtin/io/yml/test/test_save_scheme.py
+++ b/glotaran/builtin/io/yml/test/test_save_scheme.py
@@ -19,8 +19,8 @@ if TYPE_CHECKING:
 
 
 want = """\
-model_file: m.yml
-parameters_file: p.csv
+model: m.yml
+parameters: p.csv
 data_files:
   dataset_1: d.nc
 clp_link_tolerance: 0.0
@@ -39,8 +39,6 @@ def test_save_scheme(tmp_path: Path):
         model,
         parameter,
         {"dataset_1": dataset},
-        model_file="m.yml",
-        parameters_file="p.csv",
         data_files={"dataset_1": "d.nc"},
     )
     save_model(model, tmp_path / "m.yml")

--- a/glotaran/builtin/io/yml/test/test_save_scheme.py
+++ b/glotaran/builtin/io/yml/test/test_save_scheme.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 want = """\
 model: m.yml
 parameters: p.csv
-data_files:
+data:
   dataset_1: d.nc
 clp_link_tolerance: 0.0
 maximum_number_function_evaluations: null
@@ -35,15 +35,14 @@ result_path: null
 
 
 def test_save_scheme(tmp_path: Path):
+    save_model(model, tmp_path / "m.yml")
+    save_parameters(parameter, tmp_path / "p.csv")
+    save_dataset(dataset, tmp_path / "d.nc")
     scheme = Scheme(
         model,
         parameter,
         {"dataset_1": dataset},
-        data_files={"dataset_1": "d.nc"},
     )
-    save_model(model, tmp_path / "m.yml")
-    save_parameters(parameter, tmp_path / "p.csv")
-    save_dataset(dataset, tmp_path / "d.nc")
     scheme_path = tmp_path / "testscheme.yml"
     save_scheme(file_name=scheme_path, format_name="yml", scheme=scheme)
 

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -107,11 +107,10 @@ class YmlProjectIo(ProjectIoInterface):
     def load_scheme(self, file_name: str) -> Scheme:
         spec = self._load_yml(file_name)
         scheme_spec_deprecations(spec)
-        file_path = Path(file_name)
-        return fromdict(Scheme, spec, folder=file_path.parent)
+        return fromdict(Scheme, spec, folder=Path(file_name).parent)
 
     def save_scheme(self, scheme: Scheme, file_name: str):
-        scheme_dict = asdict(scheme)
+        scheme_dict = asdict(scheme, folder=Path(file_name).parent)
         _write_dict(file_name, scheme_dict)
 
     def load_result(self, result_path: str) -> Result:
@@ -128,7 +127,7 @@ class YmlProjectIo(ProjectIoInterface):
             :class:`Result` instance created from the saved format.
         """
         spec = self._load_yml(result_path)
-        return fromdict(Result, spec)
+        return fromdict(Result, spec, folder=Path(result_path).parent)
 
     def save_result(self, result: Result, result_path: str):
         """Write a :class:`Result` instance to a spec file.
@@ -141,10 +140,10 @@ class YmlProjectIo(ProjectIoInterface):
             Path to write the result data to.
         """
         save_result(result, Path(result_path).parent.as_posix(), format_name="folder")
-        result_dict = asdict(result)
+        result_dict = asdict(result, folder=Path(result_path).parent)
         _write_dict(result_path, result_dict)
 
-    def _load_yml(self, file_name: str) -> dict:
+    def _load_yml(self, file_name: str) -> dict[str, Any]:
         yaml = YAML()
         if self.format == "yml_str":
             spec = yaml.load(file_name)

--- a/glotaran/deprecation/modules/test/test_project_scheme.py
+++ b/glotaran/deprecation/modules/test/test_project_scheme.py
@@ -59,7 +59,7 @@ def test_scheme_from_yaml_file_method(tmp_path: Path):
         model: {model_path}
         parameters: {parameter_path}
         maximum_number_function_evaluations: 42
-        data_files:
+        data:
             dataset1: {dataset_path}"""
     )
 

--- a/glotaran/deprecation/modules/test/test_project_scheme.py
+++ b/glotaran/deprecation/modules/test/test_project_scheme.py
@@ -56,8 +56,8 @@ def test_scheme_from_yaml_file_method(tmp_path: Path):
 
     scheme_path.write_text(
         f"""
-        model_file: {model_path}
-        parameters_file: {parameter_path}
+        model: {model_path}
+        parameters: {parameter_path}
         maximum_number_function_evaluations: 42
         data_files:
             dataset1: {dataset_path}"""

--- a/glotaran/io/__init__.py
+++ b/glotaran/io/__init__.py
@@ -33,6 +33,7 @@ from glotaran.plugin_system.project_io_registration import save_result
 from glotaran.plugin_system.project_io_registration import save_scheme
 from glotaran.plugin_system.project_io_registration import set_project_plugin
 from glotaran.plugin_system.project_io_registration import show_project_io_method_help
+from glotaran.utils.io import load_datasets
 
 
 def __getattr__(attribute_name: str):

--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -10,6 +10,7 @@ from warnings import warn
 import xarray as xr
 
 from glotaran.deprecation import raise_deprecation_error
+from glotaran.io import load_model
 from glotaran.model.clp_penalties import EqualAreaPenalty
 from glotaran.model.constraint import Constraint
 from glotaran.model.dataset_group import DatasetGroup
@@ -23,6 +24,7 @@ from glotaran.model.weight import Weight
 from glotaran.parameter import Parameter
 from glotaran.parameter import ParameterGroup
 from glotaran.plugin_system.megacomplex_registration import get_megacomplex
+from glotaran.typing.protocols import FileLoadableProtocol
 from glotaran.utils.ipython import MarkdownStr
 
 default_model_items = {
@@ -42,8 +44,10 @@ default_dataset_properties = {
 }
 
 
-class Model:
+class Model(FileLoadableProtocol):
     """A base class for global analysis models."""
+
+    loader = load_model
 
     def __init__(
         self,
@@ -64,6 +68,7 @@ class Model:
         self._add_default_items_and_properties()
         self._add_megacomplexe_types()
         self._add_dataset_type()
+        self.source_path = "model.yml"
 
     @classmethod
     def from_dict(

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -13,8 +13,10 @@ import pandas as pd
 from tabulate import tabulate
 
 from glotaran.deprecation import deprecate
+from glotaran.io import load_parameters
 from glotaran.io import save_parameters
 from glotaran.parameter.parameter import Parameter
+from glotaran.typing.protocols import FileLoadableProtocol
 from glotaran.utils.ipython import MarkdownStr
 
 if TYPE_CHECKING:
@@ -28,11 +30,13 @@ class ParameterNotFoundException(Exception):
         super().__init__(f"Cannot find parameter {'.'.join(path+[label])!r}")
 
 
-class ParameterGroup(dict):
+class ParameterGroup(dict, FileLoadableProtocol):
     """Represents are group of parameters.
 
     Can contain other groups, creating a tree-like hierarchy.
     """
+
+    loader = load_parameters
 
     def __init__(self, label: str = None, root_group: ParameterGroup = None):
         """Initialize a :class:`ParameterGroup` instance with ``label``.
@@ -59,6 +63,7 @@ class ParameterGroup(dict):
             if root_group is None
             else None
         )
+        self.source_path = "parameters.csv"
         super().__init__()
 
     @classmethod

--- a/glotaran/parameter/parameter_history.py
+++ b/glotaran/parameter/parameter_history.py
@@ -1,19 +1,27 @@
 """The glotaran parameter history package."""
 from __future__ import annotations
 
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas as pd
 
 from glotaran.parameter.parameter_group import ParameterGroup
+from glotaran.typing.protocols import FileLoadableProtocol
+
+if TYPE_CHECKING:
+    from os import PathLike
 
 
-class ParameterHistory:
+class ParameterHistory(FileLoadableProtocol):
     """A class representing a history of parameters."""
 
     def __init__(self):  # noqa: D107
 
         self._parameter_labels: list[str] = []
         self._parameters: list[np.ndarray] = []
+        self.source_path = "parameter_history.csv"
 
     @classmethod
     def from_dataframe(cls, history_df: pd.DataFrame) -> ParameterHistory:
@@ -54,6 +62,8 @@ class ParameterHistory:
         """
         df = pd.read_csv(path)
         return cls.from_dataframe(df)
+
+    loader = from_csv  # type:ignore[assignment]
 
     @property
     def parameter_labels(self) -> list[str]:
@@ -102,7 +112,7 @@ class ParameterHistory:
         """
         return pd.DataFrame(self._parameters, columns=self.parameter_labels)
 
-    def to_csv(self, file_name: str, delimiter: str = ","):
+    def to_csv(self, file_name: str | PathLike[str], delimiter: str = ","):
         """Write a :class:`ParameterGroup` to a CSV file.
 
         Parameters
@@ -112,6 +122,7 @@ class ParameterHistory:
         delimiter : str
             The delimiter of the CSV file.
         """
+        self.source_path = Path(file_name).as_posix()
         self.to_dataframe().to_csv(file_name, sep=delimiter)
 
     def append(self, parameter_group: ParameterGroup):

--- a/glotaran/plugin_system/data_io_registration.py
+++ b/glotaran/plugin_system/data_io_registration.py
@@ -8,8 +8,10 @@ and causing an [override] type error in the plugins implementation.
 """
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+import xarray as xr
 from tabulate import tabulate
 
 from glotaran.io.interface import DataIoInterface
@@ -33,8 +35,6 @@ if TYPE_CHECKING:
     from typing import Any
     from typing import Callable
     from typing import Literal
-
-    import xarray as xr
 
     from glotaran.io.interface import DataLoader
     from glotaran.io.interface import DataSaver
@@ -172,7 +172,7 @@ def get_data_io(format_name: str) -> DataIoInterface:
 @not_implemented_to_value_error
 def load_dataset(
     file_name: str | PathLike[str], format_name: str = None, **kwargs: Any
-) -> xr.Dataset | xr.DataArray:
+) -> xr.Dataset:
     """Read data from a file to :xarraydoc:`Dataset` or :xarraydoc:`DataArray`.
 
     Parameters
@@ -188,11 +188,17 @@ def load_dataset(
 
     Returns
     -------
-    xr.Dataset|xr.DataArray
+    xr.Dataset
         Data loaded from the file.
     """
     io = get_data_io(format_name or inferr_file_format(file_name))
-    return io.load_dataset(str(file_name), **kwargs)  # type: ignore[call-arg]
+    dataset = io.load_dataset(str(file_name), **kwargs)  # type: ignore[call-arg]
+
+    if isinstance(dataset, xr.DataArray):
+        dataset = dataset.to_dataset(name="data")
+    dataset.attrs["loader"] = load_dataset
+    dataset.attrs["source_path"] = Path(file_name).as_posix()
+    return dataset
 
 
 @not_implemented_to_value_error
@@ -203,6 +209,7 @@ def save_dataset(
     *,
     data_filters: list[str] | None = None,
     allow_overwrite: bool = False,
+    update_source_path: bool = True,
     **kwargs: Any,
 ) -> None:
     """Save data from :xarraydoc:`Dataset` or :xarraydoc:`DataArray` to a file.
@@ -219,6 +226,9 @@ def save_dataset(
         Optional list of items in the dataset to be saved.
     allow_overwrite : bool
         Whether or not to allow overwriting existing files, by default False
+    update_source_path: bool
+        Whether or not to update the ``source_path`` attribute to ``file_name`` when saving.
+        by default True
     **kwargs : Any
         Additional keyword arguments passes to the ``write_dataset`` implementation
         of the data io plugin. If you aren't sure about those use ``get_datawriter``
@@ -226,11 +236,21 @@ def save_dataset(
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_data_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
+    if "loader" in dataset.attrs:
+        del dataset.attrs["loader"]
+    if "source_path" in dataset.attrs:
+        orig_source_path: str = dataset.attrs["source_path"]
+        del dataset.attrs["source_path"]
     io.save_dataset(  # type: ignore[call-arg]
         file_name=str(file_name),
         dataset=dataset,
         **kwargs,
     )
+    dataset.attrs["loader"] = load_dataset
+    if update_source_path is True:
+        dataset.attrs["source_path"] = Path(file_name).as_posix()
+    else:
+        dataset.attrs["source_path"] = Path(orig_source_path).as_posix()
 
 
 def get_dataloader(format_name: str) -> DataLoader:

--- a/glotaran/plugin_system/io_plugin_utils.py
+++ b/glotaran/plugin_system/io_plugin_utils.py
@@ -5,24 +5,29 @@ from __future__ import annotations
 import os
 from functools import partial
 from functools import wraps
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import Iterable
-from typing import Iterator
 from typing import TypeVar
 from typing import cast
 
 DecoratedFunc = TypeVar("DecoratedFunc", bound=Callable[..., Any])  # decorated function
 
+if TYPE_CHECKING:
+    from typing import Iterable
+    from typing import Iterator
+
+    from glotaran.typing import StrOrPath
+
 
 def inferr_file_format(
-    file_path: str | os.PathLike[str], *, needs_to_exist: bool = True, allow_folder=False
+    file_path: StrOrPath, *, needs_to_exist: bool = True, allow_folder=False
 ) -> str:
     """Inferr format of a file if it exists.
 
     Parameters
     ----------
-    file_path : str
+    file_path : StrOrPath
         Path/str to the file.
     needs_to_exist : bool
         Whether or not a file need to exists for an successful format inferring.
@@ -47,16 +52,15 @@ def inferr_file_format(
         raise ValueError(f"There is no file {file_path!r}.")
 
     _, file_format = os.path.splitext(file_path)
-    if file_format == "":
-        if allow_folder:
-            return "folder"
-        else:
-            raise ValueError(
-                f"Cannot determine format of file {file_path!r}, "
-                "please provide an explicit format."
-            )
-    else:
+    if file_format != "":
         return file_format.lstrip(".")
+
+    if allow_folder:
+        return "folder"
+    else:
+        raise ValueError(
+            f"Cannot determine format of file {file_path!r}, " "please provide an explicit format."
+        )
 
 
 def not_implemented_to_value_error(func: DecoratedFunc) -> DecoratedFunc:

--- a/glotaran/plugin_system/io_plugin_utils.py
+++ b/glotaran/plugin_system/io_plugin_utils.py
@@ -152,12 +152,10 @@ def bool_str_repr(value: Any, true_repr: str = "*", false_repr: str = "/") -> An
     bar  /  *
     ---  -  -
     """
-    # since bool is a subclass of int we can't use isinstance
-    if type(value) == bool:
-        if value:
-            return true_repr
-        else:
-            return false_repr
+    if value is True:
+        return true_repr
+    elif value is False:
+        return false_repr
     else:
         return value
 

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -9,6 +9,7 @@ and causing an [override] type error in the plugins implementation.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
@@ -232,7 +233,9 @@ def load_model(file_name: str | PathLike[str], format_name: str = None, **kwargs
         Model instance created from the file.
     """
     io = get_project_io(format_name or inferr_file_format(file_name))
-    return io.load_model(str(file_name), **kwargs)  # type: ignore[call-arg]
+    model = io.load_model(str(file_name), **kwargs)  # type: ignore[call-arg]
+    model.source_path = Path(file_name).as_posix()
+    return model
 
 
 @not_implemented_to_value_error
@@ -242,6 +245,7 @@ def save_model(
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
+    update_source_path: bool = True,
     **kwargs: Any,
 ) -> None:
     """Save a :class:`Model` instance to a spec file.
@@ -256,6 +260,9 @@ def save_model(
         Format the file should be in, if not provided it will be inferred from the file extension.
     allow_overwrite : bool
         Whether or not to allow overwriting existing files, by default False
+    update_source_path: bool
+        Whether or not to update the ``source_path`` attribute to ``file_name`` when saving.
+        by default True
     **kwargs : Any
         Additional keyword arguments passes to the ``save_model`` implementation
         of the project io plugin.
@@ -263,6 +270,8 @@ def save_model(
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
     io.save_model(file_name=str(file_name), model=model, **kwargs)  # type: ignore[call-arg]
+    if update_source_path is True:
+        model.source_path = Path(file_name).as_posix()
 
 
 @not_implemented_to_value_error
@@ -287,7 +296,9 @@ def load_parameters(
         :class:`ParameterGroup` instance created from the file.
     """
     io = get_project_io(format_name or inferr_file_format(file_name))
-    return io.load_parameters(str(file_name), **kwargs)  # type: ignore[call-arg]
+    parameters = io.load_parameters(str(file_name), **kwargs)  # type: ignore[call-arg]
+    parameters.source_path = Path(file_name).as_posix()
+    return parameters
 
 
 @not_implemented_to_value_error
@@ -297,6 +308,7 @@ def save_parameters(
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
+    update_source_path: bool = True,
     **kwargs: Any,
 ) -> None:
     """Save a :class:`ParameterGroup` instance to a spec file.
@@ -311,6 +323,9 @@ def save_parameters(
         Format the file should be in, if not provided it will be inferred from the file extension.
     allow_overwrite : bool
         Whether or not to allow overwriting existing files, by default False
+    update_source_path: bool
+        Whether or not to update the ``source_path`` attribute to ``file_name`` when saving.
+        by default True
     **kwargs : Any
         Additional keyword arguments passes to the ``save_parameters`` implementation
         of the project io plugin.
@@ -322,6 +337,8 @@ def save_parameters(
         parameters=parameters,
         **kwargs,
     )
+    if update_source_path is True:
+        parameters.source_path = Path(file_name).as_posix()
 
 
 @not_implemented_to_value_error
@@ -344,7 +361,10 @@ def load_scheme(file_name: str | PathLike[str], format_name: str = None, **kwarg
         :class:`Scheme` instance created from the file.
     """
     io = get_project_io(format_name or inferr_file_format(file_name))
-    return io.load_scheme(str(file_name), **kwargs)  # type: ignore[call-arg]
+
+    scheme = io.load_scheme(str(file_name), **kwargs)  # type: ignore[call-arg]
+    scheme.source_path = Path(file_name).as_posix()
+    return scheme
 
 
 @not_implemented_to_value_error
@@ -354,6 +374,7 @@ def save_scheme(
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
+    update_source_path: bool = True,
     **kwargs: Any,
 ) -> None:
     """Save a :class:`Scheme` instance to a spec file.
@@ -368,6 +389,9 @@ def save_scheme(
         Format the file should be in, if not provided it will be inferred from the file extension.
     allow_overwrite : bool
         Whether or not to allow overwriting existing files, by default False
+    update_source_path: bool
+        Whether or not to update the ``source_path`` attribute to ``file_name`` when saving.
+        by default True
     **kwargs : Any
         Additional keyword arguments passes to the ``save_scheme`` implementation
         of the project io plugin.
@@ -375,6 +399,8 @@ def save_scheme(
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
     io.save_scheme(file_name=str(file_name), scheme=scheme, **kwargs)  # type: ignore[call-arg]
+    if update_source_path is True:
+        scheme.source_path = Path(file_name).as_posix()
 
 
 @not_implemented_to_value_error
@@ -400,7 +426,10 @@ def load_result(
         :class:`Result` instance created from the saved format.
     """
     io = get_project_io(format_name or inferr_file_format(result_path))
-    return io.load_result(str(result_path), **kwargs)  # type: ignore[call-arg]
+
+    result = io.load_result(str(result_path), **kwargs)  # type: ignore[call-arg]
+    result.source_path = Path(result_path).as_posix()
+    return result
 
 
 @not_implemented_to_value_error
@@ -410,6 +439,7 @@ def save_result(
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
+    update_source_path: bool = True,
     **kwargs: Any,
 ) -> list[str] | None:
     """Write a :class:`Result` instance to a spec file.
@@ -425,6 +455,9 @@ def save_result(
         it will be inferred from the file extension.
     allow_overwrite : bool
         Whether or not to allow overwriting existing files, by default False
+    update_source_path: bool
+        Whether or not to update the ``source_path`` attribute to ``result_path`` when saving.
+        by default True
     **kwargs : Any
         Additional keyword arguments passes to the ``save_result`` implementation
         of the project io plugin.
@@ -438,11 +471,14 @@ def save_result(
     io = get_project_io(
         format_name or inferr_file_format(result_path, needs_to_exist=False, allow_folder=True)
     )
-    return io.save_result(  # type: ignore[call-arg]
+    paths = io.save_result(  # type: ignore[call-arg]
         result_path=str(result_path),
         result=result,
         **kwargs,
     )
+    if update_source_path is True:
+        result.source_path = Path(result_path).as_posix()
+    return paths
 
 
 def get_project_io_method(format_name: str, method_name: ProjectIoMethods) -> Callable[..., Any]:

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -32,7 +32,6 @@ from glotaran.plugin_system.io_plugin_utils import protect_from_overwrite
 from glotaran.utils.ipython import MarkdownStr
 
 if TYPE_CHECKING:
-    from os import PathLike
     from typing import Any
     from typing import Callable
     from typing import Literal
@@ -41,6 +40,7 @@ if TYPE_CHECKING:
     from glotaran.parameter import ParameterGroup
     from glotaran.project import Result
     from glotaran.project import Scheme
+    from glotaran.typing import StrOrPath
 
     ProjectIoMethods = TypeVar(
         "ProjectIoMethods",
@@ -214,12 +214,12 @@ def get_project_io(format_name: str) -> ProjectIoInterface:
 
 
 @not_implemented_to_value_error
-def load_model(file_name: str | PathLike[str], format_name: str = None, **kwargs: Any) -> Model:
+def load_model(file_name: StrOrPath, format_name: str = None, **kwargs: Any) -> Model:
     """Create a Model instance from the specs defined in a file.
 
     Parameters
     ----------
-    file_name : str | PathLike[str]
+    file_name : StrOrPath
         File containing the model specs.
     format_name : str
         Format the file is in, if not provided it will be inferred from the file extension.
@@ -233,7 +233,7 @@ def load_model(file_name: str | PathLike[str], format_name: str = None, **kwargs
         Model instance created from the file.
     """
     io = get_project_io(format_name or inferr_file_format(file_name))
-    model = io.load_model(str(file_name), **kwargs)  # type: ignore[call-arg]
+    model = io.load_model(Path(file_name).as_posix(), **kwargs)  # type: ignore[call-arg]
     model.source_path = Path(file_name).as_posix()
     return model
 
@@ -241,7 +241,7 @@ def load_model(file_name: str | PathLike[str], format_name: str = None, **kwargs
 @not_implemented_to_value_error
 def save_model(
     model: Model,
-    file_name: str | PathLike[str],
+    file_name: StrOrPath,
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -254,7 +254,7 @@ def save_model(
     ----------
     model: Model
         :class:`Model` instance to save to specs file.
-    file_name : str | PathLike[str]
+    file_name : StrOrPath
         File to write the model specs to.
     format_name : str
         Format the file should be in, if not provided it will be inferred from the file extension.
@@ -269,20 +269,22 @@ def save_model(
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
-    io.save_model(file_name=str(file_name), model=model, **kwargs)  # type: ignore[call-arg]
+    io.save_model(  # type: ignore[call-arg]
+        file_name=Path(file_name).as_posix(),
+        model=model,
+        **kwargs,
+    )
     if update_source_path is True:
         model.source_path = Path(file_name).as_posix()
 
 
 @not_implemented_to_value_error
-def load_parameters(
-    file_name: str | PathLike[str], format_name: str = None, **kwargs
-) -> ParameterGroup:
+def load_parameters(file_name: StrOrPath, format_name: str = None, **kwargs) -> ParameterGroup:
     """Create a :class:`ParameterGroup` instance from the specs defined in a file.
 
     Parameters
     ----------
-    file_name : str | PathLike[str]
+    file_name : StrOrPath
         File containing the parameter specs.
     format_name : str
         Format the file is in, if not provided it will be inferred from the file extension.
@@ -296,7 +298,10 @@ def load_parameters(
         :class:`ParameterGroup` instance created from the file.
     """
     io = get_project_io(format_name or inferr_file_format(file_name))
-    parameters = io.load_parameters(str(file_name), **kwargs)  # type: ignore[call-arg]
+    parameters = io.load_parameters(  # type: ignore[call-arg]
+        Path(file_name).as_posix(),
+        **kwargs,
+    )
     parameters.source_path = Path(file_name).as_posix()
     return parameters
 
@@ -304,7 +309,7 @@ def load_parameters(
 @not_implemented_to_value_error
 def save_parameters(
     parameters: ParameterGroup,
-    file_name: str | PathLike[str],
+    file_name: StrOrPath,
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -317,7 +322,7 @@ def save_parameters(
     ----------
     parameters : ParameterGroup
         :class:`ParameterGroup` instance to save to specs file.
-    file_name : str | PathLike[str]
+    file_name : StrOrPath
         File to write the parameter specs to.
     format_name : str
         Format the file should be in, if not provided it will be inferred from the file extension.
@@ -333,7 +338,7 @@ def save_parameters(
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
     io.save_parameters(  # type: ignore[call-arg]
-        file_name=str(file_name),
+        file_name=Path(file_name).as_posix(),
         parameters=parameters,
         **kwargs,
     )
@@ -342,12 +347,12 @@ def save_parameters(
 
 
 @not_implemented_to_value_error
-def load_scheme(file_name: str | PathLike[str], format_name: str = None, **kwargs: Any) -> Scheme:
+def load_scheme(file_name: StrOrPath, format_name: str = None, **kwargs: Any) -> Scheme:
     """Create a :class:`Scheme` instance from the specs defined in a file.
 
     Parameters
     ----------
-    file_name : str | PathLike[str]
+    file_name : StrOrPath
         File containing the parameter specs.
     format_name : str
         Format the file is in, if not provided it will be inferred from the file extension.
@@ -362,7 +367,7 @@ def load_scheme(file_name: str | PathLike[str], format_name: str = None, **kwarg
     """
     io = get_project_io(format_name or inferr_file_format(file_name))
 
-    scheme = io.load_scheme(str(file_name), **kwargs)  # type: ignore[call-arg]
+    scheme = io.load_scheme(Path(file_name).as_posix(), **kwargs)  # type: ignore[call-arg]
     scheme.source_path = Path(file_name).as_posix()
     return scheme
 
@@ -370,7 +375,7 @@ def load_scheme(file_name: str | PathLike[str], format_name: str = None, **kwarg
 @not_implemented_to_value_error
 def save_scheme(
     scheme: Scheme,
-    file_name: str | PathLike[str],
+    file_name: StrOrPath,
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -383,7 +388,7 @@ def save_scheme(
     ----------
     scheme : Scheme
         :class:`Scheme` instance to save to specs file.
-    file_name : str | PathLike[str]
+    file_name : StrOrPath
         File to write the scheme specs to.
     format_name : str
         Format the file should be in, if not provided it will be inferred from the file extension.
@@ -398,20 +403,22 @@ def save_scheme(
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
-    io.save_scheme(file_name=str(file_name), scheme=scheme, **kwargs)  # type: ignore[call-arg]
+    io.save_scheme(  # type: ignore[call-arg]
+        file_name=Path(file_name).as_posix(),
+        scheme=scheme,
+        **kwargs,
+    )
     if update_source_path is True:
         scheme.source_path = Path(file_name).as_posix()
 
 
 @not_implemented_to_value_error
-def load_result(
-    result_path: str | PathLike[str], format_name: str = None, **kwargs: Any
-) -> Result:
+def load_result(result_path: StrOrPath, format_name: str = None, **kwargs: Any) -> Result:
     """Create a :class:`Result` instance from the specs defined in a file.
 
     Parameters
     ----------
-    result_path : str | PathLike[str]
+    result_path : StrOrPath
         Path containing the result data.
     format_name : str
         Format the result is in, if not provided and it is a file
@@ -427,7 +434,7 @@ def load_result(
     """
     io = get_project_io(format_name or inferr_file_format(result_path))
 
-    result = io.load_result(str(result_path), **kwargs)  # type: ignore[call-arg]
+    result = io.load_result(Path(result_path).as_posix(), **kwargs)  # type: ignore[call-arg]
     result.source_path = Path(result_path).as_posix()
     return result
 
@@ -435,7 +442,7 @@ def load_result(
 @not_implemented_to_value_error
 def save_result(
     result: Result,
-    result_path: str | PathLike[str],
+    result_path: StrOrPath,
     format_name: str = None,
     *,
     allow_overwrite: bool = False,
@@ -448,7 +455,7 @@ def save_result(
     ----------
     result : Result
         :class:`Result` instance to write.
-    result_path : str | PathLike[str]
+    result_path : StrOrPath
         Path to write the result data to.
     format_name : str
         Format the result should be saved in, if not provided and it is a file
@@ -472,7 +479,7 @@ def save_result(
         format_name or inferr_file_format(result_path, needs_to_exist=False, allow_folder=True)
     )
     paths = io.save_result(  # type: ignore[call-arg]
-        result_path=str(result_path),
+        result_path=Path(result_path).as_posix(),
         result=result,
         **kwargs,
     )

--- a/glotaran/plugin_system/test/test_data_io_registration.py
+++ b/glotaran/plugin_system/test/test_data_io_registration.py
@@ -27,16 +27,17 @@ from glotaran.plugin_system.data_io_registration import set_data_plugin
 from glotaran.plugin_system.data_io_registration import show_data_io_method_help
 
 if TYPE_CHECKING:
-    from os import PathLike
     from typing import Any
 
     from _pytest.capture import CaptureFixture
     from _pytest.monkeypatch import MonkeyPatch
 
+    from glotaran.typing import StrOrPath
+
 
 class MockDataIO(DataIoInterface):
     def load_dataset(  # type:ignore[override]
-        self, file_name: str | PathLike[str], *, result_container: dict[str, Any], **kwargs: Any
+        self, file_name: StrOrPath, *, result_container: dict[str, Any], **kwargs: Any
     ) -> xr.Dataset | xr.DataArray:
         """This docstring is just for help testing of 'load_dataset'."""
         result_container.update({"file_name": file_name, **kwargs})  # type:ignore
@@ -45,7 +46,7 @@ class MockDataIO(DataIoInterface):
     # TODO: Investigate why this raises an [override] type error and read_dataset doesn't
     def save_dataset(  # type:ignore[override]
         self,
-        file_name: str | PathLike[str],
+        file_name: StrOrPath,
         dataset: xr.Dataset | xr.DataArray,
         *,
         result_container: dict[str, Any],
@@ -200,7 +201,7 @@ def test_load_dataset(tmp_path: Path):
 
     dataset = load_dataset(file_path, result_container=result, dummy_arg="baz")
 
-    assert result == {"file_name": str(file_path), "dummy_arg": "baz"}
+    assert result == {"file_name": file_path.as_posix(), "dummy_arg": "baz"}
     assert np.all(dataset.data == xr.DataArray([1, 2]).to_dataset(name="data").data)
     assert dataset.source_path == file_path.as_posix()
 
@@ -230,7 +231,7 @@ def test_write_dataset(tmp_path: Path):
     )
 
     assert len(result) == 3
-    assert result["file_name"] == str(file_path)
+    assert result["file_name"] == file_path.as_posix()
     assert result["dummy_arg"] == "baz"
     assert np.all(result["dataset"] == xr.DataArray([1, 2]))
 

--- a/glotaran/plugin_system/test/test_project_io_registration.py
+++ b/glotaran/plugin_system/test/test_project_io_registration.py
@@ -30,7 +30,6 @@ from glotaran.plugin_system.project_io_registration import set_project_plugin
 from glotaran.plugin_system.project_io_registration import show_project_io_method_help
 
 if TYPE_CHECKING:
-    from os import PathLike
     from typing import Any
     from typing import Callable
 
@@ -40,6 +39,7 @@ if TYPE_CHECKING:
     from glotaran.model import Model
     from glotaran.project import Result
     from glotaran.project import Scheme
+    from glotaran.typing import StrOrPath
 
 
 class MockFileLoadable:
@@ -49,7 +49,7 @@ class MockFileLoadable:
 
 class MockProjectIo(ProjectIoInterface):
     # TODO: Investigate why write methods raises an [override] type error and load functions don't
-    def load_model(self, file_name: str | PathLike[str], **kwargs: Any) -> Model:
+    def load_model(self, file_name: StrOrPath, **kwargs: Any) -> Model:
         """This docstring is just for help testing of 'load_model'."""
         mock_obj = MockFileLoadable()
         mock_obj.func_args = {"file_name": file_name, **kwargs}
@@ -58,7 +58,7 @@ class MockProjectIo(ProjectIoInterface):
     def save_model(  # type:ignore[override]
         self,
         model: Model,
-        file_name: str | PathLike[str],
+        file_name: StrOrPath,
         **kwargs: Any,
     ):
         model.func_args.update(  # type:ignore[attr-defined]
@@ -69,7 +69,7 @@ class MockProjectIo(ProjectIoInterface):
             }
         )
 
-    def load_parameters(self, file_name: str | PathLike[str], **kwargs: Any) -> ParameterGroup:
+    def load_parameters(self, file_name: StrOrPath, **kwargs: Any) -> ParameterGroup:
         mock_obj = MockFileLoadable()
         mock_obj.func_args = {"file_name": file_name, **kwargs}
         return mock_obj  # type:ignore[return-value]
@@ -77,7 +77,7 @@ class MockProjectIo(ProjectIoInterface):
     def save_parameters(  # type:ignore[override]
         self,
         parameters: ParameterGroup,
-        file_name: str | PathLike[str],
+        file_name: StrOrPath,
         **kwargs: Any,
     ):
         parameters.func_args.update(  # type:ignore[attr-defined]
@@ -88,7 +88,7 @@ class MockProjectIo(ProjectIoInterface):
             }
         )
 
-    def load_scheme(self, file_name: str | PathLike[str], **kwargs: Any) -> Scheme:
+    def load_scheme(self, file_name: StrOrPath, **kwargs: Any) -> Scheme:
         mock_obj = MockFileLoadable()
         mock_obj.func_args = {"file_name": file_name, **kwargs}
         return mock_obj  # type:ignore[return-value]
@@ -96,7 +96,7 @@ class MockProjectIo(ProjectIoInterface):
     def save_scheme(  # type:ignore[override]
         self,
         scheme: Scheme,
-        file_name: str | PathLike[str],
+        file_name: StrOrPath,
         **kwargs: Any,
     ):
         scheme.func_args.update(  # type:ignore[attr-defined]
@@ -107,7 +107,7 @@ class MockProjectIo(ProjectIoInterface):
             }
         )
 
-    def load_result(self, result_path: str | PathLike[str], **kwargs: Any) -> Result:
+    def load_result(self, result_path: StrOrPath, **kwargs: Any) -> Result:
         mock_obj = MockFileLoadable()
         mock_obj.func_args = {"file_name": result_path, **kwargs}
         return mock_obj  # type:ignore[return-value]
@@ -115,7 +115,7 @@ class MockProjectIo(ProjectIoInterface):
     def save_result(  # type:ignore[override]
         self,
         result: Result,
-        result_path: str | PathLike[str],
+        result_path: StrOrPath,
         **kwargs: Any,
     ):
         result.func_args.update(  # type:ignore[attr-defined]
@@ -248,7 +248,7 @@ def test_load_functions(tmp_path: Path, load_function: Callable[..., Any]):
 
     result = load_function(file_path, dummy_arg="baz")
 
-    assert result.func_args == {"file_name": str(file_path), "dummy_arg": "baz"}
+    assert result.func_args == {"file_name": file_path.as_posix(), "dummy_arg": "baz"}
     assert result.source_path == Path(file_path).as_posix()
 
 
@@ -279,7 +279,7 @@ def test_write_functions(
     )
 
     assert mock_obj.func_args == {
-        "file_name": str(file_path),
+        "file_name": file_path.as_posix(),
         "data_object": mock_obj,
         "dummy_arg": "baz",
     }

--- a/glotaran/project/dataclass_helpers.py
+++ b/glotaran/project/dataclass_helpers.py
@@ -1,7 +1,10 @@
 """Contains helper methods for dataclasses."""
 from __future__ import annotations
 
-import dataclasses
+from dataclasses import MISSING
+from dataclasses import field
+from dataclasses import fields
+from dataclasses import is_dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -10,11 +13,13 @@ if TYPE_CHECKING:
     from typing import Callable
     from typing import TypeVar
 
+    from glotaran.typing.protocols import FileLoadable
+
     DefaultType = TypeVar("DefaultType")
 
 
 def exclude_from_dict_field(
-    default: DefaultType = dataclasses.MISSING,  # type:ignore[assignment]
+    default: DefaultType = MISSING,  # type:ignore[assignment]
 ) -> DefaultType:
     """Create a dataclass field with which will be excluded from ``asdict``.
 
@@ -28,13 +33,13 @@ def exclude_from_dict_field(
     DefaultType
         The created field.
     """
-    return dataclasses.field(default=default, metadata={"exclude_from_dict": True})
+    return field(default=default, metadata={"exclude_from_dict": True})
 
 
 def file_representation_field(
     target: str,
     loader: Callable[[str], Any],
-    default: DefaultType = dataclasses.MISSING,  # type:ignore[assignment]
+    default: DefaultType = MISSING,  # type:ignore[assignment]
 ) -> DefaultType:
     """Create a dataclass field with target and loader as metadata.
 
@@ -52,31 +57,125 @@ def file_representation_field(
     DefaultType
         The created field.
     """
-    return dataclasses.field(default=default, metadata={"target": target, "loader": loader})
+    return field(default=default, metadata={"target": target, "loader": loader})
 
 
-def asdict(dataclass: object) -> dict[str, Any]:
+def file_loader_factory(
+    targetClass: type[FileLoadable],
+) -> Callable[[FileLoadable | str | Path], FileLoadable]:
+    """Create ``file_loader`` functions to load ``targetClass`` from file.
+
+    Parameters
+    ----------
+    targetClass: type[FileLoadable]
+        Class the loader function should return an instance of.
+
+    Returns
+    -------
+    file_loader: Callable[[FileLoadable | str | Path], FileLoadable]
+        Function to load ``FileLoadable`` from source file or return instance if already loaded.
+    """
+
+    def file_loader(
+        source_path: FileLoadable | str | Path, folder: str | Path | None = None
+    ) -> FileLoadable:
+        """Functions to load ``targetClass`` from file.
+
+        Parameters
+        ----------
+        source_path : FileLoadable | str | Path
+            Instance to ``targetClass`` or a file path to load it from.
+        folder : str | Path | None
+            Path to the base folder ``source_path`` is a relative path to., by default None
+
+        Returns
+        -------
+        FileLoadable
+            Instance of ``targetClass``.
+
+        Raises
+        ------
+        ValueError
+            If not an instance of ``targetClass`` or a source path to load from.
+        """
+        if isinstance(source_path, (str, Path)):
+            if folder is not None:
+                target_obj = targetClass.loader(Path(folder) / source_path)
+            else:
+                target_obj = targetClass.loader(source_path)
+            target_obj.source_path = str(source_path)
+            return target_obj  # type:ignore[return-value]
+        if isinstance(source_path, targetClass):
+            return source_path
+        raise ValueError(
+            f"The value of 'target' needs to be of class {targetClass.__name__} or a file path."
+        )
+
+    return file_loader
+
+
+def file_loadable_field(targetClass: type[FileLoadable]) -> FileLoadable:
+    """Create a dataclass field which can be and object of type ``targetClass`` or file path.
+
+    Parameters
+    ----------
+    targetClass : type[FileLoadable]
+        Class the resulting value should be an instance of.
+
+    Returns
+    -------
+    FileLoadable
+        Instance of ``targetClass``.
+    """
+    return field(metadata={"file_loader": file_loader_factory(targetClass)})
+
+
+def init_file_loadable_fields(dataclass_instance: object):
+    """Load objects into class when dataclass is initialized with paths.
+
+    If the class has file_loadable fields, this should be called in the
+    ``__post_init__`` method of that class.
+
+    Parameters
+    ----------
+    dataclass_instance : object
+        Instance of the dataclass being initialized.
+        When used inside of ``__post_init__`` for the class itself use ``self``.
+    """
+    for field_item in fields(dataclass_instance):
+        if "file_loader" in field_item.metadata:
+            file_loader = field_item.metadata["file_loader"]
+            value = getattr(dataclass_instance, field_item.name)
+            setattr(dataclass_instance, field_item.name, file_loader(value))
+
+
+def asdict(dataclass: object, folder: Path = None) -> dict[str, Any]:
     """Create a dictionary containing all fields of the dataclass.
 
     Parameters
     ----------
     dataclass : object
         A dataclass instance.
+    folder: Path
+        Parent folder of :class:`FileLoadable` fields. by default None
 
     Returns
     -------
     dict[str, Any] :
         The dataclass represented as a dictionary.
     """
-    fields = dataclasses.fields(dataclass)
-
     dataclass_dict = {}
-    for field in fields:
-        if "exclude_from_dict" not in field.metadata:
-            value = getattr(dataclass, field.name)
-            dataclass_dict[field.name] = (
-                asdict(value) if dataclasses.is_dataclass(value) else value
-            )
+    for field_item in fields(dataclass):
+        if "exclude_from_dict" not in field_item.metadata:
+            value = getattr(dataclass, field_item.name)
+            dataclass_dict[field_item.name] = asdict(value) if is_dataclass(value) else value
+        if "file_loader" in field_item.metadata:
+            value = getattr(dataclass, field_item.name)
+            if value.source_path is not None:
+                source_path = Path(value.source_path)
+                if folder is not None and source_path.is_absolute():
+                    source_path = source_path.relative_to(folder)
+                dataclass_dict[field_item.name] = source_path.as_posix()
 
     return dataclass_dict
 
@@ -98,28 +197,31 @@ def fromdict(dataclass_type: type, dataclass_dict: dict[str, Any], folder: Path 
     object
         Created instance of dataclass_type.
     """
-    fields = dataclasses.fields(dataclass_type)
-
-    for field in fields:
-        if "target" in field.metadata and "loader" in field.metadata:
-            file_path = dataclass_dict.get(field.name)
+    for field_item in fields(dataclass_type):
+        if "target" in field_item.metadata and "loader" in field_item.metadata:
+            file_path = dataclass_dict.get(field_item.name)
             if file_path is None:
                 continue
             elif isinstance(file_path, list):
-                dataclass_dict[field.metadata["target"]] = [
-                    field.metadata["loader"](f if folder is None else folder / f)
+                dataclass_dict[field_item.metadata["target"]] = [
+                    field_item.metadata["loader"](f if folder is None else folder / f)
                     for f in file_path
                 ]
             elif isinstance(file_path, dict):
-                dataclass_dict[field.metadata["target"]] = {
-                    k: field.metadata["loader"](f if folder is None else folder / f)
+                dataclass_dict[field_item.metadata["target"]] = {
+                    k: field_item.metadata["loader"](f if folder is None else folder / f)
                     for k, f in file_path.items()
                 }
             else:
-                dataclass_dict[field.metadata["target"]] = field.metadata["loader"](
+                dataclass_dict[field_item.metadata["target"]] = field_item.metadata["loader"](
                     file_path if folder is None else folder / file_path
                 )
-        elif dataclasses.is_dataclass(field.default) and field.name in dataclass_dict:
-            dataclass_dict[field.name] = type(field.default)(**dataclass_dict[field.name])
+        if "file_loader" in field_item.metadata:
+            file_path = dataclass_dict.get(field_item.name)
+            dataclass_dict[field_item.name] = field_item.metadata["file_loader"](file_path, folder)
+        elif is_dataclass(field_item.default) and field_item.name in dataclass_dict:
+            dataclass_dict[field_item.name] = type(field_item.default)(
+                **dataclass_dict[field_item.name]
+            )
 
     return dataclass_type(**dataclass_dict)

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -31,8 +31,9 @@ from glotaran.utils.ipython import MarkdownStr
 
 if TYPE_CHECKING:
 
-    from os import PathLike
     from typing import Callable
+
+    from glotaran.typing import StrOrPath
 
 
 class IncompleteResultError(Exception):
@@ -126,10 +127,10 @@ class Result:
 
     :math:`rms = \sqrt{\chi^2_{red}}`
     """
-    source_path: str | PathLike[str] = field(
+    source_path: StrOrPath = field(
         default="result.yml", init=False, repr=False, metadata={"exclude_from_dict": True}
     )
-    loader: Callable[[str | PathLike[str]], Result] = field(
+    loader: Callable[[StrOrPath], Result] = field(
         default=load_result, init=False, repr=False, metadata={"exclude_from_dict": True}
     )
 

--- a/glotaran/project/scheme.py
+++ b/glotaran/project/scheme.py
@@ -21,11 +21,12 @@ from glotaran.utils.ipython import MarkdownStr
 
 if TYPE_CHECKING:
 
-    from os import PathLike
     from typing import Callable
     from typing import Literal
 
     import xarray as xr
+
+    from glotaran.typing import StrOrPath
 
 
 @dataclass
@@ -56,10 +57,10 @@ class Scheme(FileLoadableProtocol):
         "Levenberg-Marquardt",
     ] = "TrustRegionReflection"
     result_path: str | None = None
-    source_path: str | PathLike[str] = field(
+    source_path: StrOrPath = field(
         default="scheme.yml", init=False, repr=False, metadata={"exclude_from_dict": True}
     )
-    loader: Callable[[str | PathLike[str]], Scheme] = field(
+    loader: Callable[[StrOrPath], Scheme] = field(
         default=load_scheme, init=False, repr=False, metadata={"exclude_from_dict": True}
     )
 

--- a/glotaran/project/scheme.py
+++ b/glotaran/project/scheme.py
@@ -2,41 +2,44 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import field
 from dataclasses import fields
 from typing import TYPE_CHECKING
 
 from glotaran.deprecation import deprecate
 from glotaran.deprecation import warn_deprecated
 from glotaran.io import load_dataset
-from glotaran.io import load_model
-from glotaran.io import load_parameters
 from glotaran.io import load_scheme
+from glotaran.model import Model
+from glotaran.parameter import ParameterGroup
 from glotaran.project.dataclass_helpers import exclude_from_dict_field
+from glotaran.project.dataclass_helpers import file_loadable_field
 from glotaran.project.dataclass_helpers import file_representation_field
+from glotaran.project.dataclass_helpers import init_file_loadable_fields
+from glotaran.typing.protocols import FileLoadableProtocol
 from glotaran.utils.ipython import MarkdownStr
 
 if TYPE_CHECKING:
 
+    from os import PathLike
+    from typing import Callable
     from typing import Literal
 
     import xarray as xr
 
-    from glotaran.model import Model
-    from glotaran.parameter import ParameterGroup
-
 
 @dataclass
-class Scheme:
+class Scheme(FileLoadableProtocol):
     """A scheme is a collection of a model, parameters and a dataset.
 
     A scheme also holds options for optimization.
     """
 
-    model: Model = exclude_from_dict_field()
-    parameters: ParameterGroup = exclude_from_dict_field()
+    model: Model = file_loadable_field(Model)
+    parameters: ParameterGroup = file_loadable_field(ParameterGroup)
     data: dict[str, xr.DataArray | xr.Dataset] = exclude_from_dict_field()
-    model_file: str | None = file_representation_field("model", load_model, default=None)
-    parameters_file: str | None = file_representation_field("parameters", load_parameters, None)
+    # model_file: str | None = file_representation_field("model", load_model, default=None)
+    # parameters_file: str | None = file_representation_field("parameters", load_parameters, None)
     data_files: dict[str, str] | None = file_representation_field("data", load_dataset, None)
     clp_link_tolerance: float = 0.0
     maximum_number_function_evaluations: int | None = None
@@ -53,9 +56,18 @@ class Scheme:
         "Levenberg-Marquardt",
     ] = "TrustRegionReflection"
     result_path: str | None = None
+    source_path: str | PathLike[str] = field(
+        default="scheme.yml", init=False, repr=False, metadata={"exclude_from_dict": True}
+    )
+    loader: Callable[[str | PathLike[str]], Scheme] = field(
+        default=load_scheme, init=False, repr=False, metadata={"exclude_from_dict": True}
+    )
 
     def __post_init__(self):
         """Override attributes after initialization."""
+        init_file_loadable_fields(self)
+
+        # Deprecations
         if self.non_negative_least_squares is not None:
             warn_deprecated(
                 deprecated_qual_name_usage=(
@@ -72,9 +84,9 @@ class Scheme:
                 default_group.residual_function = "non_negative_least_squares"
             else:
                 default_group.residual_function = "variable_projection"
-            for field in fields(self):
-                if field.name == "non_negative_least_squares":
-                    field.metadata = {}
+            for field_item in fields(self):
+                if field_item.name == "non_negative_least_squares":
+                    field_item.metadata = {}
 
         if self.group is not None:
             warn_deprecated(
@@ -85,9 +97,9 @@ class Scheme:
                 stacklevel=4,
             )
             self.model.dataset_group_models["default"].link_clp = self.group
-            for field in fields(self):
-                if field.name == "group":
-                    field.metadata = {}
+            for field_item in fields(self):
+                if field_item.name == "group":
+                    field_item.metadata = {}
 
         if self.group_tolerance is not None:
             warn_deprecated(

--- a/glotaran/project/scheme.py
+++ b/glotaran/project/scheme.py
@@ -8,21 +8,21 @@ from typing import TYPE_CHECKING
 
 from glotaran.deprecation import deprecate
 from glotaran.deprecation import warn_deprecated
-from glotaran.io import load_dataset
 from glotaran.io import load_scheme
 from glotaran.model import Model
 from glotaran.parameter import ParameterGroup
 from glotaran.project.dataclass_helpers import exclude_from_dict_field
 from glotaran.project.dataclass_helpers import file_loadable_field
-from glotaran.project.dataclass_helpers import file_representation_field
 from glotaran.project.dataclass_helpers import init_file_loadable_fields
 from glotaran.typing.protocols import FileLoadableProtocol
+from glotaran.utils.io import DatasetMapping
 from glotaran.utils.ipython import MarkdownStr
 
 if TYPE_CHECKING:
 
     from typing import Callable
     from typing import Literal
+    from typing import Mapping
 
     import xarray as xr
 
@@ -38,10 +38,7 @@ class Scheme(FileLoadableProtocol):
 
     model: Model = file_loadable_field(Model)
     parameters: ParameterGroup = file_loadable_field(ParameterGroup)
-    data: dict[str, xr.DataArray | xr.Dataset] = exclude_from_dict_field()
-    # model_file: str | None = file_representation_field("model", load_model, default=None)
-    # parameters_file: str | None = file_representation_field("parameters", load_parameters, None)
-    data_files: dict[str, str] | None = file_representation_field("data", load_dataset, None)
+    data: Mapping[str, xr.Dataset] = file_loadable_field(DatasetMapping, is_wrapper_class=True)
     clp_link_tolerance: float = 0.0
     maximum_number_function_evaluations: int | None = None
     non_negative_least_squares: bool | None = exclude_from_dict_field(None)

--- a/glotaran/project/test/test_dataclass_helpers.py
+++ b/glotaran/project/test/test_dataclass_helpers.py
@@ -1,33 +1,55 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from glotaran.project.dataclass_helpers import asdict
 from glotaran.project.dataclass_helpers import exclude_from_dict_field
-from glotaran.project.dataclass_helpers import file_representation_field
+from glotaran.project.dataclass_helpers import file_loadable_field
 from glotaran.project.dataclass_helpers import fromdict
+from glotaran.project.dataclass_helpers import init_file_loadable_fields
+from glotaran.typing.protocols import FileLoadableProtocol
 
 
-def dummy_loader(file: str) -> int:
-    return {"foo.file": 21, "bar.file": 42}[file]
+@dataclass
+class DummyFileLoadable(FileLoadableProtocol):
+    def __init__(self, val: str) -> None:
+        self.source_path = "dummy_file"
+        self.data = {"foo": val}
+
+    @classmethod
+    def loader(  # type:ignore[override]
+        cls: type[DummyFileLoadable],
+        file_path: str,
+    ) -> DummyFileLoadable:
+        instance = cls(f"{file_path}_loaded")
+        instance.source_path = file_path
+        return instance
 
 
 def test_serialize_to_file_name_field():
     @dataclass
     class DummyDataclass:
-        foo: int = exclude_from_dict_field()
-        foo_file: int = file_representation_field("foo", dummy_loader)
+        foo: DummyFileLoadable = file_loadable_field(DummyFileLoadable)
+        foo2: DummyFileLoadable = file_loadable_field(DummyFileLoadable)
         bar: int = exclude_from_dict_field(default=42)
-        bar_file: int = file_representation_field("bar", dummy_loader, default="bar.file")
         baz: int = 84
 
-    dummy_class = DummyDataclass(foo=21, foo_file="foo.file")
+        def __post_init__(self):
+            init_file_loadable_fields(self)
+
+    dummy_class = DummyDataclass(foo=DummyFileLoadable.loader("foo.file"), foo2="foo2.file")
+
+    assert dummy_class.foo.data == {"foo": "foo.file_loaded"}
+    assert dummy_class.foo.source_path == "foo.file"
+    assert dummy_class.foo2.data == {"foo": "foo2.file_loaded"}
+    assert dummy_class.foo2.source_path == "foo2.file"
+    assert dummy_class.bar == 42
 
     dummy_class_dict = asdict(dummy_class)
 
-    assert "foo" not in dummy_class_dict
-    assert dummy_class_dict["foo_file"] == "foo.file"
-
+    assert dummy_class_dict["foo"] == "foo.file"
+    assert dummy_class_dict["foo2"] == "foo2.file"
     assert "bar" not in dummy_class_dict
-    assert dummy_class_dict["bar_file"] == "bar.file"
 
     assert dummy_class_dict["baz"] == 84
     assert dummy_class_dict["baz"] == dummy_class.baz

--- a/glotaran/project/test/test_result.py
+++ b/glotaran/project/test/test_result.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import pandas as pd
 import pytest
 from IPython.core.formatters import format_display_data
 
 from glotaran.analysis.optimize import optimize
 from glotaran.analysis.simulation import simulate
 from glotaran.analysis.test.models import ThreeDatasetDecay as suite
+from glotaran.parameter import ParameterHistory
 from glotaran.project import Scheme
 from glotaran.project.result import IncompleteResultError
 from glotaran.project.result import Result
@@ -54,14 +56,26 @@ def test_result_ipython_rendering(dummy_result: Result):
 def test_result_incomplete_exception(dummy_result: Result):
     """Raise error if required fields are missing."""
 
+    scheme = Scheme(model=suite.model, parameters=suite.initial_parameters, data={})
+
     with pytest.raises(IncompleteResultError) as excinfo:
-        Result(1, True, "foo", "gta", ["1"])
+        Result(
+            1,
+            True,
+            "foo",
+            "gta",
+            ["1"],
+            scheme,
+            suite.initial_parameters,
+            suite.initial_parameters,
+            ParameterHistory.from_dataframe(pd.DataFrame()),
+        )
 
     for mandatory_field, file_post_fix in [
-        ("scheme", ""),
-        ("initial_parameters", ""),
-        ("optimized_parameters", ""),
-        ("parameter_history", ""),
+        # ("scheme", ""),
+        # ("initial_parameters", ""),
+        # ("optimized_parameters", ""),
+        # ("parameter_history", ""),
         ("data", "s"),
     ]:
         assert (

--- a/glotaran/project/test/test_result.py
+++ b/glotaran/project/test/test_result.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-import pandas as pd
 import pytest
 from IPython.core.formatters import format_display_data
 
 from glotaran.analysis.optimize import optimize
 from glotaran.analysis.simulation import simulate
 from glotaran.analysis.test.models import ThreeDatasetDecay as suite
-from glotaran.parameter import ParameterHistory
 from glotaran.project import Scheme
-from glotaran.project.result import IncompleteResultError
 from glotaran.project.result import Result
 
 
@@ -51,34 +48,3 @@ def test_result_ipython_rendering(dummy_result: Result):
 
     assert "text/markdown" in rendered_markdown_return
     assert rendered_markdown_return["text/markdown"].startswith("| Optimization Result")
-
-
-def test_result_incomplete_exception(dummy_result: Result):
-    """Raise error if required fields are missing."""
-
-    scheme = Scheme(model=suite.model, parameters=suite.initial_parameters, data={})
-
-    with pytest.raises(IncompleteResultError) as excinfo:
-        Result(
-            1,
-            True,
-            "foo",
-            "gta",
-            ["1"],
-            scheme,
-            suite.initial_parameters,
-            suite.initial_parameters,
-            ParameterHistory.from_dataframe(pd.DataFrame()),
-        )
-
-    for mandatory_field, file_post_fix in [
-        # ("scheme", ""),
-        # ("initial_parameters", ""),
-        # ("optimized_parameters", ""),
-        # ("parameter_history", ""),
-        ("data", "s"),
-    ]:
-        assert (
-            f"Set either '{mandatory_field}' or '{mandatory_field}_file{file_post_fix}'."
-            in str(excinfo.value)
-        )

--- a/glotaran/project/test/test_scheme.py
+++ b/glotaran/project/test/test_scheme.py
@@ -32,8 +32,8 @@ def mock_scheme(tmp_path: Path) -> Scheme:
     ).to_netcdf(dataset_path)
 
     scheme_yml_str = f"""
-    model_file: {model_path}
-    parameters_file: {parameter_path}
+    model: {model_path}
+    parameters: {parameter_path}
     maximum_number_function_evaluations: 42
     data_files:
         dataset1: {dataset_path}

--- a/glotaran/project/test/test_scheme.py
+++ b/glotaran/project/test/test_scheme.py
@@ -35,7 +35,7 @@ def mock_scheme(tmp_path: Path) -> Scheme:
     model: {model_path}
     parameters: {parameter_path}
     maximum_number_function_evaluations: 42
-    data_files:
+    data:
         dataset1: {dataset_path}
     """
     scheme_path = tmp_path / "scheme.yml"

--- a/glotaran/typing/__init__.py
+++ b/glotaran/typing/__init__.py
@@ -1,0 +1,4 @@
+"""Glotaran specific typing module."""
+from glotaran.typing.types import StrOrPath
+
+__all__ = ["StrOrPath"]

--- a/glotaran/typing/protocols.py
+++ b/glotaran/typing/protocols.py
@@ -1,3 +1,4 @@
+"""Protocol like type definitions."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -6,13 +7,17 @@ from typing import TypeVar
 
 if TYPE_CHECKING:
     from typing import Callable
+    from typing import Mapping
+    from typing import Sequence
 
-    from glotaran.typing import StrOrPath
+    from glotaran.typing.types import StrOrPath
 
 
 class FileLoadableProtocol(Protocol):
-    loader: Callable[[StrOrPath], FileLoadableProtocol]
-    source_path: StrOrPath
+    loader: Callable[
+        [StrOrPath | Sequence[StrOrPath] | Mapping[str, StrOrPath]], FileLoadableProtocol
+    ]
+    source_path: StrOrPath | Sequence[StrOrPath] | Mapping[str, StrOrPath]
 
 
 FileLoadable = TypeVar("FileLoadable", bound=FileLoadableProtocol)

--- a/glotaran/typing/protocols.py
+++ b/glotaran/typing/protocols.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from typing import Protocol
+from typing import TypeVar
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from typing import Callable
+
+
+class FileLoadableProtocol(Protocol):
+    loader: Callable[[str | PathLike[str]], FileLoadableProtocol]
+    source_path: str | PathLike[str]
+
+
+FileLoadable = TypeVar("FileLoadable", bound=FileLoadableProtocol)

--- a/glotaran/typing/protocols.py
+++ b/glotaran/typing/protocols.py
@@ -15,7 +15,8 @@ if TYPE_CHECKING:
 
 class FileLoadableProtocol(Protocol):
     loader: Callable[
-        [StrOrPath | Sequence[StrOrPath] | Mapping[str, StrOrPath]], FileLoadableProtocol
+        [StrOrPath | Sequence[StrOrPath] | Mapping[str, StrOrPath]],
+        FileLoadableProtocol,
     ]
     source_path: StrOrPath | Sequence[StrOrPath] | Mapping[str, StrOrPath]
 

--- a/glotaran/typing/protocols.py
+++ b/glotaran/typing/protocols.py
@@ -5,13 +5,14 @@ from typing import Protocol
 from typing import TypeVar
 
 if TYPE_CHECKING:
-    from os import PathLike
     from typing import Callable
+
+    from glotaran.typing import StrOrPath
 
 
 class FileLoadableProtocol(Protocol):
-    loader: Callable[[str | PathLike[str]], FileLoadableProtocol]
-    source_path: str | PathLike[str]
+    loader: Callable[[StrOrPath], FileLoadableProtocol]
+    source_path: StrOrPath
 
 
 FileLoadable = TypeVar("FileLoadable", bound=FileLoadableProtocol)

--- a/glotaran/typing/types.py
+++ b/glotaran/typing/types.py
@@ -1,5 +1,11 @@
 """Glotaran types module containing commonly used types."""
 from pathlib import Path
+from typing import Mapping
+from typing import Sequence
 from typing import Union
 
+import xarray as xr
+
 StrOrPath = Union[str, Path]
+LoadableDataset = Union[StrOrPath, xr.Dataset, xr.DataArray]
+DatasetMappable = Union[LoadableDataset, Sequence[LoadableDataset], Mapping[str, LoadableDataset]]

--- a/glotaran/typing/types.py
+++ b/glotaran/typing/types.py
@@ -1,0 +1,5 @@
+"""Glotaran types module containing commonly used types."""
+from pathlib import Path
+from typing import Union
+
+StrOrPath = Union[str, Path]

--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -16,6 +16,8 @@ from glotaran.typing.types import DatasetMappable
 if TYPE_CHECKING:
     from typing import Iterator
 
+    from glotaran.typing.types import StrOrPath
+
 
 def _load_datasets(dataset_mappable: DatasetMappable, index: int = 1) -> dict[str, xr.Dataset]:
     """Implement functionality for ``load_datasets`` and  internal use.
@@ -157,3 +159,24 @@ def load_datasets(dataset_mappable: DatasetMappable) -> DatasetMapping:
         the ``source_path`` attr.
     """
     return DatasetMapping.loader(dataset_mappable)
+
+
+def relative_posix_path(source_path: StrOrPath, base_path: StrOrPath | None = None) -> str:
+    """Ensure that ``source_path`` is a posix path, relative to ``base_path`` if defined.
+
+    Parameters
+    ----------
+    source_path : StrOrPath
+        Path which should be converted to a relative posix path.
+    base_path : StrOrPath, optional
+        Base path the resulting path string should be relative to., by default None
+
+    Returns
+    -------
+    str
+        ``source_path`` as posix path relative to ``base_path`` if defined.
+    """
+    source_path = Path(source_path)
+    if base_path is not None and source_path.is_absolute():
+        source_path = source_path.relative_to(base_path)
+    return source_path.as_posix()

--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -1,0 +1,145 @@
+"""Glotaran IO utility module."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from collections.abc import MutableMapping
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import xarray as xr
+
+from glotaran.plugin_system.data_io_registration import load_dataset
+from glotaran.typing.protocols import FileLoadableProtocol
+from glotaran.typing.types import DatasetMappable
+
+if TYPE_CHECKING:
+    from typing import Iterator
+
+
+def _load_datasets(dataset_mappable: DatasetMappable, index: int = 1) -> dict[str, xr.Dataset]:
+    """Implement functionality for ``load_datasets`` and  internal use.
+
+    Parameters
+    ----------
+    dataset_mappable : DatasetMappable
+        Instance of ``DatasetMappable`` that can be used to create a dataset mapping.
+    index : int
+        Index used to create key and ``source_path`` if not present.
+        , by default 1
+
+    Returns
+    -------
+    dict[str, xr.Dataset]
+        Mapping of datasets to initialize :class:`DatasetMapping`.
+
+    Raises
+    ------
+    TypeError
+        If the type of ``dataset_mappable`` is not explicitly supported.
+    """
+    dataset_mapping = {}
+    if isinstance(dataset_mappable, (str, Path)):
+        dataset_mapping[Path(dataset_mappable).stem] = load_dataset(dataset_mappable)
+    elif isinstance(dataset_mappable, (xr.Dataset, xr.DataArray)):
+        if isinstance(dataset_mappable, xr.DataArray):
+            dataset_mappable: xr.Dataset = dataset_mappable.to_dataset(  # type:ignore[no-redef]
+                name="data"
+            )
+        if "source_path" not in dataset_mappable.attrs:
+            dataset_mappable.attrs["source_path"] = f"dataset_{index}.nc"
+        dataset_mapping[Path(dataset_mappable.source_path).stem] = dataset_mappable
+    elif isinstance(dataset_mappable, Sequence):
+        for index, dataset in enumerate(dataset_mappable, start=1):
+            key, value = next(iter(_load_datasets(dataset, index=index).items()))
+            dataset_mapping[key] = value
+    elif isinstance(dataset_mappable, Mapping):
+        for key, dataset in dataset_mappable.items():
+            _, value = next(iter(_load_datasets(dataset).items()))
+            dataset_mapping[key] = value
+    else:
+        raise TypeError(
+            f"Type '{type(dataset_mappable).__name__}' for 'dataset_mappable' of value "
+            f"'{dataset_mappable}' is not supported."
+            f"\nSupported types are:\n {DatasetMappable}."
+        )
+    return dataset_mapping
+
+
+class DatasetMapping(MutableMapping, FileLoadableProtocol):
+    """Wrapper class for a mapping of datasets which can be used for a ``file_loadable_field``."""
+
+    def __init__(self, init_map: Mapping[str, xr.Dataset] = None) -> None:
+        """Initialize an instance of :class:`DatasetMapping`.
+
+        Parameters
+        ----------
+        init_dict : dict[str, xr.Dataset], optional
+            Mapping to initially populate the instance., by default None
+        """
+        super().__init__()
+        self.source_path: dict[str, str] = {}
+        self.__data_dict: dict[str, xr.Dataset] = {}
+        if init_map is not None:
+            for key, dataset in init_map.items():
+                self[key] = dataset
+
+    @classmethod
+    def loader(cls: type[DatasetMapping], dataset_mappable: DatasetMappable) -> DatasetMapping:
+        """Loader function utilized by ``file_loadable_field``.
+
+        Parameters
+        ----------
+        dataset_mappable : DatasetMappable
+            Mapping of datasets to initialize :class:`DatasetMapping`.
+
+        Returns
+        -------
+        DatasetMapping
+            Populated instance of :class:`DatasetMapping`.
+        """
+        return cls(_load_datasets(dataset_mappable))
+
+    def __getitem__(self, key: str) -> xr.Dataset:
+        """Implement retrieving an element by its key."""
+        return self.__data_dict[key]
+
+    def __setitem__(self, key: str, value: xr.Dataset) -> None:
+        """Implement setting an elements value."""
+        if "source_path" not in value.attrs:
+            value.attrs["source_path"] = f"{key}.nc"
+        self.source_path[key] = value.source_path
+        self.__data_dict[key] = value
+
+    def __iter__(self) -> Iterator[str]:
+        """Implement looping over an instance."""
+        yield from self.__data_dict.keys()
+
+    def __delitem__(self, key: str) -> None:
+        """Implement deleting an item."""
+        del self.source_path[key]
+        del self.__data_dict[key]
+
+    def __len__(self) -> int:
+        """Implement calling ``len`` on an instance."""
+        return len(self.__data_dict)
+
+
+def load_datasets(dataset_mappable: DatasetMappable) -> DatasetMapping:
+    """Load multiple datasets into a mapping (convenience function).
+
+    This is used for ``file_loadable_field`` of a dataset mapping e.g.
+    in :class:`Scheme`
+
+    Parameters
+    ----------
+    dataset_mappable : DatasetMappable
+        Single dataset/file path to a dataset or sequence or mapping of it.
+
+    Returns
+    -------
+    DatasetMapping
+        Mapping of dataset with string keys, where datasets hare ensured to have
+        the ``source_path`` attr.
+    """
+    return DatasetMapping.loader(dataset_mappable)

--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -1,6 +1,7 @@
 """Glotaran IO utility module."""
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
 from collections.abc import MutableMapping
 from collections.abc import Sequence
@@ -176,7 +177,7 @@ def relative_posix_path(source_path: StrOrPath, base_path: StrOrPath | None = No
     str
         ``source_path`` as posix path relative to ``base_path`` if defined.
     """
-    source_path = Path(source_path)
-    if base_path is not None and source_path.is_absolute():
-        source_path = source_path.relative_to(base_path)
-    return source_path.as_posix()
+    source_path = Path(source_path).as_posix()
+    if base_path is not None and os.path.isabs(source_path):
+        source_path = os.path.relpath(source_path, Path(base_path).as_posix())
+    return Path(source_path).as_posix()

--- a/glotaran/utils/test/test_io.py
+++ b/glotaran/utils/test/test_io.py
@@ -10,6 +10,7 @@ import xarray as xr
 from glotaran.io import save_dataset
 from glotaran.utils.io import DatasetMapping
 from glotaran.utils.io import load_datasets
+from glotaran.utils.io import relative_posix_path
 
 
 @pytest.fixture
@@ -128,3 +129,25 @@ def test_load_datasets_wrong_type():
         ),
     ):
         load_datasets(1)
+
+
+@pytest.mark.parametrize("rel_file_path", ("file.txt", "folder/file.txt"))
+def test_relative_posix_path(tmp_path: Path, rel_file_path: str):
+    """All possible permutation for the input values."""
+    full_path = tmp_path / rel_file_path
+
+    result_str = relative_posix_path(str(full_path))
+
+    assert result_str == full_path.as_posix()
+
+    result_path = relative_posix_path(full_path)
+
+    assert result_path == full_path.as_posix()
+
+    rel_result_str = relative_posix_path(str(full_path), tmp_path)
+
+    assert rel_result_str == rel_file_path
+
+    rel_result_path = relative_posix_path(full_path, str(tmp_path))
+
+    assert rel_result_path == rel_file_path

--- a/glotaran/utils/test/test_io.py
+++ b/glotaran/utils/test/test_io.py
@@ -151,3 +151,9 @@ def test_relative_posix_path(tmp_path: Path, rel_file_path: str):
     rel_result_path = relative_posix_path(full_path, str(tmp_path))
 
     assert rel_result_path == rel_file_path
+
+    rel_result_no_coomon = relative_posix_path(
+        (tmp_path / f"../{rel_file_path}").resolve().as_posix(), str(tmp_path)
+    )
+
+    assert rel_result_no_coomon == f"../{rel_file_path}"

--- a/glotaran/utils/test/test_io.py
+++ b/glotaran/utils/test/test_io.py
@@ -1,0 +1,130 @@
+"""Tests for glotaran/utils/io.py"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from glotaran.io import save_dataset
+from glotaran.utils.io import DatasetMapping
+from glotaran.utils.io import load_datasets
+
+
+@pytest.fixture
+def dummy_datasets(tmp_path: Path) -> tuple[Path, xr.Dataset, xr.Dataset]:
+    ds1 = xr.DataArray([1, 2]).to_dataset(name="data")
+    ds2 = xr.DataArray([3, 4]).to_dataset(name="data")
+    save_dataset(ds1, tmp_path / "ds1_file.nc")
+    save_dataset(ds2, tmp_path / "ds2_file.nc")
+    return tmp_path, ds1, ds2
+
+
+def test_dataset_mapping():
+    """Basic mapping functionality of ``DatasetMapping``."""
+    ds_mapping = DatasetMapping()
+
+    ds_mapping["ds1"] = xr.DataArray([1, 2]).to_dataset(name="data")
+    ds_mapping["ds2"] = xr.DataArray([3, 4]).to_dataset(name="data")
+
+    assert "ds1" in ds_mapping
+    assert "ds2" in ds_mapping
+    assert len(ds_mapping) == 2
+
+    for ds_name, expected_ds_name in zip(ds_mapping, ["ds1", "ds2"]):
+        assert ds_name == expected_ds_name
+
+    del ds_mapping["ds1"]
+
+    assert "ds1" not in ds_mapping
+    assert "ds2" in ds_mapping
+    assert len(ds_mapping) == 1
+
+
+def test_load_datasets_single_dataset(dummy_datasets: tuple[Path, xr.Dataset, xr.Dataset]):
+    """Functionality of ``load_datasets`` with a single dataset of all supported types."""
+    tmp_path, ds1, _ = dummy_datasets
+    expected_source_path = (tmp_path / "ds1_file.nc").as_posix()
+
+    str_result = load_datasets((tmp_path / "ds1_file.nc").as_posix())
+
+    assert "ds1_file" in str_result
+    assert np.all(str_result["ds1_file"].data == ds1.data)
+    assert str_result["ds1_file"].source_path == expected_source_path
+    assert str_result.source_path["ds1_file"] == expected_source_path
+
+    path_result = load_datasets(tmp_path / "ds1_file.nc")
+
+    assert "ds1_file" in path_result
+    assert np.all(path_result["ds1_file"].data == ds1.data)
+    assert path_result["ds1_file"].source_path == expected_source_path
+    assert path_result.source_path["ds1_file"] == expected_source_path
+
+    dataset_result = load_datasets(ds1)
+
+    assert "ds1_file" in dataset_result
+    assert np.all(dataset_result["ds1_file"].data == ds1.data)
+    assert dataset_result["ds1_file"].source_path == expected_source_path
+    assert dataset_result.source_path["ds1_file"] == expected_source_path
+
+    dataarray_result = load_datasets(xr.DataArray([1, 2]))
+
+    assert "dataset_1" in dataarray_result
+    assert np.all(dataarray_result["dataset_1"].data == ds1.data)
+    assert dataarray_result["dataset_1"].source_path == "dataset_1.nc"
+    assert dataarray_result.source_path["dataset_1"] == "dataset_1.nc"
+
+    pure_dataset_result = load_datasets(xr.DataArray([1, 2]).to_dataset(name="data"))
+
+    assert "dataset_1" in pure_dataset_result
+    assert np.all(pure_dataset_result["dataset_1"].data == ds1.data)
+    assert pure_dataset_result["dataset_1"].source_path == "dataset_1.nc"
+    assert pure_dataset_result.source_path["dataset_1"] == "dataset_1.nc"
+
+
+def test_load_datasets_sequence(dummy_datasets: tuple[Path, xr.Dataset, xr.Dataset]):
+    """Functionality of ``load_datasets`` with a sequence."""
+    tmp_path, ds1, ds2 = dummy_datasets
+
+    result = load_datasets([tmp_path / "ds1_file.nc", tmp_path / "ds2_file.nc"])
+
+    assert "ds1_file" in result
+    assert np.all(result["ds1_file"].data == ds1.data)
+    assert result["ds1_file"].source_path == (tmp_path / "ds1_file.nc").as_posix()
+    assert result.source_path["ds1_file"] == (tmp_path / "ds1_file.nc").as_posix()
+
+    assert "ds2_file" in result
+    assert np.all(result["ds2_file"].data == ds2.data)
+    assert result["ds2_file"].source_path == (tmp_path / "ds2_file.nc").as_posix()
+    assert result.source_path["ds2_file"] == (tmp_path / "ds2_file.nc").as_posix()
+
+
+def test_load_datasets_mapping(dummy_datasets: tuple[Path, xr.Dataset, xr.Dataset]):
+    """Functionality of ``load_datasets`` with a mapping."""
+    tmp_path, ds1, ds2 = dummy_datasets
+
+    result = load_datasets({"ds1": tmp_path / "ds1_file.nc", "ds2": tmp_path / "ds2_file.nc"})
+
+    assert "ds1" in result
+    assert np.all(result["ds1"].data == ds1.data)
+    assert result["ds1"].source_path == (tmp_path / "ds1_file.nc").as_posix()
+    assert result.source_path["ds1"] == (tmp_path / "ds1_file.nc").as_posix()
+
+    assert "ds2" in result
+    assert np.all(result["ds2"].data == ds2.data)
+    assert result["ds2"].source_path == (tmp_path / "ds2_file.nc").as_posix()
+    assert result.source_path["ds2"] == (tmp_path / "ds2_file.nc").as_posix()
+
+
+def test_load_datasets_wrong_type():
+    """Raise TypeError for not supported type"""
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"Type 'int' for 'dataset_mappable' of value "
+            r"'1' is not supported\."
+            r"\nSupported types are:\n"
+        ),
+    ):
+        load_datasets(1)


### PR DESCRIPTION
This PR removes the file representation fields from  the augmented dataclasses completely and thus simplifies the API
from:
https://github.com/glotaran/pyglotaran/blob/ded0711b0bc4c133636b02a0a1b7b407a6a26c99/glotaran/builtin/io/yml/test/test_save_scheme.py#L38-L45
to
```python
    scheme = Scheme(
        model,
        parameter,
        {"dataset_1": dataset},
    )
```

### Additional side effects and improvements:
- There now is  a `glotaran.typing` module
- `FileLoadable` classes (`Model`, `ParameterGroup`, `Scheme`, `Result`, `DatasetMapping`) know their own file origin
- There is a new convenience io function `load_datasets` which can load datasets in bulk, which then can be consumed by Scheme


### Change summary

- ♻️👌 Removed file fields in ProjectIo like classes and used unified field
- ♻️🔌 Refactored load_dataset to always return xr.Dataset
- ♻️ Added type 'StrOrPath' and refactored io plugins with new type 
- ✨ Implemented convenience function 'load_datasets' 
- ♻️👌 Made 'DatasetMapping.source_path' a property accessing the dataset 
- ♻️👌 Replaced all file_representation_field with file_loadable_field
- ♻️✨ Factored making paths relative and posix style out and added support  for Sequence like FileLoadable classes
- ♻️ Refactored bool_str_repr after [sourcery suggested a different change](https://github.com/glotaran/pyglotaran/pull/904)
- ♻️🩹 Changed implementation of relative_posix_path to use os.path.relpath

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #858 
