### PR TITLE
👌 Improve ParameterGroup markdown rendering

### DIFF
--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -27,6 +27,7 @@ class Keys:
     MAX = "max"
     MIN = "min"
     NON_NEG = "non-negative"
+    STD_ERR = "standard-error"
     VARY = "vary"
 
 
@@ -238,6 +239,8 @@ class Parameter(_SupportsArray):
             self.minimum = options[Keys.MIN]
         if Keys.VARY in options:
             self.vary = options[Keys.VARY]
+        if Keys.STD_ERR in options:
+            self.standard_error = options[Keys.STD_ERR]
 
     @property
     def label(self) -> str | None:

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -579,10 +579,15 @@ class ParameterGroup(dict):
                     )
                 parameter.value = value
 
-    def markdown(self) -> MarkdownStr:
+    def markdown(self, float_format: str = ".3e") -> MarkdownStr:
         """Format the :class:`ParameterGroup` as markdown string.
 
         This is done by recursing the nested :class:`ParameterGroup` tree.
+
+        Parameters
+        ----------
+        float_format: str
+            Format string for floating point numbers, by default ".3e"
 
         Returns
         -------
@@ -594,12 +599,12 @@ class ParameterGroup(dict):
         table_header = [
             "_Label_",
             "_Value_",
-            "_StdErr_",
-            "_Min_",
-            "_Max_",
+            "_Standard Error_",
+            "_Minimum_",
+            "_Maximum_",
             "_Vary_",
             "_Non-Negative_",
-            "_Expr_",
+            "_Expression_",
         ]
         if self.label is not None:
             return_string += f"{node_indentation}* __{self.label}__:\n"
@@ -613,19 +618,23 @@ class ParameterGroup(dict):
                     parameter.maximum,
                     parameter.vary,
                     parameter.non_negative,
-                    parameter.expression,
+                    f"`{parameter.expression}`",
                 ]
                 for _, parameter in self._parameters.items()
             ]
             parameter_table = indent(
                 tabulate(
-                    parameter_rows, headers=table_header, tablefmt="github", missingval="None"
+                    parameter_rows,
+                    headers=table_header,
+                    tablefmt="github",
+                    missingval="None",
+                    floatfmt=float_format,
                 ),
                 f"  {node_indentation}",
             )
             return_string += f"\n{parameter_table}\n\n"
         for _, child_group in sorted(self.items()):
-            return_string += f"{child_group.__str__()}"
+            return_string += f"{child_group.markdown(float_format=float_format)}"
         return MarkdownStr(return_string)
 
     def _repr_markdown_(self) -> str:

--- a/glotaran/parameter/test/test_parameter_group_rendering.py
+++ b/glotaran/parameter/test/test_parameter_group_rendering.py
@@ -42,6 +42,15 @@ RENDERED_MARKDOWN = """\
 
 """  # noqa: E501
 
+RENDERED_MARKDOWN_E5_PRECISION = """\
+  * __irf__:
+
+    | _Label_   |     _Value_ |   _Standard Error_ |   _Minimum_ |   _Maximum_ | _Vary_   | _Non-Negative_   | _Expression_   |
+    |-----------|-------------|--------------------|-------------|-------------|----------|------------------|----------------|
+    | center    | 1.30000e+00 |        1.23457e-05 |        -inf |         inf | True     | False            | `None`         |
+
+"""  # noqa: E501
+
 
 def test_param_group_markdown_is_order_independent():
     """Markdown output of ParameterGroup.markdown() is independent of initial order"""
@@ -66,6 +75,12 @@ def test_param_group_markdown_is_order_independent():
     assert str(initial_parameters1.markdown()) == RENDERED_MARKDOWN
     assert str(initial_parameters2.markdown()) == RENDERED_MARKDOWN
     assert str(initial_parameters_ref.markdown()) == RENDERED_MARKDOWN
+
+    minimal_params = ParameterGroup.from_dict(
+        {"irf": [["center", 1.3, {"standard-error": 0.000012345678}]]}
+    )
+
+    assert str(minimal_params.markdown(float_format=".5e")) == RENDERED_MARKDOWN_E5_PRECISION
 
 
 def test_param_group_repr():

--- a/glotaran/parameter/test/test_parameter_group_rendering.py
+++ b/glotaran/parameter/test/test_parameter_group_rendering.py
@@ -14,31 +14,31 @@ j:
 PARAMETERS_3C_KINETIC = """\
 kinetic:
     - ["1", 300e-3]
