### PR TITLE
👌 Improve Result, Parameter and ParameterGroup markdown

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 - ✨ Add parameter IO support for more formats supported by pandas (#896)
 - 👌 Apply IRF shift in coherent artifact megacomplex (#992)
 - 👌 Added IRF shift to result dataset (#994)
+- 👌 Improve Result, Parameter and ParameterGroup markdown (#1012)
 
 ### 🩹 Bug fixes
 

--- a/glotaran/analysis/optimize.py
+++ b/glotaran/analysis/optimize.py
@@ -119,8 +119,8 @@ def _create_result(
     number_of_jacobian_evaluation = ls_result.njev if success else None
     optimality = float(ls_result.optimality) if success else None
     number_of_data_points = ls_result.fun.size if success else None
-    number_of_variables = ls_result.x.size if success else None
-    degrees_of_freedom = number_of_data_points - number_of_variables if success else None
+    number_of_parameters = ls_result.x.size if success else None
+    degrees_of_freedom = number_of_data_points - number_of_parameters if success else None
     chi_square = float(np.sum(ls_result.fun ** 2)) if success else None
     reduced_chi_square = chi_square / degrees_of_freedom if success else None
     root_mean_square_error = float(np.sqrt(reduced_chi_square)) if success else None
@@ -173,7 +173,7 @@ def _create_result(
         jacobian=jacobian,
         number_of_data_points=number_of_data_points,
         number_of_jacobian_evaluations=number_of_jacobian_evaluation,
-        number_of_parameters=number_of_variables,
+        number_of_parameters=number_of_parameters,
         optimality=optimality,
         reduced_chi_square=reduced_chi_square,
         root_mean_square_error=root_mean_square_error,

--- a/glotaran/analysis/optimize.py
+++ b/glotaran/analysis/optimize.py
@@ -173,7 +173,7 @@ def _create_result(
         jacobian=jacobian,
         number_of_data_points=number_of_data_points,
         number_of_jacobian_evaluations=number_of_jacobian_evaluation,
-        number_of_variables=number_of_variables,
+        number_of_parameters=number_of_variables,
         optimality=optimality,
         reduced_chi_square=reduced_chi_square,
         root_mean_square_error=root_mean_square_error,

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -112,7 +112,7 @@ class Parameter(_SupportsArray):
     def from_list_or_value(
         cls,
         value: int | float | list,
-        default_options: dict = None,
+        default_options: dict[str, Any] | None = None,
         label: str = None,
     ) -> Parameter:
         """Create a parameter from a list or numeric value.
@@ -121,7 +121,7 @@ class Parameter(_SupportsArray):
         ----------
         value : int | float | list
             The list or numeric value.
-        default_options : dict
+        default_options : dict[str, Any]|None
             A dictionary of default options.
         label : str
             The label of the parameter.
@@ -509,6 +509,7 @@ class Parameter(_SupportsArray):
                     expression = expression.replace(
                         f"${label}", f"_{parameter.markdown(all_parameters=all_parameters)}_"
                     )
+
             md += f"({value}={expression})"
         else:
             md += f"({value}, fixed)"

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -10,6 +10,7 @@ import numpy as np
 from numpy.typing._array_like import _SupportsArray
 
 from glotaran.utils.ipython import MarkdownStr
+from glotaran.utils.sanitize import pretty_format_numerical
 from glotaran.utils.sanitize import sanitize_parameter_list
 
 if TYPE_CHECKING:
@@ -492,7 +493,9 @@ class Parameter(_SupportsArray):
         value = f"{parameter.value:.2e}"
         if parameter.vary:
             if parameter.standard_error is not np.nan:
-                value += f"±{parameter.standard_error:.2e}"
+                t_value = pretty_format_numerical(parameter.value / parameter.standard_error)
+                value += f"±{parameter.standard_error:.2e}, t-value: {t_value}"
+
             if initial_parameters is not None:
                 initial_value = initial_parameters.get(parameter.full_label).value
                 value += f", initial: {initial_value:.2e}"

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -275,7 +275,7 @@ class Parameter(_SupportsArray):
 
     @full_label.setter
     def full_label(self, full_label: str):
-        self._full_label = str(full_label)
+        self._full_label = str(full_label)  # sourcery skip
 
     @property
     def non_negative(self) -> bool:
@@ -507,7 +507,7 @@ class Parameter(_SupportsArray):
                     label = match[0]
                     parameter = all_parameters.get(label)
                     expression = expression.replace(
-                        "$" + label, f"_{parameter.markdown(all_parameters=all_parameters)}_"
+                        f"${label}", f"_{parameter.markdown(all_parameters=all_parameters)}_"
                     )
             md += f"({value}={expression})"
         else:

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -18,6 +18,7 @@ from glotaran.io import load_parameters
 from glotaran.io import save_parameters
 from glotaran.parameter.parameter import Parameter
 from glotaran.utils.ipython import MarkdownStr
+from glotaran.utils.sanitize import pretty_format_numerical
 
 if TYPE_CHECKING:
     from glotaran.parameter.parameter_history import ParameterHistory
@@ -606,6 +607,7 @@ class ParameterGroup(dict):
             "_Label_",
             "_Value_",
             "_Standard Error_",
+            "_t-value_",
             "_Minimum_",
             "_Maximum_",
             "_Vary_",
@@ -620,6 +622,7 @@ class ParameterGroup(dict):
                     parameter.label,
                     parameter.value,
                     parameter.standard_error,
+                    repr(pretty_format_numerical(parameter.value / parameter.standard_error)),
                     parameter.minimum,
                     parameter.maximum,
                     parameter.vary,
@@ -641,7 +644,7 @@ class ParameterGroup(dict):
             return_string += f"\n{parameter_table}\n\n"
         for _, child_group in sorted(self.items()):
             return_string += f"{child_group.markdown(float_format=float_format)}"
-        return MarkdownStr(return_string)
+        return MarkdownStr(return_string.replace("'", " "))
 
     def _repr_markdown_(self) -> str:
         """Create a markdown respresentation.

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -126,12 +126,9 @@ class ParameterGroup(dict):
         """
         root = cls(label=label, root_group=root_group)
 
-        # get defaults
-        defaults = None
-        for item in parameter_list:
-            if isinstance(item, dict):
-                defaults = item
-                break
+        defaults: dict[str, Any] | None = next(
+            (item for item in parameter_list if isinstance(item, dict)), None  # type:ignore[misc]
+        )
 
         for i, item in enumerate(parameter_list):
             if isinstance(item, (str, int, float)):

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -437,7 +437,7 @@ class ParameterGroup(dict):
             Raised if no parameter with the given label exists.
         """
         # sometimes the spec parser delivers the labels as int
-        label = str(label)
+        label = str(label)  # sourcery skip
 
         path = label.split(".")
         label = path.pop()

--- a/glotaran/parameter/test/test_parameter_group_rendering.py
+++ b/glotaran/parameter/test/test_parameter_group_rendering.py
@@ -21,33 +21,33 @@ kinetic:
 RENDERED_MARKDOWN = """\
   * __irf__:
 
-    | _Label_   |   _Value_ |   _Standard Error_ |   _Minimum_ |   _Maximum_ | _Vary_   | _Non-Negative_   | _Expression_   |
-    |-----------|-----------|--------------------|-------------|-------------|----------|------------------|----------------|
-    | center    | 1.300e+00 |                nan |        -inf |         inf | True     | False            | `None`         |
-    | width     | 7.800e+00 |                nan |        -inf |         inf | True     | False            | `None`         |
+    | _Label_   |   _Value_ |   _Standard Error_ | _t-value_   |   _Minimum_ |   _Maximum_ | _Vary_   | _Non-Negative_   | _Expression_   |
+    |-----------|-----------|--------------------|-------------|-------------|-------------|----------|------------------|----------------|
+    | center    | 1.300e+00 |                nan |  nan        |        -inf |         inf | True     | False            | `None`         |
+    | width     | 7.800e+00 |                nan |  nan        |        -inf |         inf | True     | False            | `None`         |
 
   * __j__:
 
-    |   _Label_ |   _Value_ |   _Standard Error_ |   _Minimum_ |   _Maximum_ | _Vary_   | _Non-Negative_   | _Expression_   |
-    |-----------|-----------|--------------------|-------------|-------------|----------|------------------|----------------|
-    |         1 | 1.000e+00 |                nan |        -inf |         inf | False    | False            | `None`         |
+    |   _Label_ |   _Value_ |   _Standard Error_ | _t-value_   |   _Minimum_ |   _Maximum_ | _Vary_   | _Non-Negative_   | _Expression_   |
+    |-----------|-----------|--------------------|-------------|-------------|-------------|----------|------------------|----------------|
+    |         1 | 1.000e+00 |                nan |  nan        |        -inf |         inf | False    | False            | `None`         |
 
   * __kinetic__:
 
-    |   _Label_ |   _Value_ |   _Standard Error_ |   _Minimum_ |   _Maximum_ | _Vary_   | _Non-Negative_   | _Expression_              |
-    |-----------|-----------|--------------------|-------------|-------------|----------|------------------|---------------------------|
-    |         1 | 3.000e-01 |        nan         |        -inf |         inf | True     | False            | `None`                    |
-    |         2 | 5.000e-02 |          1.235e-05 |        -inf |         inf | True     | False            | `None`                    |
-    |         3 | 3.500e-01 |        nan         |        -inf |         inf | False    | False            | `$kinetic.1 + $kinetic.2` |
+    |   _Label_ |   _Value_ |   _Standard Error_ | _t-value_   |   _Minimum_ |   _Maximum_ | _Vary_   | _Non-Negative_   | _Expression_              |
+    |-----------|-----------|--------------------|-------------|-------------|-------------|----------|------------------|---------------------------|
+    |         1 | 3.000e-01 |        nan         |  nan        |        -inf |         inf | True     | False            | `None`                    |
+    |         2 | 5.000e-02 |          1.235e-05 |  4050       |        -inf |         inf | True     | False            | `None`                    |
+    |         3 | 3.500e-01 |        nan         |  nan        |        -inf |         inf | False    | False            | `$kinetic.1 + $kinetic.2` |
 
 """  # noqa: E501
 
 RENDERED_MARKDOWN_E5_PRECISION = """\
   * __irf__:
 
-    | _Label_   |     _Value_ |   _Standard Error_ |   _Minimum_ |   _Maximum_ | _Vary_   | _Non-Negative_   | _Expression_   |
-    |-----------|-------------|--------------------|-------------|-------------|----------|------------------|----------------|
-    | center    | 1.30000e+00 |        1.23457e-05 |        -inf |         inf | True     | False            | `None`         |
+    | _Label_   |     _Value_ |   _Standard Error_ | _t-value_   |   _Minimum_ |   _Maximum_ | _Vary_   | _Non-Negative_   | _Expression_   |
+    |-----------|-------------|--------------------|-------------|-------------|-------------|----------|------------------|----------------|
+    | center    | 1.30000e+00 |        1.23457e-05 |  105300     |        -inf |         inf | True     | False            | `None`         |
 
 """  # noqa: E501
 

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -112,8 +112,8 @@ class Result:
     """Number of data points :math:`N`."""
     number_of_jacobian_evaluations: int | None = None
     """The number of jacobian evaluations."""
-    number_of_variables: int | None = None
-    """Number of variables in optimization :math:`N_{vars}`"""
+    number_of_parameters: int | None = None
+    """Number of parameters in optimization :math:`N_{vars}`"""
     optimality: float | None = None
     reduced_chi_square: float | None = None
     r"""The reduced chi-square of the optimization.
@@ -186,7 +186,7 @@ class Result:
         """
         general_table_rows: list[list[Any]] = [
             ["Number of residual evaluation", self.number_of_function_evaluations],
-            ["Number of variables", self.number_of_variables],
+            ["Number of parameters", self.number_of_parameters],
             ["Number of datapoints", self.number_of_data_points],
             ["Degrees of freedom", self.degrees_of_freedom],
             ["Chi Square", f"{self.chi_square or np.nan:.2e}"],

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -82,7 +82,7 @@ class Result:
     documentation for the model.
     """
 
-    additional_penalty: np.ndarray | None = exclude_from_dict_field(None)
+    additional_penalty: list[np.ndarray] | None = exclude_from_dict_field(None)
     """A vector with the value for each additional penalty, or None"""
 
     cost: ArrayLike | None = exclude_from_dict_field(None)
@@ -193,7 +193,9 @@ class Result:
             ["Reduced Chi Square", f"{self.reduced_chi_square or np.nan:.2e}"],
             ["Root Mean Square Error (RMSE)", f"{self.root_mean_square_error or np.nan:.2e}"],
         ]
-        if self.additional_penalty is not None:
+        if self.additional_penalty is not None and any(
+            len(penalty) != 0 for penalty in self.additional_penalty
+        ):
             general_table_rows.append(["RMSE additional penalty", self.additional_penalty])
 
         result_table = tabulate(

--- a/glotaran/utils/sanitize.py
+++ b/glotaran/utils/sanitize.py
@@ -6,6 +6,33 @@ from typing import Any
 from glotaran.utils.regex import RegexPattern as rp
 
 
+def pretty_format_numerical(value: float, decimal_places: int = 1) -> str:
+    """Format value with with at most ``decimal_places`` decimal places.
+
+    Used to format values like the t-value.
+
+    Parameters
+    ----------
+    value: float
+        Numerical value to format.
+    decimal_places: int
+        Decimal places to display. Defaults to 1
+
+    Returns
+    -------
+    str
+        Pretty formatted version of the value.
+    """
+    format_template = "{value:{format_instruction}}"
+    if value < 10 ** (-decimal_places):
+        format_instruction = f".{decimal_places}e"
+    elif value < 10 ** (decimal_places):
+        format_instruction = f".{decimal_places}f"
+    else:
+        format_instruction = ".0f"
+    return format_template.format(value=value, format_instruction=format_instruction)
+
+
 def sanitize_list_with_broken_tuples(mangled_list: list[str | float]) -> list[str]:
     """Sanitize a list with 'broken' tuples.
 

--- a/glotaran/utils/sanitize.py
+++ b/glotaran/utils/sanitize.py
@@ -80,8 +80,7 @@ def sanitize_dict_keys(d: dict) -> dict:
             k_new = tuple(map(str, rp.word.findall(k)))
             d_new[k_new] = v
         elif isinstance(d, (dict, list)):
-            new_v = sanitize_dict_keys(v)
-            if new_v:
+            if new_v := sanitize_dict_keys(v):
                 d[k] = new_v
     return d_new
 

--- a/glotaran/utils/test/test_sanitize.py
+++ b/glotaran/utils/test/test_sanitize.py
@@ -5,6 +5,7 @@ from typing import NamedTuple
 
 import pytest
 
+from glotaran.utils.sanitize import pretty_format_numerical
 from glotaran.utils.sanitize import sanitize_list_with_broken_tuples
 
 
@@ -52,6 +53,26 @@ def test_mangled_list_sanitization(test_data: MangledListTestData):
 def test_fix_tuple_string_list(test_data: MangledListTestData):
     actual = sanitize_list_with_broken_tuples(test_data.input)
     assert all(a in b for a, b in zip(actual, test_data.output))
+
+
+@pytest.mark.parametrize(
+    "value, decimal_places, expected",
+    (
+        (0.00000001, 1, "1.0e-08"),
+        (0.1, 1, "0.1"),
+        (1.7, 1, "1.7"),
+        (10, 1, "10"),
+        (0.00000001, 8, "0.00000001"),
+        (0.009, 2, "9.00e-03"),
+        (0.01, 2, "0.01"),
+        (12.3, 2, "12.30"),
+    ),
+)
+def test_pretty_format_numerical(value: float, decimal_places: int, expected: str):
+    """Pretty format values depending on decimal_places to show."""
+    result = pretty_format_numerical(value, decimal_places)
+
+    assert result == expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Just some minor visual changes to the markdown representation of Result, Parameter and ParameterGroup.
Requested by @ism200 

Before:
![grafik](https://user-images.githubusercontent.com/9513634/157510131-28bbabc7-bc42-435d-bb3b-cd1fd0a40b70.png)
![grafik](https://user-images.githubusercontent.com/9513634/157510185-254f6a8a-2bbc-422c-be11-59f3954a4049.png)



After:
![grafik](https://user-images.githubusercontent.com/9513634/157509842-ff791c00-4931-4a0e-bd27-76f59a0d0fe1.png)
![grafik](https://user-images.githubusercontent.com/9513634/157509885-8483585c-e5fe-47df-8ceb-d023060b747e.png)


### Change summary

- [👌 Renamed 'Number of variables' to 'Number of parameters' in result md](https://github.com/glotaran/pyglotaran/commit/d8cfcc808ae12229697da70f295aef1ac272940d)
- [👌 Remove 'RMSE additional penalty' from report if empty](https://github.com/glotaran/pyglotaran/commit/cce088a6dd6e5cceded55a71b5cd666a1e0234c5)
- [👌 Added t-value to parameter markdown reprs](https://github.com/glotaran/pyglotaran/commit/1d1c9a74c122550c138d9e06e41311294dc01bfa)
- [🚧 Add sourcery skip to code that should not be refactored](https://github.com/glotaran/pyglotaran/pull/1012/commits/5b84045b1215f1612093e007c054d66a020bd215)


### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
