### PR TITLE
🚀🩹 v0.4.2 release preparation and bugfix backport for result consistency checking purposes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 - 🩹🚧 Backport of bugfix #927 discovered in PR #860 related to initial_concentration normalization when saving results (#935).
 
+### 🚧 Maintenance
+
+- 🚇🚧 Updated 'gold standard' result comparison reference ([old](https://github.com/glotaran/pyglotaran-examples/commit/9b8591c668ad7383a908b853339966d5a5f7fe43) -> [new](https://github.com/glotaran/pyglotaran-examples/commit/fc5a5ca0c7fd8b224c85027b510a15717c696c7b))
+
 ## 0.4.1 (2021-09-07)
 
 ### ✨ Features

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.2 (2021-12-12)
+
+### 🩹 Bug fixes
+
+- 🩹🚧 Backport of bugfix #927 discovered in PR #860 related to initial_concentration normalization when saving results (#935).
+
 ## 0.4.1 (2021-09-07)
 
 ### ✨ Features

--- a/glotaran/__init__.py
+++ b/glotaran/__init__.py
@@ -8,7 +8,7 @@ from glotaran.plugin_system.base_registry import load_plugins
 
 load_plugins()
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 
 def __getattr__(attribute_name: str):

--- a/glotaran/builtin/models/kinetic_image/kinetic_image_result.py
+++ b/glotaran/builtin/models/kinetic_image/kinetic_image_result.py
@@ -78,7 +78,7 @@ def retrieve_decay_associated_data(model, dataset, dataset_descriptor, name):
 
             matrix = k_matrix.full(compartments)
             matrix_reduced = k_matrix.reduced(compartments)
-            a_matrix = k_matrix.a_matrix(dataset_descriptor.initial_concentration)
+            a_matrix = k_matrix.a_matrix(dataset_descriptor.initial_concentration.normalized())
             rates = k_matrix.rates(dataset_descriptor.initial_concentration)
             lifetimes = 1 / rates
 


### PR DESCRIPTION
# Maintenance release v0.4.2 with bugfix backport for result consistency checking purposes

##  🩹🚧 Backport of bugfix #927 discovered in PR #860 related to initial_concentration normalization when saving results (#935).

It was [found](https://github.com/glotaran/pyglotaran/pull/860#issuecomment-985467588) in #860 that the a_matrix when calculated for result saving was calculated without normalized initial_concentrations while the calculation for the optimization was (correctly) using the normalized version. Fixing this bug in #927 then breaks result consistency checking for some case studies, thus requiring backporting of this bugfix to the 0.4 maintenance branch which we continue to use for result/consistency checking.


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 👌 Link to issue issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 📚 Adds documentation of the feature