-    - ["2", 500e-4]
-    - ["3", 700e-5]
+    - ["2", 500e-4, {standard-error: 0.000012345678}]
+    - ["3", {expr: $kinetic.1 + $kinetic.2}]
 """
 
 RENDERED_MARKDOWN = """\
   * __irf__:
 
-    | _Label_   |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
-    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
-    | center    |       1.3 |        nan |    -inf |     inf | True     | False            | None     |
-    | width     |       7.8 |        nan |    -inf |     inf | True     | False            | None     |
+    | _Label_   |   _Value_ |   _Standard Error_ |   _Minimum_ |   _Maximum_ | _Vary_   | _Non-Negative_   | _Expression_   |
+    |-----------|-----------|--------------------|-------------|-------------|----------|------------------|----------------|
+    | center    | 1.300e+00 |                nan |        -inf |         inf | True     | False            | `None`         |
+    | width     | 7.800e+00 |                nan |        -inf |         inf | True     | False            | `None`         |
 
   * __j__:
 
-    |   _Label_ |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
-    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
-    |         1 |         1 |        nan |    -inf |     inf | False    | False            | None     |
+    |   _Label_ |   _Value_ |   _Standard Error_ |   _Minimum_ |   _Maximum_ | _Vary_   | _Non-Negative_   | _Expression_   |
+    |-----------|-----------|--------------------|-------------|-------------|----------|------------------|----------------|
+    |         1 | 1.000e+00 |                nan |        -inf |         inf | False    | False            | `None`         |
 
   * __kinetic__:
 
-    |   _Label_ |   _Value_ |   _StdErr_ |   _Min_ |   _Max_ | _Vary_   | _Non-Negative_   | _Expr_   |
-    |-----------|-----------|------------|---------|---------|----------|------------------|----------|
-    |         1 |     0.3   |        nan |    -inf |     inf | True     | False            | None     |
-    |         2 |     0.05  |        nan |    -inf |     inf | True     | False            | None     |
-    |         3 |     0.007 |        nan |    -inf |     inf | True     | False            | None     |
+    |   _Label_ |   _Value_ |   _Standard Error_ |   _Minimum_ |   _Maximum_ | _Vary_   | _Non-Negative_   | _Expression_              |
+    |-----------|-----------|--------------------|-------------|-------------|----------|------------------|---------------------------|
+    |         1 | 3.000e-01 |        nan         |        -inf |         inf | True     | False            | `None`                    |
+    |         2 | 5.000e-02 |          1.235e-05 |        -inf |         inf | True     | False            | `None`                    |
+    |         3 | 3.500e-01 |        nan         |        -inf |         inf | False    | False            | `$kinetic.1 + $kinetic.2` |
 
 """  # noqa: E501
 
@@ -52,9 +52,9 @@ def test_param_group_markdown_is_order_independent():
         {
             "j": [["1", 1, {"vary": False, "non-negative": False}]],
             "kinetic": [
-                ["1", 300e-3],
-                ["2", 500e-4],
-                ["3", 700e-5],
+                ["1", 0.3],
+                ["2", 500e-4, {"standard-error": 0.000012345678}],
+                ["3", 700e-5, {"expr": "$kinetic.1 + $kinetic.2"}],
             ],
             "irf": [["center", 1.3], ["width", 7.8]],
         }


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo or adding an example to the showcase. -->

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

Please provide enough information so that others can review your pull request:

Explain the **details** for making this change. What existing problem does the pull request solve?.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

### Change summary

- Table headers in markdown don't use a mix of abbreviations and spelled out names but only spelled out names
- Expression column doesn't evidently render as latex when 2 or more parameters are present
- Numbers get formatted as `.3e` by default
- User can decide on the float precision of the markdown table by passing `float_format`

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #916
