### PR TITLE
Serveral refactorings in `glotaran.Parameter`

### DIFF
--- a/glotaran/deprecation/modules/test/test_parameter_parameter_group.py
+++ b/glotaran/deprecation/modules/test/test_parameter_parameter_group.py
@@ -14,14 +14,14 @@ def test_parameter_group_to_csv(tmp_path: Path):
     )
     expected = dedent(
         """\
-        label,value,minimum,maximum,vary,non-negative,expression
-        j.1,1.0,-inf,inf,False,False,None
-        j.0,0.0,-inf,inf,False,False,None
-        kinetic.1,0.5,-inf,inf,True,False,None
-        kinetic.2,0.3,-inf,inf,True,False,None
-        kinetic.3,0.1,-inf,inf,True,False,None
-        irf.center,0.3,-inf,inf,True,False,None
-        irf.width,0.1,-inf,inf,True,False,None
+        label,value,expression,minimum,maximum,non-negative,vary,standard-error
+        j.1,1.0,None,-inf,inf,False,False,0.0
+        j.0,0.0,None,-inf,inf,False,False,0.0
+        kinetic.1,0.5,None,-inf,inf,False,True,0.0
+        kinetic.2,0.3,None,-inf,inf,False,True,0.0
+        kinetic.3,0.1,None,-inf,inf,False,True,0.0
+        irf.center,0.3,None,-inf,inf,False,True,0.0
+        irf.width,0.1,None,-inf,inf,False,True,0.0
         """
     )
 

--- a/glotaran/deprecation/modules/test/test_parameter_parameter_group.py
+++ b/glotaran/deprecation/modules/test/test_parameter_parameter_group.py
@@ -6,7 +6,7 @@ from glotaran.deprecation.modules.test import deprecation_warning_on_call_test_h
 from glotaran.examples.sequential import parameter
 
 
