### PR TITLE
🩹 Remove inheriting from 'FileLoadableProtocol'

### DIFF
--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -24,7 +24,6 @@ from glotaran.model.weight import Weight
 from glotaran.parameter import Parameter
 from glotaran.parameter import ParameterGroup
 from glotaran.plugin_system.megacomplex_registration import get_megacomplex
-from glotaran.typing.protocols import FileLoadableProtocol
 from glotaran.utils.ipython import MarkdownStr
 
 default_model_items = {
@@ -44,7 +43,7 @@ default_dataset_properties = {
 }
 
 
-class Model(FileLoadableProtocol):
+class Model:
     """A base class for global analysis models."""
 
     loader = load_model

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -17,7 +17,6 @@ from glotaran.deprecation import deprecate
 from glotaran.io import load_parameters
 from glotaran.io import save_parameters
 from glotaran.parameter.parameter import Parameter
-from glotaran.typing.protocols import FileLoadableProtocol
 from glotaran.utils.ipython import MarkdownStr
 
 if TYPE_CHECKING:
@@ -31,7 +30,7 @@ class ParameterNotFoundException(Exception):
         super().__init__(f"Cannot find parameter {'.'.join(path+[label])!r}")
 
 
-class ParameterGroup(dict, FileLoadableProtocol):
+class ParameterGroup(dict):
     """Represents are group of parameters.
 
     Can contain other groups, creating a tree-like hierarchy.

--- a/glotaran/parameter/parameter_history.py
+++ b/glotaran/parameter/parameter_history.py
@@ -8,13 +8,12 @@ import numpy as np
 import pandas as pd
 
 from glotaran.parameter.parameter_group import ParameterGroup
-from glotaran.typing.protocols import FileLoadableProtocol
 
 if TYPE_CHECKING:
     from os import PathLike
 
 
-class ParameterHistory(FileLoadableProtocol):
+class ParameterHistory:
     """A class representing a history of parameters."""
 
     def __init__(self):  # noqa: D107

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -54,16 +54,24 @@ class Result:
     free_parameter_labels: list[str]
     """List of labels of the free parameters used in optimization."""
 
-    scheme: Scheme = file_loadable_field(Scheme)
+    scheme: Scheme = file_loadable_field(Scheme)  # type:ignore[type-var]
 
-    initial_parameters: ParameterGroup = file_loadable_field(ParameterGroup)
+    initial_parameters: ParameterGroup = file_loadable_field(  # type:ignore[type-var]
+        ParameterGroup
+    )
 
-    optimized_parameters: ParameterGroup = file_loadable_field(ParameterGroup)
+    optimized_parameters: ParameterGroup = file_loadable_field(  # type:ignore[type-var]
+        ParameterGroup
+    )
 
-    parameter_history: ParameterHistory = file_loadable_field(ParameterHistory)
+    parameter_history: ParameterHistory = file_loadable_field(  # type:ignore[type-var]
+        ParameterHistory
+    )
     """The parameter history."""
 
-    data: Mapping[str, xr.Dataset] = file_loadable_field(DatasetMapping, is_wrapper_class=True)
+    data: Mapping[str, xr.Dataset] = file_loadable_field(  # type:ignore[type-var]
+        DatasetMapping, is_wrapper_class=True
+    )
     """The resulting data as a dictionary of :xarraydoc:`Dataset`.
 
     Notes

--- a/glotaran/project/scheme.py
+++ b/glotaran/project/scheme.py
@@ -14,7 +14,6 @@ from glotaran.parameter import ParameterGroup
 from glotaran.project.dataclass_helpers import exclude_from_dict_field
 from glotaran.project.dataclass_helpers import file_loadable_field
 from glotaran.project.dataclass_helpers import init_file_loadable_fields
-from glotaran.typing.protocols import FileLoadableProtocol
 from glotaran.utils.io import DatasetMapping
 from glotaran.utils.ipython import MarkdownStr
 
@@ -30,15 +29,17 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class Scheme(FileLoadableProtocol):
+class Scheme:
     """A scheme is a collection of a model, parameters and a dataset.
 
     A scheme also holds options for optimization.
     """
 
-    model: Model = file_loadable_field(Model)
-    parameters: ParameterGroup = file_loadable_field(ParameterGroup)
-    data: Mapping[str, xr.Dataset] = file_loadable_field(DatasetMapping, is_wrapper_class=True)
+    model: Model = file_loadable_field(Model)  # type:ignore[type-var]
+    parameters: ParameterGroup = file_loadable_field(ParameterGroup)  # type:ignore[type-var]
+    data: Mapping[str, xr.Dataset] = file_loadable_field(
+        DatasetMapping, is_wrapper_class=True
+    )  # type:ignore[type-var]
     clp_link_tolerance: float = 0.0
     maximum_number_function_evaluations: int | None = None
     non_negative_least_squares: bool | None = exclude_from_dict_field(None)

--- a/glotaran/project/test/test_dataclass_helpers.py
+++ b/glotaran/project/test/test_dataclass_helpers.py
@@ -7,11 +7,10 @@ from glotaran.project.dataclass_helpers import exclude_from_dict_field
 from glotaran.project.dataclass_helpers import file_loadable_field
 from glotaran.project.dataclass_helpers import fromdict
 from glotaran.project.dataclass_helpers import init_file_loadable_fields
-from glotaran.typing.protocols import FileLoadableProtocol
 
 
 @dataclass
-class DummyFileLoadable(FileLoadableProtocol):
+class DummyFileLoadable:
     def __init__(self, val: str) -> None:
         self.source_path = "dummy_file"
         self.data = {"foo": val}

--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING
 import xarray as xr
 
 from glotaran.plugin_system.data_io_registration import load_dataset
-from glotaran.typing.protocols import FileLoadableProtocol
 from glotaran.typing.types import DatasetMappable
 
 if TYPE_CHECKING:
@@ -69,7 +68,7 @@ def _load_datasets(dataset_mappable: DatasetMappable, index: int = 1) -> dict[st
     return dataset_mapping
 
 
-class DatasetMapping(MutableMapping, FileLoadableProtocol):
+class DatasetMapping(MutableMapping):
     """Wrapper class for a mapping of datasets which can be used for a ``file_loadable_field``."""
 
     def __init__(self, init_map: Mapping[str, xr.Dataset] = None) -> None:


### PR DESCRIPTION
In python 3.9.7 (currently the only python 3.9 version on conda) [there was a bug](https://github.com/python/cpython/pull/27545) that ignores the __init__ method of classes that inherit from a Protocol.

This lead to the following error (discovered by @jsnel )
```python
TypeError: Protocols cannot be instantiated
```

Rather than restricting the usable python versions for typing sake, I will file an issue at `mypy` since the conformity with protocols should be picked up automatically.

### Change summary

- 🩹 Removed inheriting from 'FileLoadableProtocol'

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)