### PR TITLE
🩹 Bugfix Use normalized initial_concentrations in result creation for decay megacomplex

### DIFF
--- a/glotaran/builtin/megacomplexes/decay/util.py
+++ b/glotaran/builtin/megacomplexes/decay/util.py
@@ -167,7 +167,7 @@ def retrieve_decay_associated_data(
 
     matrix = k_matrix.full(species)
     matrix_reduced = k_matrix.reduced(species)
-    a_matrix = k_matrix.a_matrix(dataset_model.initial_concentration)
+    a_matrix = k_matrix.a_matrix(dataset_model.initial_concentration.normalized())
     rates = k_matrix.rates(dataset_model.initial_concentration)
     lifetimes = 1 / rates
 


### PR DESCRIPTION
### Change summary

- Use normalized Irf in creation of resulting A matrix and DAS
- Bugfix also back-ported to v0.4 maintenance branch in #935 

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

Closes #926, #932
