### PR TITLE
 🚇👌 Exclude dependabot push CI runs

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+  pull_request:
 
 jobs:
   pre-commit:

--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 - 🔧 Improve packaging tooling (#923)
 - 🔧🚇 Exclude test files from duplication checks on sonarcloud (#959)
 - 🔧🚇 Only run check-maifest on the CI #967
+- 🚇👌 Exclude dependabot push CI runs #978
 
 ## 0.5.1 (2021-12-31)
 


### PR DESCRIPTION
Since dependabot opens its branches for PRs on our repo and we require a linear history builds on `push` and `pull_request` are the same. And by deactivating the CI for the `push` event on dependabot branches we save time and energy.

### Change summary

- 🚇👌 Exclude dependabot push CI runs

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)