-def test_parameter_group_to_csv(tmp_path: Path):
+def test_parameter_group_to_csv_no_stderr(tmp_path: Path):
     """``ParameterGroup.to_csv`` raises deprecation warning and saves file."""
     parameter_path = tmp_path / "test_parameter.csv"
     deprecation_warning_on_call_test_helper(
@@ -15,13 +15,13 @@ def test_parameter_group_to_csv(tmp_path: Path):
     expected = dedent(
         """\
         label,value,expression,minimum,maximum,non-negative,vary,standard-error
-        j.1,1.0,None,-inf,inf,False,False,0.0
-        j.0,0.0,None,-inf,inf,False,False,0.0
-        kinetic.1,0.5,None,-inf,inf,False,True,0.0
-        kinetic.2,0.3,None,-inf,inf,False,True,0.0
-        kinetic.3,0.1,None,-inf,inf,False,True,0.0
-        irf.center,0.3,None,-inf,inf,False,True,0.0
-        irf.width,0.1,None,-inf,inf,False,True,0.0
+        j.1,1.0,None,-inf,inf,False,False,None
+        j.0,0.0,None,-inf,inf,False,False,None
+        kinetic.1,0.5,None,-inf,inf,False,True,None
+        kinetic.2,0.3,None,-inf,inf,False,True,None
+        kinetic.3,0.1,None,-inf,inf,False,True,None
+        irf.center,0.3,None,-inf,inf,False,True,None
+        irf.width,0.1,None,-inf,inf,False,True,None
         """
     )
 

--- a/glotaran/model/test/test_model.py
+++ b/glotaran/model/test/test_model.py
@@ -514,9 +514,9 @@ def test_model_markdown():
         * **k1**:
           * *Label*: k1
           * *Matrix*:
-            * *('s2', 's1')*: rates.1: **5.01000e-01** *(StdErr: 0e+00)*
-            * *('s3', 's2')*: rates.2: **2.02000e-02** *(StdErr: 0e+00)*
-            * *('s3', 's3')*: rates.3: **1.05000e-03** *(StdErr: 0e+00)*
+            * *('s2', 's1')*: rates.1: **5.01000e-01** *(StdErr: nan)*
+            * *('s3', 's2')*: rates.2: **2.02000e-02** *(StdErr: nan)*
+            * *('s3', 's3')*: rates.3: **1.05000e-03** *(StdErr: nan)*
 
 
         ## Initial Concentration
@@ -532,8 +532,8 @@ def test_model_markdown():
         * **irf1** (multi-gaussian):
           * *Label*: irf1
           * *Type*: multi-gaussian
-          * *Center*: [irf.center: **1.30000e+00** *(StdErr: 0e+00)*]
-          * *Width*: [irf.width: **7.80000e+00** *(StdErr: 0e+00)*]
+          * *Center*: [irf.center: **1.30000e+00** *(StdErr: nan)*]
+          * *Width*: [irf.width: **7.80000e+00** *(StdErr: nan)*]
           * *Normalize*: True
           * *Backsweep*: False
 

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -491,19 +491,18 @@ class Parameter(_SupportsArray):
                 initial_value = initial_parameter.get(self.full_label).value
                 value += f", initial: {initial_value:.2e}"
             md += f"({value})"
+        elif self.expression is not None:
+            expression = self.expression
+            if all_parameter is not None:
+                for match in PARAMETER_EXPRESION_REGEX.findall(expression):
+                    label = match[0]
+                    parameter = all_parameter.get(label)
+                    expression = expression.replace(
+                        "$" + label, f"_{parameter.markdown(all_parameter=all_parameter)}_"
+                    )
+            md += f"({value}={expression})"
         else:
-            if self.expression is not None:
-                expression = self.expression
-                if all_parameter is not None:
-                    for match in PARAMETER_EXPRESION_REGEX.findall(expression):
-                        label = match[0]
-                        parameter = all_parameter.get(label)
-                        expression = expression.replace(
-                            "$" + label, f"_{parameter.markdown(all_parameter=all_parameter)}_"
-                        )
-                md += f"({value}={expression})"
-            else:
-                md += f"({value}, fixed)"
+            md += f"({value}, fixed)"
 
         return MarkdownStr(md)
 

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -273,7 +273,7 @@ class Parameter(_SupportsArray):
 
     @property
     def non_negative(self) -> bool:
-        r"""Indicate if the parameter is non-negativ.
+        r"""Indicate if the parameter is non-negative.
 
         If true, the parameter will be transformed with :math:`p' = \log{p}` and
         :math:`p = \exp{p'}`.
@@ -285,7 +285,7 @@ class Parameter(_SupportsArray):
         Returns
         -------
         bool
-            Whether the parameter is non-negativ.
+            Whether the parameter is non-negative.
         """
         return self._non_negative if self.expression is None else False
 

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -172,6 +172,8 @@ class Parameter(_SupportsArray):
     def as_dict(self, as_optimized: bool = True) -> dict[str, Any]:
         """Create a dictionary containing the parameter properties.
 
+        Note:
+        -----
         Intended for internal use.
 
         Parameters

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -165,7 +165,7 @@ class Parameter(_SupportsArray):
         parameter_dict["label"] = parameter_dict["label"].split(".")[-1]
         if "non-negative" in parameter_dict:
             parameter_dict["non_negative"] = parameter_dict.pop("non-negative")
-        parameter_dict.pop("standart-error", None)
+        parameter_dict.pop("standard-error", None)
 
         return cls(**parameter_dict)
 
@@ -182,7 +182,7 @@ class Parameter(_SupportsArray):
         return {
             "label": self.full_label,
             "value": self.value,
-            "standart-error": self.standard_error,
+            "standard-error": self.standard_error,
             "expression": self.expression,
             "minimum": self.minimum,
             "maximum": self.maximum,

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -47,7 +47,7 @@ class Parameter(_SupportsArray):
         maximum: float = np.inf,
         minimum: float = -np.inf,
         non_negative: bool = False,
-        standard_error: float | None = None,
+        standard_error: float = np.nan,
         value: float = np.nan,
         vary: bool = True,
     ):
@@ -69,8 +69,8 @@ class Parameter(_SupportsArray):
             Lower boundary for the parameter to be varied to., by default -np.inf
         non_negative : bool
             Whether the parameter should always be bigger than zero., by default False
-        standard_error: float | None
-            The standard error of the parameter.
+        standard_error: float
+            The standard error of the parameter. , by default ``np.nan``
         value : float
             Value of the parameter, by default np.nan
         vary : bool
@@ -395,7 +395,7 @@ class Parameter(_SupportsArray):
         return self._transformed_expression
 
     @property
-    def standard_error(self) -> float | None:
+    def standard_error(self) -> float:
         """Standard error of the optimized parameter.
 
         Returns
@@ -406,7 +406,7 @@ class Parameter(_SupportsArray):
         return self._stderr
 
     @standard_error.setter
-    def standard_error(self, standard_error: float | None):
+    def standard_error(self, standard_error: float):
         self._stderr = standard_error
 
     @property
@@ -485,7 +485,7 @@ class Parameter(_SupportsArray):
 
         value = f"{self.value:.2e}"
         if self.vary:
-            if self.standard_error is not None:
+            if self.standard_error is not np.nan:
                 value += f"±{self.standard_error}"
             if initial_parameter is not None:
                 initial_value = initial_parameter.get(self.full_label).value

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -149,14 +149,14 @@ class Parameter(_SupportsArray):
         return param
 
     @classmethod
-    def from_dict(cls, parameter_dict: dict[str, Parameter]) -> Parameter:
+    def from_dict(cls, parameter_dict: dict[str, Any]) -> Parameter:
         """Create a :class:`Parameter` from a dictionary.
 
         Expects a dictionary created by :method:`Parameter.as_dict`.
 
         Parameters
         ----------
-        parameter_dict : dict
+        parameter_dict : dict[str, Any]
             The source dictionary.
 
         Returns
@@ -169,7 +169,7 @@ class Parameter(_SupportsArray):
         parameter_dict["label"] = parameter_dict["label"].split(".")[-1]
         return cls(**parameter_dict)
 
-    def as_dict(self, as_optimized: bool = True) -> dict:
+    def as_dict(self, as_optimized: bool = True) -> dict[str, Any]:
         """Create a dictionary containing the parameter properties.
 
         Intended for internal use.
@@ -181,7 +181,7 @@ class Parameter(_SupportsArray):
 
         Returns
         -------
-        dict
+        dict[str, Any]
             The created dictionary.
         """
         parameter_dict = {
@@ -218,12 +218,12 @@ class Parameter(_SupportsArray):
         self.value = p.value
         self.vary = p.vary
 
-    def _set_options_from_dict(self, options: dict):
+    def _set_options_from_dict(self, options: dict[str, Any]):
         """Set the parameter's options from a dictionary.
 
         Parameters
         ----------
-        options : dict
+        options : dict[str, Any]
             A dictionary containing parameter options.
         """
         if Keys.EXPR in options:

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -144,6 +144,52 @@ class Parameter(_SupportsArray):
             param._set_options_from_dict(options)
         return param
 
+    @classmethod
+    def from_dict(cls, parameter_dict: dict) -> Parameter:
+        """Create a :class:`Parameter` from a dictionary.
+
+        Expects a dictionary created by :method:`Parameter.as_dict`.
+
+        Parameters
+        ----------
+        parameter_dict : dict
+            The source dictionary.
+
+        Returns
+        -------
+        Parameter
+            The created :class:`Parameter`
+        """
+        parameter_dict = parameter_dict.copy()
+        parameter_dict["full_label"] = parameter_dict["label"]
+        parameter_dict["label"] = parameter_dict["label"].split(".")[-1]
+        if "non-negative" in parameter_dict:
+            parameter_dict["non_negative"] = parameter_dict.pop("non-negative")
+        parameter_dict.pop("standart-error", None)
+
+        return cls(**parameter_dict)
+
+    def as_dict(self) -> dict:
+        """Create a dictionary containing the parameter properties.
+
+        Intended for internal use.
+
+        Returns
+        -------
+        dict
+            The created dictionary.
+        """
+        return {
+            "label": self.full_label,
+            "value": self.value,
+            "standart-error": self.standard_error,
+            "expression": self.expression,
+            "minimum": self.minimum,
+            "maximum": self.maximum,
+            "non-negative": self.non_negative,
+            "vary": self.vary,
+        }
+
     def set_from_group(self, group: ParameterGroup):
         """Set all values of the parameter to the values of the corresponding parameter in the group.
 

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -149,7 +149,7 @@ class Parameter(_SupportsArray):
         return param
 
     @classmethod
-    def from_dict(cls, parameter_dict: dict) -> Parameter:
+    def from_dict(cls, parameter_dict: dict[str, Parameter]) -> Parameter:
         """Create a :class:`Parameter` from a dictionary.
 
         Expects a dictionary created by :method:`Parameter.as_dict`.

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -44,11 +44,11 @@ class Parameter(_SupportsArray):
         label: str = None,
         full_label: str = None,
         expression: str | None = None,
-        maximum: int | float = np.inf,
-        minimum: int | float = -np.inf,
+        maximum: float = np.inf,
+        minimum: float = -np.inf,
         non_negative: bool = False,
         standard_error: float | None = None,
-        value: float | int = np.nan,
+        value: float = np.nan,
         vary: bool = True,
     ):
         """Optimization Parameter supporting numpy array operations.
@@ -63,9 +63,9 @@ class Parameter(_SupportsArray):
         expression : str | None
             Expression to calculate the parameters value from,
             e.g. if used in relation to another parameter. , by default None
-        maximum : int
+        maximum : float
             Upper boundary for the parameter to be varied to., by default np.inf
-        minimum : int
+        minimum : float
             Lower boundary for the parameter to be varied to., by default -np.inf
         non_negative : bool
             Whether the parameter should always be bigger than zero., by default False

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -46,6 +46,7 @@ class Parameter(_SupportsArray):
         maximum: int | float = np.inf,
         minimum: int | float = -np.inf,
         non_negative: bool = False,
+        standard_error: float = 0.0,
         value: float | int = np.nan,
         vary: bool = True,
     ):
@@ -79,7 +80,7 @@ class Parameter(_SupportsArray):
         self.maximum = maximum
         self.minimum = minimum
         self.non_negative = non_negative
-        self.standard_error = 0.0
+        self.standard_error = standard_error
         self.value = value
         self.vary = vary
 
@@ -160,35 +161,38 @@ class Parameter(_SupportsArray):
         Parameter
             The created :class:`Parameter`
         """
-        parameter_dict = parameter_dict.copy()
+        parameter_dict = {k.replace("-", "_"): v for k, v in parameter_dict.items()}
         parameter_dict["full_label"] = parameter_dict["label"]
         parameter_dict["label"] = parameter_dict["label"].split(".")[-1]
-        if "non-negative" in parameter_dict:
-            parameter_dict["non_negative"] = parameter_dict.pop("non-negative")
-        parameter_dict.pop("standard-error", None)
-
         return cls(**parameter_dict)
 
-    def as_dict(self) -> dict:
+    def as_dict(self, as_optimized: bool = True) -> dict:
         """Create a dictionary containing the parameter properties.
 
         Intended for internal use.
+
+        Parameters
+        ----------
+        as_optimized : bool
+            Whether to include properties which are the result of optimization.
 
         Returns
         -------
         dict
             The created dictionary.
         """
-        return {
+        parameter_dict = {
             "label": self.full_label,
             "value": self.value,
-            "standard-error": self.standard_error,
             "expression": self.expression,
             "minimum": self.minimum,
             "maximum": self.maximum,
             "non-negative": self.non_negative,
             "vary": self.vary,
         }
+        if as_optimized:
+            parameter_dict["standard-error"] = self.standard_error
+        return parameter_dict
 
     def set_from_group(self, group: ParameterGroup):
         """Set all values of the parameter to the values of the corresponding parameter in the group.

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -232,25 +232,35 @@ class ParameterGroup(dict, FileLoadableProtocol):
         """
         return self._root_group
 
-    def to_parameter_dict_list(self) -> list[dict]:
+    def to_parameter_dict_list(self, as_optimized: bool = True) -> list[dict]:
         """Create list of parameter dictionaries from the group.
+
+        Parameters
+        ----------
+        as_optimized : bool
+            Whether to include properties which are the result of optimization.
 
         Returns
         -------
         list[dict]
             Alist of parameter dictionaries.
         """
-        return [p[1].as_dict() for p in self.all()]
+        return [p[1].as_dict(as_optimized=as_optimized) for p in self.all()]
 
-    def to_dataframe(self) -> pd.DataFrame:
+    def to_dataframe(self, as_optimized: bool = True) -> pd.DataFrame:
         """Create a pandas data frame from the group.
+
+        Parameters
+        ----------
+        as_optimized : bool
+            Whether to include properties which are the result of optimization.
 
         Returns
         -------
         pd.DataFrame
             The created data frame.
         """
-        return pd.DataFrame(self.to_parameter_dict_list())
+        return pd.DataFrame(self.to_parameter_dict_list(as_optimized=as_optimized))
 
     def get_group_for_paramter_by_label(
         self, parameter_label: str, create_if_not_exist: bool = False

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from copy import copy
 from textwrap import indent
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import Generator
 
 import asteval
@@ -69,7 +70,7 @@ class ParameterGroup(dict, FileLoadableProtocol):
     @classmethod
     def from_dict(
         cls,
-        parameter_dict: dict[str, dict | list],
+        parameter_dict: dict[str, dict[str, Any] | list[float | list[Any]]],
         label: str = None,
         root_group: ParameterGroup = None,
     ) -> ParameterGroup:
@@ -103,7 +104,7 @@ class ParameterGroup(dict, FileLoadableProtocol):
     @classmethod
     def from_list(
         cls,
-        parameter_list: list[float | list],
+        parameter_list: list[float | list[Any]],
         label: str = None,
         root_group: ParameterGroup = None,
     ) -> ParameterGroup:
@@ -111,7 +112,7 @@ class ParameterGroup(dict, FileLoadableProtocol):
 
         Parameters
         ----------
-        parameter_list : list[float | list]
+        parameter_list : list[float | list[Any]]
             A parameter list containing parameters
         label : str
             The label of the group.
@@ -147,12 +148,12 @@ class ParameterGroup(dict, FileLoadableProtocol):
         return root
 
     @classmethod
-    def from_parameter_dict_list(cls, parameter_dict_list: list[dict]) -> ParameterGroup:
+    def from_parameter_dict_list(cls, parameter_dict_list: list[dict[str, Any]]) -> ParameterGroup:
         """Create a :class:`ParameterGroup` from a list of parameter dictionaries.
 
         Parameters
         ----------
-        parameter_dict_list : list[dict]
+        parameter_dict_list : list[dict[str, Any]]
             A list of parameter dictionaries.
 
         Returns
@@ -232,7 +233,7 @@ class ParameterGroup(dict, FileLoadableProtocol):
         """
         return self._root_group
 
-    def to_parameter_dict_list(self, as_optimized: bool = True) -> list[dict]:
+    def to_parameter_dict_list(self, as_optimized: bool = True) -> list[dict[str, Any]]:
         """Create list of parameter dictionaries from the group.
 
         Parameters
@@ -242,7 +243,7 @@ class ParameterGroup(dict, FileLoadableProtocol):
 
         Returns
         -------
-        list[dict]
+        list[dict[str, Any]]
             Alist of parameter dictionaries.
         """
         return [p[1].as_dict(as_optimized=as_optimized) for p in self.all()]

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -262,7 +262,7 @@ class ParameterGroup(dict, FileLoadableProtocol):
         """
         return pd.DataFrame(self.to_parameter_dict_list(as_optimized=as_optimized))
 
-    def get_group_for_paramter_by_label(
+    def get_group_for_parameter_by_label(
         self, parameter_label: str, create_if_not_exist: bool = False
     ) -> ParameterGroup:
         """Get the group for a parameter by it's label.

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -162,7 +162,7 @@ class ParameterGroup(dict, FileLoadableProtocol):
         """
         parameter_group = cls()
         for parameter_dict in parameter_dict_list:
-            group = parameter_group.get_group_for_paramter_by_label(
+            group = parameter_group.get_group_for_parameter_by_label(
                 parameter_dict["label"], create_if_not_exist=True
             )
             group.add_parameter(Parameter.from_dict(parameter_dict))

--- a/glotaran/parameter/test/test_parameter.py
+++ b/glotaran/parameter/test/test_parameter.py
@@ -346,7 +346,7 @@ def test_parameter_numpy_operations():
     assert parm1 <= parm2
 
 
-def test_parameter_to_from_dict():
+def test_parameter_dict_roundtrip():
     param = Parameter(
         label="foo",
         full_label="bar.foo",

--- a/glotaran/parameter/test/test_parameter.py
+++ b/glotaran/parameter/test/test_parameter.py
@@ -582,3 +582,28 @@ def test_parameter_to_csv(tmpdir):
         assert p.vary == p_from_csv.vary
         assert p.non_negative == p_from_csv.non_negative
         assert p.expression == p_from_csv.expression
+
+
+def test_parameter_to_from_dict():
+    param = Parameter(
+        label="foo",
+        full_label="bar.foo",
+        expression="1",
+        maximum=2,
+        minimum=1,
+        non_negative=True,
+        value=42,
+        vary=False,
+    )
+
+    param_dict = param.as_dict()
+    param_from_dict = Parameter.from_dict(param_dict)
+
+    assert param.label == param_from_dict.label
+    assert param.full_label == param_from_dict.full_label
+    assert param.expression == param_from_dict.expression
+    assert param.maximum == param_from_dict.maximum
+    assert param.minimum == param_from_dict.minimum
+    assert param.non_negative == param_from_dict.non_negative
+    assert param.value == param_from_dict.value
+    assert param.vary == param_from_dict.vary

--- a/glotaran/parameter/test/test_parameter_group.py
+++ b/glotaran/parameter/test/test_parameter_group.py
@@ -224,11 +224,22 @@ def test_parameter_group_to_csv(tmpdir):
     """,
         format_name="yml_str",
     )
+    for _, p in params.all():
+        p.standard_error = 42
 
     save_parameters(params, csv_path, "csv")
+    wanted = """label,value,standard-error,expression,minimum,maximum,non-negative,vary
+b.1,0.25,42,None,0.0,8.0,False,False
+b.2,0.75,42,1 - $b.1,-inf,inf,False,False
+rates.total,2.0,42,None,-inf,inf,False,True
+rates.branch1,0.5,42,$rates.total * $b.1,-inf,inf,False,False
+rates.branch2,1.5,42,$rates.total * $b.2,-inf,inf,False,False
+"""
 
     with open(csv_path) as f:
-        print(f.read())
+        got = f.read()
+        print(got)
+        assert got == wanted
     params_from_csv = load_parameters(csv_path)
 
     for label, p in params.all():

--- a/glotaran/parameter/test/test_parameter_group.py
+++ b/glotaran/parameter/test/test_parameter_group.py
@@ -228,12 +228,12 @@ def test_parameter_group_to_csv(tmpdir):
         p.standard_error = 42
 
     save_parameters(params, csv_path, "csv")
-    wanted = """label,value,standard-error,expression,minimum,maximum,non-negative,vary
-b.1,0.25,42,None,0.0,8.0,False,False
-b.2,0.75,42,1 - $b.1,-inf,inf,False,False
-rates.total,2.0,42,None,-inf,inf,False,True
-rates.branch1,0.5,42,$rates.total * $b.1,-inf,inf,False,False
-rates.branch2,1.5,42,$rates.total * $b.2,-inf,inf,False,False
+    wanted = """label,value,expression,minimum,maximum,non-negative,vary,standard-error
+b.1,0.25,None,0.0,8.0,False,False,42
+b.2,0.75,1 - $b.1,-inf,inf,False,False,42
+rates.total,2.0,None,-inf,inf,False,True,42
+rates.branch1,0.5,$rates.total * $b.1,-inf,inf,False,False,42
+rates.branch2,1.5,$rates.total * $b.2,-inf,inf,False,False,42
 """
 
     with open(csv_path) as f:

--- a/glotaran/parameter/test/test_parameter_group.py
+++ b/glotaran/parameter/test/test_parameter_group.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from textwrap import dedent
+
 import numpy as np
 
 from glotaran.io import load_parameters
@@ -150,13 +152,15 @@ def test_parameter_group_set_from_label_and_value_arrays():
 
 def test_parameter_group_from_csv(tmpdir):
 
-    TEST_CSV = """
-label, value, minimum, maximum, vary, non-negative, expression
-rates.k1,0.050,0,5,True,True,None
-rates.k2,None,-inf,inf,True,True,$rates.k1 * 2
-rates.k3,2.311,-inf,inf,True,True,None
-pen.eq.1,1.000,-inf,inf,False,False,None
-"""
+    TEST_CSV = dedent(
+        """\
+        label, value, minimum, maximum, vary, non-negative, expression
+        rates.k1,0.050,0,5,True,True,None
+        rates.k2,None,-inf,inf,True,True,$rates.k1 * 2
+        rates.k3,2.311,-inf,inf,True,True,None
+        pen.eq.1,1.000,-inf,inf,False,False,None
+        """
+    )
 
     csv_path = tmpdir.join("parameters.csv")
     with open(csv_path, "w") as f:
@@ -228,13 +232,16 @@ def test_parameter_group_to_csv(tmpdir):
         p.standard_error = 42
 
     save_parameters(params, csv_path, "csv")
-    wanted = """label,value,expression,minimum,maximum,non-negative,vary,standard-error
-b.1,0.25,None,0.0,8.0,False,False,42
-b.2,0.75,1 - $b.1,-inf,inf,False,False,42
-rates.total,2.0,None,-inf,inf,False,True,42
-rates.branch1,0.5,$rates.total * $b.1,-inf,inf,False,False,42
-rates.branch2,1.5,$rates.total * $b.2,-inf,inf,False,False,42
-"""
+    wanted = dedent(
+        """\
+        label,value,expression,minimum,maximum,non-negative,vary,standard-error
+        b.1,0.25,None,0.0,8.0,False,False,42
+        b.2,0.75,1 - $b.1,-inf,inf,False,False,42
+        rates.total,2.0,None,-inf,inf,False,True,42
+        rates.branch1,0.5,$rates.total * $b.1,-inf,inf,False,False,42
+        rates.branch2,1.5,$rates.total * $b.2,-inf,inf,False,False,42
+        """
+    )
 
     with open(csv_path) as f:
         got = f.read()

--- a/glotaran/parameter/test/test_parameter_group.py
+++ b/glotaran/parameter/test/test_parameter_group.py
@@ -1,106 +1,242 @@
-from IPython.core.formatters import format_display_data
+from __future__ import annotations
+
+import numpy as np
 
 from glotaran.io import load_parameters
-from glotaran.parameter.parameter_group import ParameterGroup
-
-PARAMETERS_3C_BASE = """\
-irf:
-    - ["center", 1.3]
-    - ["width", 7.8]
-j:
-    - ["1", 1, {"vary": False, "non-negative": False}]
-"""
-
-PARAMETERS_3C_KINETIC = """\
-kinetic:
-    - ["1", 300e-3]
-    - ["2", 500e-4]
-    - ["3", 700e-5]
-"""
-
-RENDERED_MARKDOWN = """\
-  * __irf__:
-
-    | _Label_   |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
-    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
-    | center    |       1.3 |          0 |    -inf |     inf | True     | False            | None     |
-    | width     |       7.8 |          0 |    -inf |     inf | True     | False            | None     |
-
-  * __j__:
-
-    |   _Label_ |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
-    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
-    |         1 |         1 |          0 |    -inf |     inf | False    | False            | None     |
-
-  * __kinetic__:
-
-    |   _Label_ |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
-    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
-    |         1 |     0.3   |          0 |    -inf |     inf | True     | False            | None     |
-    |         2 |     0.05  |          0 |    -inf |     inf | True     | False            | None     |
-    |         3 |     0.007 |          0 |    -inf |     inf | True     | False            | None     |
-
-"""  # noqa: E501
+from glotaran.io import save_parameters
 
 
-def test_param_group_markdown_is_order_independent():
-    """Markdown output of ParameterGroup.markdown() is independent of initial order"""
-    PARAMETERS_3C_INITIAL1 = f"""{PARAMETERS_3C_BASE}\n{PARAMETERS_3C_KINETIC}"""
-    PARAMETERS_3C_INITIAL2 = f"""{PARAMETERS_3C_KINETIC}\n{PARAMETERS_3C_BASE}"""
+def test_parameter_group_copy():
+    params = """
+    kinetic:
+        - ["5", 1, {non-negative: true, min: -1, max: 1, vary: false}]
+        - 4
+        - 5
+    j:
+        - 7
+        - 8
+    """
+    params = load_parameters(params, format_name="yml_str")
+    copy = params.copy()
 
-    initial_parameters_ref = ParameterGroup.from_dict(
-        {
-            "j": [["1", 1, {"vary": False, "non-negative": False}]],
-            "kinetic": [
-                ["1", 300e-3],
-                ["2", 500e-4],
-                ["3", 700e-5],
-            ],
-            "irf": [["center", 1.3], ["width", 7.8]],
-        }
+    for label, parameter in params.all():
+        assert copy.has(label)
+        copied_parameter = copy.get(label)
+        assert parameter.value == copied_parameter.value
+        assert parameter.non_negative == copied_parameter.non_negative
+        assert parameter.minimum == copied_parameter.minimum
+        assert parameter.maximum == copied_parameter.maximum
+        assert parameter.vary == copied_parameter.vary
+
+
+def test_parameter_group_from_list():
+    params = """
+    - 5
+    - 4
+    - 3
+    - 2
+    - 1
+    """
+
+    params = load_parameters(params, format_name="yml_str")
+
+    assert len(list(params.all())) == 5
+
+    assert [p.label for _, p in params.all()] == [f"{i}" for i in range(1, 6)]
+    assert [p.value for _, p in params.all()] == list(range(1, 6))[::-1]
+
+
+def test_parameter_group_from_dict():
+    params = """
+    kinetic:
+        - 3
+        - 4
+        - 5
+    j:
+        - 7
+        - 8
+    """
+
+    params = load_parameters(params, format_name="yml_str")
+
+    assert len(list(params.all())) == 5
+    group = params["kinetic"]
+    assert len(list(group.all())) == 3
+    assert [p.label for _, p in group.all()] == [f"{i}" for i in range(1, 4)]
+    assert [p.value for _, p in group.all()] == list(range(3, 6))
+    group = params["j"]
+    assert len(list(group.all())) == 2
+    assert [p.label for _, p in group.all()] == [f"{i}" for i in range(1, 3)]
+    assert [p.value for _, p in group.all()] == list(range(7, 9))
+
+
+def test_parameter_group_from_dict_nested():
+    params = """
+    kinetic:
+        j:
+            - 7
+            - 8
+            - 9
+    """
+
+    params = load_parameters(params, format_name="yml_str")
+    assert len(list(params.all())) == 3
+    group = params["kinetic"]
+    assert len(list(group.all())) == 3
+    group = group["j"]
+    assert len(list(group.all())) == 3
+    assert [p.label for _, p in group.all()] == [f"{i}" for i in range(1, 4)]
+    assert [p.value for _, p in group.all()] == list(range(7, 10))
+
+
+def test_parameter_group_to_array():
+    params = """
+    - ["1", 1, {non-negative: false, min: -1, max: 1, vary: false}]
+    - ["2", 4e2, {non-negative: true, min: 10, max: 8e2, vary: true}]
+    - ["3", 2e4]
+    """
+
+    params = load_parameters(params, format_name="yml_str")
+
+    labels, values, lower_bounds, upper_bounds = params.get_label_value_and_bounds_arrays(
+        exclude_non_vary=False
     )
 
-    initial_parameters1 = load_parameters(PARAMETERS_3C_INITIAL1, format_name="yml_str")
-    initial_parameters2 = load_parameters(PARAMETERS_3C_INITIAL2, format_name="yml_str")
+    assert len(labels) == 3
+    assert len(values) == 3
+    assert len(lower_bounds) == 3
+    assert len(upper_bounds) == 3
 
-    assert initial_parameters1.markdown() == RENDERED_MARKDOWN
-    assert initial_parameters2.markdown() == RENDERED_MARKDOWN
-    assert initial_parameters_ref.markdown() == RENDERED_MARKDOWN
+    assert labels == ["1", "2", "3"]
+    assert np.allclose(values, [1, np.log(4e2), 2e4])
+    assert np.allclose(lower_bounds, [-1, np.log(10), -np.inf])
+    assert np.allclose(upper_bounds, [1, np.log(8e2), np.inf])
 
+    (
+        labels_only_vary,
+        values_only_vary,
+        lower_bounds_only_vary,
+        upper_bounds_only_vary,
+    ) = params.get_label_value_and_bounds_arrays(exclude_non_vary=True)
 
-def test_param_group_repr():
-    """Repr creates code to recreate the object with from_dict."""
-    result = ParameterGroup.from_dict({"foo": {"bar": [["1", 1.0], ["2", 2.0], ["3", 3.0]]}})
-    result_short = ParameterGroup.from_dict({"foo": {"bar": [1, 2, 3]}})
-    expected = "ParameterGroup.from_dict({'foo': {'bar': [['1', 1.0], ['2', 2.0], ['3', 3.0]]}})"
+    assert len(labels_only_vary) == 2
+    assert len(values_only_vary) == 2
+    assert len(lower_bounds_only_vary) == 2
+    assert len(upper_bounds_only_vary) == 2
 
-    assert result == result_short
-    assert result_short.__repr__() == expected
-    assert result.__repr__() == expected
-    assert result == eval(result.__repr__())
-
-
-def test_param_group_repr_from_list():
-    """Repr creates code to recreate the object with from_list."""
-    result = ParameterGroup.from_list([["1", 2.3], ["2", 3.0]])
-    result_short = ParameterGroup.from_list([2.3, 3.0])
-    expected = "ParameterGroup.from_list([['1', 2.3], ['2', 3.0]])"
-
-    assert result == result_short
-    assert result.__repr__() == expected
-    assert result_short.__repr__() == expected
-    assert result == eval(result.__repr__())
+    assert labels_only_vary == ["2", "3"]
 
 
-def test_param_group_ipython_rendering():
-    """Autorendering in ipython"""
-    param_group = ParameterGroup.from_dict({"foo": {"bar": [["1", 1.0], ["2", 2.0], ["3", 3.0]]}})
-    rendered_obj = format_display_data(param_group)[0]
+def test_parameter_group_set_from_label_and_value_arrays():
+    params = """
+    - ["1", 1, {non-negative: false, min: -1, max: 1, vary: false}]
+    - ["2", 4e2, {non-negative: true, min: 10, max: 8e2, vary: true}]
+    - ["3", 2e4]
+    """
 
-    assert "text/markdown" in rendered_obj
-    assert rendered_obj["text/markdown"].startswith("  * __foo__")
+    params = load_parameters(params, format_name="yml_str")
 
-    rendered_markdown_return = format_display_data(param_group.markdown())[0]
+    labels = ["1", "2", "3"]
+    values = [0, np.log(6e2), 42]
 
-    assert "text/markdown" in rendered_markdown_return
-    assert rendered_markdown_return["text/markdown"].startswith("  * __foo__")
+    params.set_from_label_and_value_arrays(labels, values)
+
+    values[1] = np.exp(values[1])
+
+    for i in range(3):
+        assert params.get(f"{i+1}").value == values[i]
+
+
+def test_parameter_group_from_csv(tmpdir):
+
+    TEST_CSV = """
+label, value, minimum, maximum, vary, non-negative, expression
+rates.k1,0.050,0,5,True,True,None
+rates.k2,None,-inf,inf,True,True,$rates.k1 * 2
+rates.k3,2.311,-inf,inf,True,True,None
+pen.eq.1,1.000,-inf,inf,False,False,None
+"""
+
+    csv_path = tmpdir.join("parameters.csv")
+    with open(csv_path, "w") as f:
+        f.write(TEST_CSV)
+
+    params = load_parameters(csv_path)
+
+    assert "rates" in params
+
+    assert params.has("rates.k1")
+    p = params.get("rates.k1")
+    assert p.label == "k1"
+    assert p.value == 0.05
+    assert p.minimum == 0
+    assert p.maximum == 5
+    assert p.vary
+    assert p.non_negative
+    assert p.expression is None
+
+    assert params.has("rates.k2")
+    p = params.get("rates.k2")
+    assert p.label == "k2"
+    assert p.value == params.get("rates.k1") * 2
+    assert p.minimum == -np.inf
+    assert p.maximum == np.inf
+    assert not p.vary
+    assert not p.non_negative
+    assert p.expression == "$rates.k1 * 2"
+
+    assert params.has("rates.k3")
+    p = params.get("rates.k3")
+    assert p.label == "k3"
+    assert p.value == 2.311
+    assert p.minimum == -np.inf
+    assert p.maximum == np.inf
+    assert p.vary
+    assert p.non_negative
+    assert p.expression is None
+
+    assert "pen" in params
+    assert "eq" in params["pen"]
+
+    assert params.has("pen.eq.1")
+    p = params.get("pen.eq.1")
+    assert p.label == "1"
+    assert p.value == 1.0
+    assert p.minimum == -np.inf
+    assert p.maximum == np.inf
+    assert not p.vary
+    assert not p.non_negative
+    assert p.expression is None
+
+
+def test_parameter_group_to_csv(tmpdir):
+    csv_path = tmpdir.join("parameters.csv")
+    params = load_parameters(
+        """
+    b:
+        - ["1", 0.25, {vary: false, min: 0, max: 8}]
+        - ["2", 0.75, {expr: '1 - $b.1', non-negative: true}]
+    rates:
+        - ["total", 2]
+        - ["branch1", {expr: '$rates.total * $b.1'}]
+        - ["branch2", {expr: '$rates.total * $b.2'}]
+    """,
+        format_name="yml_str",
+    )
+
+    save_parameters(params, csv_path, "csv")
+
+    with open(csv_path) as f:
+        print(f.read())
+    params_from_csv = load_parameters(csv_path)
+
+    for label, p in params.all():
+        assert params_from_csv.has(label)
+        p_from_csv = params_from_csv.get(label)
+        assert p.label == p_from_csv.label
+        assert p.value == p_from_csv.value
+        assert p.minimum == p_from_csv.minimum
+        assert p.maximum == p_from_csv.maximum
+        assert p.vary == p_from_csv.vary
+        assert p.non_negative == p_from_csv.non_negative
+        assert p.expression == p_from_csv.expression

--- a/glotaran/parameter/test/test_parameter_group_rendering.py
+++ b/glotaran/parameter/test/test_parameter_group_rendering.py
@@ -1,0 +1,106 @@
+from IPython.core.formatters import format_display_data
+
+from glotaran.io import load_parameters
+from glotaran.parameter.parameter_group import ParameterGroup
+
+PARAMETERS_3C_BASE = """\
+irf:
+    - ["center", 1.3]
+    - ["width", 7.8]
+j:
+    - ["1", 1, {"vary": False, "non-negative": False}]
+"""
+
+PARAMETERS_3C_KINETIC = """\
+kinetic:
+    - ["1", 300e-3]
+    - ["2", 500e-4]
+    - ["3", 700e-5]
+"""
+
+RENDERED_MARKDOWN = """\
+  * __irf__:
+
+    | _Label_   |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
+    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
+    | center    |       1.3 |          0 |    -inf |     inf | True     | False            | None     |
+    | width     |       7.8 |          0 |    -inf |     inf | True     | False            | None     |
+
+  * __j__:
+
+    |   _Label_ |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
+    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
+    |         1 |         1 |          0 |    -inf |     inf | False    | False            | None     |
+
+  * __kinetic__:
+
+    |   _Label_ |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
+    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
+    |         1 |     0.3   |          0 |    -inf |     inf | True     | False            | None     |
+    |         2 |     0.05  |          0 |    -inf |     inf | True     | False            | None     |
+    |         3 |     0.007 |          0 |    -inf |     inf | True     | False            | None     |
+
+"""  # noqa: E501
+
+
+def test_param_group_markdown_is_order_independent():
+    """Markdown output of ParameterGroup.markdown() is independent of initial order"""
+    PARAMETERS_3C_INITIAL1 = f"""{PARAMETERS_3C_BASE}\n{PARAMETERS_3C_KINETIC}"""
+    PARAMETERS_3C_INITIAL2 = f"""{PARAMETERS_3C_KINETIC}\n{PARAMETERS_3C_BASE}"""
+
+    initial_parameters_ref = ParameterGroup.from_dict(
+        {
+            "j": [["1", 1, {"vary": False, "non-negative": False}]],
+            "kinetic": [
+                ["1", 300e-3],
+                ["2", 500e-4],
+                ["3", 700e-5],
+            ],
+            "irf": [["center", 1.3], ["width", 7.8]],
+        }
+    )
+
+    initial_parameters1 = load_parameters(PARAMETERS_3C_INITIAL1, format_name="yml_str")
+    initial_parameters2 = load_parameters(PARAMETERS_3C_INITIAL2, format_name="yml_str")
+
+    assert initial_parameters1.markdown() == RENDERED_MARKDOWN
+    assert initial_parameters2.markdown() == RENDERED_MARKDOWN
+    assert initial_parameters_ref.markdown() == RENDERED_MARKDOWN
+
+
+def test_param_group_repr():
+    """Repr creates code to recreate the object with from_dict."""
+    result = ParameterGroup.from_dict({"foo": {"bar": [["1", 1.0], ["2", 2.0], ["3", 3.0]]}})
+    result_short = ParameterGroup.from_dict({"foo": {"bar": [1, 2, 3]}})
+    expected = "ParameterGroup.from_dict({'foo': {'bar': [['1', 1.0], ['2', 2.0], ['3', 3.0]]}})"
+
+    assert result == result_short
+    assert result_short.__repr__() == expected
+    assert result.__repr__() == expected
+    assert result == eval(result.__repr__())
+
+
+def test_param_group_repr_from_list():
+    """Repr creates code to recreate the object with from_list."""
+    result = ParameterGroup.from_list([["1", 2.3], ["2", 3.0]])
+    result_short = ParameterGroup.from_list([2.3, 3.0])
+    expected = "ParameterGroup.from_list([['1', 2.3], ['2', 3.0]])"
+
+    assert result == result_short
+    assert result.__repr__() == expected
+    assert result_short.__repr__() == expected
+    assert result == eval(result.__repr__())
+
+
+def test_param_group_ipython_rendering():
+    """Autorendering in ipython"""
+    param_group = ParameterGroup.from_dict({"foo": {"bar": [["1", 1.0], ["2", 2.0], ["3", 3.0]]}})
+    rendered_obj = format_display_data(param_group)[0]
+
+    assert "text/markdown" in rendered_obj
+    assert rendered_obj["text/markdown"].startswith("  * __foo__")
+
+    rendered_markdown_return = format_display_data(param_group.markdown())[0]
+
+    assert "text/markdown" in rendered_markdown_return
+    assert rendered_markdown_return["text/markdown"].startswith("  * __foo__")

--- a/glotaran/parameter/test/test_parameter_group_rendering.py
+++ b/glotaran/parameter/test/test_parameter_group_rendering.py
@@ -23,22 +23,22 @@ RENDERED_MARKDOWN = """\
 
     | _Label_   |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
     |-----------|-----------|------------|---------|---------|----------|------------------|----------|
-    | center    |       1.3 |          0 |    -inf |     inf | True     | False            | None     |
-    | width     |       7.8 |          0 |    -inf |     inf | True     | False            | None     |
+    | center    |       1.3 |        nan |    -inf |     inf | True     | False            | None     |
+    | width     |       7.8 |        nan |    -inf |     inf | True     | False            | None     |
 
   * __j__:
 
     |   _Label_ |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
     |-----------|-----------|------------|---------|---------|----------|------------------|----------|
-    |         1 |         1 |          0 |    -inf |     inf | False    | False            | None     |
+    |         1 |         1 |        nan |    -inf |     inf | False    | False            | None     |
 
   * __kinetic__:
 
     |   _Label_ |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
     |-----------|-----------|------------|---------|---------|----------|------------------|----------|
-    |         1 |     0.3   |          0 |    -inf |     inf | True     | False            | None     |
-    |         2 |     0.05  |          0 |    -inf |     inf | True     | False            | None     |
-    |         3 |     0.007 |          0 |    -inf |     inf | True     | False            | None     |
+    |         1 |     0.3   |        nan |    -inf |     inf | True     | False            | None     |
+    |         2 |     0.05  |        nan |    -inf |     inf | True     | False            | None     |
+    |         3 |     0.007 |        nan |    -inf |     inf | True     | False            | None     |
 
 """  # noqa: E501
 
@@ -63,9 +63,9 @@ def test_param_group_markdown_is_order_independent():
     initial_parameters1 = load_parameters(PARAMETERS_3C_INITIAL1, format_name="yml_str")
     initial_parameters2 = load_parameters(PARAMETERS_3C_INITIAL2, format_name="yml_str")
 
-    assert initial_parameters1.markdown() == RENDERED_MARKDOWN
-    assert initial_parameters2.markdown() == RENDERED_MARKDOWN
-    assert initial_parameters_ref.markdown() == RENDERED_MARKDOWN
+    assert str(initial_parameters1.markdown()) == RENDERED_MARKDOWN
+    assert str(initial_parameters2.markdown()) == RENDERED_MARKDOWN
+    assert str(initial_parameters_ref.markdown()) == RENDERED_MARKDOWN
 
 
 def test_param_group_repr():


### PR DESCRIPTION
This PR streamlines the to and from dataframe methods of parameter group and ensures all parameter properties are included in the dataframe.

### Change summary

- Added methods `as_dict` and `from_dict` to `Parameter`
- Added methods `to_parameter_dict_list` and `from_parameter_dict_list` to `ParameterGroup`
- Refactored `to_dataframe` and `from_dataframe` to use new methods
- Refactored parameter tests
- Load standard error from df
- save standard error to parameter df
  - `to_datafame` has a switch `as_optimized` now which defaults to true, a later pr must adapt the io API
- Added `Parameter.markdown` as basis for follow up PR
  - This NOT used `ParameterGroup` to markdown. It is intended to be used by `Model.markdown`
  
### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 📚 Adds documentation of the feature

### Closes issues

closes #902
u