### PR TITLE
🚇 Only run doxygen workflow when requested

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -5,6 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   run-doxygen:
     name: Doxygen callgraph
+    environment: Debug
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Since we most of the time don't make use of the Doxygen generated callgraphs we don't need to always run the workflow.
Thus is created a [github environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) called `Debug` which needs approval from a member of @glotaran/contributors to run.
That way Doxygen won't run until we approve/request it.

### Change summary

- 🚇 Only run doxygen workflow when requested

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
