### PR TITLE
🔧🚇 Exclude test files from duplication checks on sonarcloud

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.cpd.exclusions=**/test_*.py

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 ### 🚧 Maintenance
 
 - 🔧 Improve packaging tooling (#923)
+  🔧🚇 Exclude test files from duplication checks on sonarcloud (#959)
 
 ## 0.5.1 (2021-12-31)
 


### PR DESCRIPTION
Due to duplications that aren't even part of a PR sonarcloud is failing its test (e.g. #958 )

![image](https://user-images.githubusercontent.com/9513634/149675549-23bcf070-29cc-4fc5-9c53-10c954e83892.png)

![image](https://user-images.githubusercontent.com/9513634/149675636-8f6dd154-2cff-4354-bd2f-161515e18b7c.png)

By adding the test files which should be verbose and readable, I hope we can get around this issue.

### Change summary

- 🔧 Exclude test files from duplication checks

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
