### PR TITLE
Add include statement to model yml

### DIFF
--- a/glotaran/builtin/io/yml/test/test_model_include.py
+++ b/glotaran/builtin/io/yml/test/test_model_include.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from glotaran.io import load_model
+
+TEST_MODEL_DATASET = """\
+dataset:
+  d1:
+    megacomplex: [m1]
+"""
+TEST_MODEL_MEGACOMPLEX = """\
+megacomplex:
+  m1:
+    type: decay
+    k_matrix: []
+"""
+
+TEST_MODEL = """\
+include:
+  - {d_path}
+  - {m_path}
+"""
+
+
+def test_model_include(tmp_path: Path):
+    d_path = tmp_path / "dataset.yml"
+    m_path = tmp_path / "megacomplex.yml"
+    model_path = tmp_path / "model.yml"
+
+    with open(d_path, "w") as f:
+        f.write(TEST_MODEL_DATASET)
+
+    with open(m_path, "w") as f:
+        f.write(TEST_MODEL_MEGACOMPLEX)
+    with open(model_path, "w") as f:
+        f.write(TEST_MODEL.format(d_path=d_path, m_path=m_path))
+
+    model = load_model(model_path)
+
+    assert "d1" in model.dataset
+    assert "m1" in model.megacomplex

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -48,6 +48,13 @@ class YmlProjectIo(ProjectIoInterface):
 
         spec = sanitize_yaml(spec)
 
+        if "include" in spec:
+            includes = spec.pop("include")
+            if not isinstance(includes, list):
+                includes = [includes]
+            for include in includes:
+                spec.update(self._load_yml(include))
+
         default_megacomplex = spec.get("default_megacomplex")
 
         if default_megacomplex is None and any(


### PR DESCRIPTION
This PR adds the statement `include` to the model spec. This is useful for splitting large models into multiple files.

### Change summary

- added `include` keyword to model spec yaml and added parsing logic
- this might have troubles when round tripping, so more work on that is required

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 📚 Adds documentation of the feature

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #XXXX
