### PR TITLE
✨Add Python 3.10 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,23 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: friday
-    time: "18:00"
-    timezone: Europe/Amsterdam
-  open-pull-requests-limit: 20
-  reviewers:
-  - jsnel
-  assignees:
-  - jsnel
-  ignore:
-  - dependency-name: setuptools
-    versions:
-    - "> 41.2"
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: friday
+      time: "18:00"
+      timezone: Europe/Amsterdam
+    open-pull-requests-limit: 20
+    reviewers:
+      - jsnel
+    assignees:
+      - jsnel
 
-# Maintain dependencies for GitHub Actions
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-    day: friday
-    time: "18:00"
-    timezone: Europe/Amsterdam
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: friday
+      time: "18:00"
+      timezone: Europe/Amsterdam

--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### ✨ Features
 
+- ✨ Python 3.10 support (#977)
 - ✨ Add simple decay megacomplexes (#860)
 - ✨ Feature: Generators (#866)
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,7 +13,6 @@ rich==11.1.0
 ruamel.yaml==0.17.20
 scipy==1.7.3
 sdtfile==2021.11.18
-setuptools==41.2
 tabulate==0.8.9
 xarray==0.20.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics
@@ -45,7 +46,7 @@ install_requires =
     setuptools>=41.2
     tabulate>=0.8.8
     xarray!=0.20.0,!=0.20.1,!=0.21.0,>=0.16.2
-python_requires = >=3.8, <3.10
+python_requires = >=3.8, <3.11
 setup_requires =
     setuptools>=41.2
 tests_require = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 3.4.0
 skipsdist = true
 skip_missing_interpreters=true
-envlist = py{38}, pre-commit, docs, docs-notebooks, docs-links
+envlist = py{38,39,310}, pre-commit, docs, docs-notebooks, docs-links
 
 [pytest]
 ; Uncomment the following lines to deactivate pyglotaran all plugins


### PR DESCRIPTION
[Numba 0.55.0 added support for python 3.10](https://github.com/numba/numba/releases/tag/0.55.0) which means so can we

### Change summary

- 🚇🧪 Add tests for python 3.10
- ⬆️ Raised max supported python version to <3.11
- ⬆️ Unpin `setuptools`

Using an old version of `setuptools` caused a lot of import errors in python 3.10
Pinning the version of `setuptools` goes back to the time when we still had c-extensions, so it is safe to unpin it

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
