### PR TITLE
🩹Fix bug in create_index_independent_result_dataset

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
 
 ### 🩹 Bug fixes
 
+- 🩹 Fix Crash in optimization_group_calculator_linked when using guidance spectra (#950)
+
 ### 📚 Documentation
 
 ### 🗑️ Deprecations (due in 0.8.0)

--- a/glotaran/analysis/optimization_group_calculator_linked.py
+++ b/glotaran/analysis/optimization_group_calculator_linked.py
@@ -463,10 +463,11 @@ class OptimizationGroupCalculatorLinked(OptimizationGroupCalculator):
 
         dataset["matrix"] = (
             (
+                (self._global_dimension),
                 (self._model_dimension),
                 ("clp_label"),
             ),
-            self._group.matrices[label].matrix,
+            np.asarray([m.matrix for m in self._group.matrices[label]]),
         )
         dataset["clp"] = self._group.clps[label]
 

--- a/glotaran/analysis/optimization_group_calculator_linked.py
+++ b/glotaran/analysis/optimization_group_calculator_linked.py
@@ -461,14 +461,24 @@ class OptimizationGroupCalculatorLinked(OptimizationGroupCalculator):
     ) -> xr.Dataset:
         """Creates a result datasets for index independent matrices."""
 
-        dataset["matrix"] = (
-            (
-                (self._global_dimension),
-                (self._model_dimension),
-                ("clp_label"),
-            ),
-            np.asarray([m.matrix for m in self._group.matrices[label]]),
-        )
+        dummy = self._group.matrices[label]
+        if isinstance(dummy, CalculatedMatrix):
+            dataset["matrix"] = (
+                (
+                    (self._model_dimension),
+                    ("clp_label"),
+                ),
+                self._group.matrices[label].matrix,
+            )
+        else:
+            dataset["matrix"] = (
+                (
+                    (self._global_dimension),
+                    (self._model_dimension),
+                    ("clp_label"),
+                ),
+                np.asarray([m.matrix for m in self._group.matrices[label]]),
+            )
         dataset["clp"] = self._group.clps[label]
 
         for index, grouped_problem in enumerate(self.bag):

--- a/glotaran/analysis/optimization_group_calculator_linked.py
+++ b/glotaran/analysis/optimization_group_calculator_linked.py
@@ -397,7 +397,7 @@ class OptimizationGroupCalculatorLinked(OptimizationGroupCalculator):
             for i, index_model in enumerate(group_model.dataset_models):
                 label = index_model.label
                 if self._group.dataset_models[label] is not None:
-                    start = sum(group_model.data_sizes[0:i])
+                    start = sum(group_model.data_sizes[:i])
                     end = start + group_model.data_sizes[i]
                     matrix[start:end, :] *= self._group.dataset_models[label].scale
 


### PR DESCRIPTION
### Change summary

- Indexing did not match content of _group.matrices (list of CalculatedMatrix objects)
- Dimension did not match (for guidance spectra) (global_dimension_index appeared to be missing

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Closes #950 
