### PR TITLE
🩹 Fix 'dataset_groups' not shown in model markdown

### DIFF
--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -422,6 +422,15 @@ class Model:
         string += ", ".join(self._megacomplex_types)
         string += "\n\n"
 
+        string += f"{base_heading}# Dataset Groups\n\n"
+        for group_name, group in self.dataset_group_models.items():
+            string += f"* **{group_name}**:\n"
+            string += f"  * *Label*: {group_name}\n"
+            for item_name, item_value in asdict(group).items():
+                string += f"  * *{item_name}*: {item_value}\n"
+
+        string += "\n"
+
         for name in self.model_items:
             items = getattr(self, name)
             if not items:


### PR DESCRIPTION
Adds the `Dataset Groups` subsection to the markdown representation of model (used in the markdown report).


### Change summary

- 🧪 Added failing test case showing the expected output of Model.markdown
- 🩹 Change Model.markdown to satisfy the test

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #885
