### PR TITLE
🩹 Fix save_result crashes on Windows if input data are on a different drive than result

### DIFF
--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -184,5 +184,5 @@ def relative_posix_path(source_path: StrOrPath, base_path: StrOrPath | None = No
         try:
             source_path = os.path.relpath(source_path, Path(base_path).as_posix())
         except ValueError:
-            source_path = Path(source_path).as_posix()
+            pass
     return Path(source_path).as_posix()

--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -164,6 +164,9 @@ def load_datasets(dataset_mappable: DatasetMappable) -> DatasetMapping:
 def relative_posix_path(source_path: StrOrPath, base_path: StrOrPath | None = None) -> str:
     """Ensure that ``source_path`` is a posix path, relative to ``base_path`` if defined.
 
+    On windows if ``source_path`` and ``base_path`` are on different drives, it will return
+    the absolute posix path to the file.
+
     Parameters
     ----------
     source_path : StrOrPath
@@ -178,5 +181,8 @@ def relative_posix_path(source_path: StrOrPath, base_path: StrOrPath | None = No
     """
     source_path = Path(source_path).as_posix()
     if base_path is not None and os.path.isabs(source_path):
-        source_path = os.path.relpath(source_path, Path(base_path).as_posix())
+        try:
+            source_path = os.path.relpath(source_path, Path(base_path).as_posix())
+        except ValueError:
+            source_path = Path(source_path).as_posix()
     return Path(source_path).as_posix()

--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -164,7 +164,7 @@ def load_datasets(dataset_mappable: DatasetMappable) -> DatasetMapping:
 def relative_posix_path(source_path: StrOrPath, base_path: StrOrPath | None = None) -> str:
     """Ensure that ``source_path`` is a posix path, relative to ``base_path`` if defined.
 
-    On windows if ``source_path`` and ``base_path`` are on different drives, it will return
+    On Windows if ``source_path`` and ``base_path`` are on different drives, it will return
     the absolute posix path to the file.
 
     Parameters

--- a/glotaran/utils/test/test_io.py
+++ b/glotaran/utils/test/test_io.py
@@ -160,9 +160,9 @@ def test_relative_posix_path(tmp_path: Path, rel_file_path: str):
     assert rel_result_no_coomon == f"../{rel_file_path}"
 
 
-@pytest.mark.skipif(not sys.platform.startswith("win32"), reason="Only needed for wondows")
+@pytest.mark.skipif(not sys.platform.startswith("win32"), reason="Only needed for Windows")
 def test_relative_posix_path_windows_diff_drives():
-    """os.path.relpath doesn't cause crash when files are of different drives."""
+    """os.path.relpath doesn't cause crash when files are on different drives."""
 
     source_path = "D:\\data\\data_file.txt"
     result = relative_posix_path(source_path, "C:\\result_path")

--- a/glotaran/utils/test/test_io.py
+++ b/glotaran/utils/test/test_io.py
@@ -1,6 +1,7 @@
 """Tests for glotaran/utils/io.py"""
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -157,3 +158,13 @@ def test_relative_posix_path(tmp_path: Path, rel_file_path: str):
     )
 
     assert rel_result_no_coomon == f"../{rel_file_path}"
+
+
+@pytest.mark.skipif(not sys.platform.startswith("win32"), reason="Only needed for wondows")
+def test_relative_posix_path_windows_diff_drives():
+    """os.path.relpath doesn't cause crash when files are of different drives."""
+
+    source_path = "D:\\data\\data_file.txt"
+    result = relative_posix_path(source_path, "C:\\result_path")
+
+    assert result == Path(source_path).as_posix()


### PR DESCRIPTION
This fixes the crash of `save_result` when the original data and the result path are on different drives on windows.

~The commit e431760a9646e3ca311107926cafa4a952092416 is optional.~

### Change summary

- 🩹 Made 'relative_posix_path' more stable on windows
~- ♻️ Changed save_result folder to use the result.data for scheme.data~

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

closes #924
