### PR TITLE
🩹🚇 Fix release pipeline not running on push tag

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+    tags:
+      - v**
     branches-ignore:
       - "dependabot/**"
   pull_request:
@@ -116,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,6 +2,8 @@ name: "Run Examples"
 
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.8
       - name: Install ASV
         run: |
-          pip install asv virtualenv
+          pip install 'asv!=0.5' virtualenv
 
       - name: show home file
         run: |


### PR DESCRIPTION
Looks like specifying `branches-ignore` on the push event also prevents it from running on pushed tags.
This prevents the release workflow from publishing to PyPI.

### Change summary

- [🩹🚇 Fixed release pipeline not running on push tag](https://github.com/glotaran/pyglotaran/commit/9b42d4db638258c86f79d9bdeae86bd41cf7b7c0)
- [🩹🚇 Exclude asv version 0.5](https://github.com/glotaran/pyglotaran/pull/990/commits/98fce429c723e9d6f4108fd36eaafbb8e0984cd2) (there was a [mishap when packaging](https://github.com/airspeed-velocity/asv/pull/1013) resulting in a broken package)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)