### PR TITLE
🚇Update test_result_consistency

### DIFF
--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -180,7 +180,7 @@ def data_var_test(
     eps = np.finfo(np.float32).eps
     rtol = 1e-5  # default value of allclose
     if expected_var_name.endswith("residual"):  # type:ignore[operator]
-        eps = expected_result["data"].values.max() * 1e-8
+        eps = max(eps, expected_result["data"].values.max() * eps)
 
     if "singular_vectors" in expected_var_name:  # type:ignore[operator]
         # Sometimes the coords in the (right) singular vectors are swapped
@@ -235,6 +235,7 @@ def data_var_test(
         f"{float(np.sum(abs_diff))} and shape: {expected_var_value.shape}\n"
         "Mean difference: "
         f"{float(np.sum(abs_diff))/np.prod(expected_var_value.shape)}\n"
+        f"Using: \n - {rtol=} \n - {eps=} \n - {float_resolution=}"
     )
 
     coord_test(

--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -211,6 +211,11 @@ def data_var_test(
             np.abs(eps * expected_values_scaled),
             np.ones(expected_var_value.data.shape) * eps,
         )
+    elif "spectra" in expected_var_name:
+        float_resolution = np.maximum(
+            np.ones(expected_var_value.data.shape) * eps * np.max(np.abs(expected_var_value.data)),
+            np.ones(expected_var_value.data.shape) * eps,
+        )
     else:
         float_resolution = np.maximum(
             np.abs(eps * expected_var_value.data),

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 ### 🚧 Maintenance
 
 - 🚇🚧 Updated 'gold standard' result comparison reference ([old](https://github.com/glotaran/pyglotaran-examples/commit/9b8591c668ad7383a908b853339966d5a5f7fe43) -> [new](https://github.com/glotaran/pyglotaran-examples/commit/fc5a5ca0c7fd8b224c85027b510a15717c696c7b))
+- 🚇 Refine test_result_consistency #936
 
 ## 0.4.1 (2021-09-07)
 


### PR DESCRIPTION
Update float_resolution for comparison of spectral values, fixing issue #937 identified in #936

Refer to comment in #936 reproduced below:

After the update we find that the result comparison still fails but only for a singular data point in one of the examples (log below). Digging a little deeper (looking at the plot) we find that the point of failure is at a place were the spectral value in question is very small (~-1.497), compared to the overall maximum of the spectrum (~7500). However, the spectra are compared locally (per wavelength) and the absolute tolerance for the comparison between results is scaled with the local value of the data, meaning that the tolerance for a point close to zero is much tighter than the tolerance for a point near the maximum. This is a point where the result comparison could be further refined, but for now we accept this as a PASS ✔️ and this PR may be merged.

<details>
<summary>FAILED .github/test_result_consistency.py::test_result_data_var_consistency[study_fluorescence-decay_associated_spectra]</summary>

```python
E       AssertionError: Result data_var data mismatch: 'decay_associated_spectra' in 'dataset1.nc'.
E         With sum of absolute difference: 0.0039020775839004873 and shape: (49, 5)
E         Mean difference: 1.592684728122648e-05
E         
E       assert False
E        +  where False = <function allclose.<locals>._allclose at 0x7f40599e5790>(<xarray.DataArray 'decay_associated_spectra' (spectral: 49, component: 5)>\narray([[-145.581345,   52.590453,   21.6330...7\n    rate      (component) float64 ...\n    lifetime  (component) float64 ...\nDimensions without coordinates: component, <xarray.DataArray 'decay_associated_spectra' (spectral: 49, component: 5)>\narray([[-145.581346,   52.590453,   21.6330...7\n    rate      (component) float64 ...\n    lifetime  (component) float64 ...\nDimensions without coordinates: component, atol=array([[1.73546487e-05, 6.26927054e-06, 2.57886253e-06, 2.17881660e-06,\n        6.32769907e-06],\n       [1.50005268e-0...     5.91504505e-06],\n       [5.92400043e-05, 4.45607905e-05, 4.22466039e-06, 1.01596965e-04,\n        6.42848991e-06]]), rtol=1e-05, print_fail=20)

.github/test_result_consistency.py:221: AssertionError
----------------------------- Captured stdout call -----------------------------
allclose first 1 failures:
  (40, 1): -1.4969902223364386 -1.4969635695838823
=========================== short test summary info ============================
FAILED .github/test_result_consistency.py::test_result_data_var_consistency[study_fluorescence-decay_associated_spectra]
```
</details>

_Originally posted by @jsnel in https://github.com/glotaran/pyglotaran/issues/935#issuecomment-991814672_


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)

