### PR TITLE
🩹 Disallow xarray 0.21.0 in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     sdtfile>=2020.8.3
     setuptools>=41.2
     tabulate>=0.8.8
-    xarray!=0.20.0,!=0.20.1,>=0.16.2
+    xarray!=0.20.0,!=0.20.1,!=0.21.0,>=0.16.2
 python_requires = >=3.8, <3.10
 setup_requires =
     setuptools>=41.2


### PR DESCRIPTION
Currently our [ASV workflow fails](https://github.com/glotaran/pyglotaran/runs/4990008398?check_suite_focus=true) since `xarray==0.21.0` had a [mishap forgetting to add `packaging` as a dependency](https://github.com/pydata/xarray/pull/6207). 
Happens to the best of us, especially since `packaging` piggybacks on `pytest` so you won't see this error in any test environment, and even in our docs something added it, so they pass.

Anyway, to have our benchmarks work and go on with our stuff, let's just disallow this version until everything is sorted out.

If `xarray` decides to make a  [post-release](https://www.python.org/dev/peps/pep-0440/#post-releases), we can simply revert this change. If they rather choose to make a bugfix release it will stay in.

### Change summary

- 🩹 Disallow xarray 0.21.0

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)