### PR TITLE
🔧🚇 Only run check-maifest on the CI

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -13,6 +13,21 @@ jobs:
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.3
 
+  check-manifest:
+    name: Check Manifest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install check manifest
+        run: python -m pip install check-manifest
+      - name: Run check manifest
+        run: check-manifest
+
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -88,7 +103,7 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
-    needs: pre-commit
+    needs: [pre-commit, check-manifest]
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,8 +145,3 @@ repos:
         types: [file]
         types_or: [python, pyi, markdown, rst, jupyter]
         args: [-L doas]
-
-  - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.47"
-    hooks:
-      - id: check-manifest

--- a/changelog.md
+++ b/changelog.md
@@ -22,7 +22,8 @@
 ### 🚧 Maintenance
 
 - 🔧 Improve packaging tooling (#923)
-  🔧🚇 Exclude test files from duplication checks on sonarcloud (#959)
+- 🔧🚇 Exclude test files from duplication checks on sonarcloud (#959)
+- 🔧🚇 Only run check-maifest on the CI #967
 
 ## 0.5.1 (2021-12-31)
 


### PR DESCRIPTION
While it is important that we check if all files we want to bundle are actually bundled in the distribution, checking this in pre-commit can be cumbersome.
E.g. you were working on a PR and when you got it to work the way you want you to commit different small changes in contextual closed commits. If you added new files which you don't want to add in this commit `check-manifest` won't allow you to make this commit since it looks at all files and not only the tracked ones.
This in turn means that you need to make big commits or use the `--no-verify` flag which both can lead to bad commits.

### Change summary

- 🔧🚇 Only run check-manifest on the CI

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
