### PR TITLE
✨ Add extract sas helper function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
 - 👌 Apply IRF shift in coherent artifact megacomplex (#992)
 - 👌 Added IRF shift to result dataset (#994)
 - 👌 Improve Result, Parameter and ParameterGroup markdown (#1012)
+- ✨ Add extract sas helper function (#1015)
 
 ### 🩹 Bug fixes
 

--- a/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
+++ b/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
@@ -242,7 +242,7 @@ def get_data_file_format(line):
 #  @file_reader(extension="ascii", name="Wavelength-/Time-Explicit ASCII")
 @register_data_io("ascii")
 class AsciiDataIo(DataIoInterface):
-    def load_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
+    def load_dataset(self, file_name: str, *, prepare: bool = True) -> xr.Dataset | xr.DataArray:
         """Reads an ascii file in wavelength- or time-explicit format.
 
         See [1]_ for documentation of this format.
@@ -272,7 +272,7 @@ class AsciiDataIo(DataIoInterface):
             else TimeExplicitFile(file_name)
         )
 
-        return data_file.read(prepare=True)
+        return data_file.read(prepare=prepare)
 
     def save_dataset(
         self,

--- a/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
+++ b/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
@@ -27,7 +27,7 @@ class ExplicitFile:
     """
 
     # TODO: implement time_intervals
-    def __init__(self, filepath: str = None, dataset: xr.DataArray = None):
+    def __init__(self, filepath: str | None = None, dataset: xr.DataArray | None = None):
         self._file_data_format = None
         self._observations = []  # TODO: choose name: data_points, observations, data
         self._times = []
@@ -76,22 +76,19 @@ class ExplicitFile:
 
         if os.path.isfile(self._file) and not overwrite:
             raise FileExistsError(f"File already exist:\n{self._file}")
-        comment = self._comment + " " + comment
+        comment = f"{self._comment} {comment}"
 
-        comments = "# Filename: " + str(self._file) + "\n" + " ".join(comment.splitlines()) + "\n"
+        comments = f"# Filename: {str(self._file)}\n{' '.join(comment.splitlines())}\n"
 
         if file_format == DataFileType.wavelength_explicit:
             wav = "\t".join(repr(num) for num in self._spectral_indices)
             header = (
-                comments + "Wavelength explicit\nIntervalnr {}"
-                "".format(len(self._spectral_indices)) + "\n" + wav
+                f"{comments}Wavelength explicit\nIntervalnr {len(self._spectral_indices)}\n{wav}"
             )
             raw_data = np.vstack((self._times.T, self._observations)).T
         elif file_format == DataFileType.time_explicit:
             tim = "\t".join(repr(num) for num in self._times)
-            header = (
-                comments + "Time explicit\nIntervalnr {}" "".format(len(self._times)) + "\n" + tim
-            )
+            header = f"{comments}Time explicit\nIntervalnr {len(self._times)}\n{tim}"
             raw_data = np.vstack((self._spectral_indices.T, self._observations.T)).T
         else:
             raise NotImplementedError

--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -267,7 +267,7 @@ def extract_sas(
     result: Result | xr.Dataset
         Optimization ``Result`` instance or result dataset.
     species: str | None
-        Name op the species to extract the SAS for. Defaults to None
+        Name of the species to extract the SAS for. Defaults to None
     dataset: str | None
         Name of the dataset to look up in a Result instance. Defaults to None
 
@@ -297,7 +297,7 @@ def extract_sas(
         from glotaran.io import save_dataset
 
         sas = extract_sas(result, "species_1","dataset_1")
-        save_dataset("sas__result_dataset_1__species_1.ascii")
+        save_dataset(sas, "sas__result_dataset_1__species_1.ascii")
 
 
     Extracting the SAS from a result dataset loaded from file.
@@ -310,7 +310,7 @@ def extract_sas(
 
         result_dataset = load_result("result_dataset_1.nc")
         sas = extract_sas(result_dataset, "species_1")
-        save_dataset("sas__result_dataset_1__species_1.ascii")
+        save_dataset(sas, "sas__result_dataset_1__species_1.ascii")
 
     """
     # workaround to prevent circular imports

--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -256,7 +256,7 @@ def safe_dataframe_replace(
 
 
 def extract_sas(
-    result: Result | xr.Dataset, dataset: str | None = None, species: str | None = None
+    result: Result | xr.Dataset, species: str | None = None, dataset: str | None = None
 ) -> xr.DataArray:
     """Extract SAS data from a result.
 
@@ -266,10 +266,10 @@ def extract_sas(
     ----------
     result: Result | xr.Dataset
         Optimization ``Result`` instance or result dataset.
-    dataset: str | None
-        Name of the dataset to look up in a Result instance. Defaults to None
     species: str | None
         Name op the species to extract the SAS for. Defaults to None
+    dataset: str | None
+        Name of the dataset to look up in a Result instance. Defaults to None
 
     Returns
     -------
@@ -294,8 +294,10 @@ def extract_sas(
     .. code-block:: python
 
         from glotaran.utils.io import extract_sas
+        from glotaran.io import save_dataset
 
-        sas = extract_sas(result, "dataset_1", "species_1")
+        sas = extract_sas(result, "species_1","dataset_1")
+        save_dataset("sas__result_dataset_1__species_1.ascii")
 
 
     Extracting the SAS from a result dataset loaded from file.
@@ -303,10 +305,12 @@ def extract_sas(
     .. code-block:: python
 
         from glotaran.io import load_result
+        from glotaran.io import save_dataset
         from glotaran.utils.io import extract_sas
 
         result_dataset = load_result("result_dataset_1.nc")
         sas = extract_sas(result_dataset, "species_1")
+        save_dataset("sas__result_dataset_1__species_1.ascii")
 
     """
     # workaround to prevent circular imports

--- a/glotaran/utils/test/test_io.py
+++ b/glotaran/utils/test/test_io.py
@@ -269,7 +269,7 @@ def test_extract_sas(scheme: Scheme):
     result = optimize(scheme)
     result_dataset = result.data["dataset_1"]
 
-    sas = extract_sas(result, "dataset_1", "species_1")
+    sas = extract_sas(result, "species_1", "dataset_1")
 
     assert sas.coords["time"] == [0]
     assert np.all(sas.coords["spectral"] == result_dataset.coords["spectral"])
@@ -290,7 +290,7 @@ def test_extract_sas_ascii_round_trip(tmp_path: Path):
     result = optimize(seq_scheme)
     tmp_file = tmp_path / "sas.ascii"
 
-    sas = extract_sas(result, "dataset_1", "species_1")
+    sas = extract_sas(result, "species_1", "dataset_1")
     save_dataset(sas, tmp_file)
     loaded_sas = load_dataset(tmp_file, prepare=False)
     del sas.attrs["loader"]
@@ -306,7 +306,7 @@ def test_extract_sas_exceptions():
     result = optimize(seq_scheme)
 
     with pytest.raises(ValueError) as exec_info:
-        extract_sas(result, "not_a_dataset")
+        extract_sas(result, dataset="not_a_dataset")
 
     assert str(exec_info.value) == (
         "The result doesn't contain a dataset with name 'not_a_dataset'.\n"
@@ -321,7 +321,7 @@ def test_extract_sas_exceptions():
     )
 
     with pytest.raises(ValueError) as exec_info:
-        extract_sas(result, "dataset_1")
+        extract_sas(result, dataset="dataset_1")
 
     assert str(exec_info.value) == (
         "The result doesn't contain a species with name None.\n"
@@ -329,7 +329,7 @@ def test_extract_sas_exceptions():
     )
 
     with pytest.raises(ValueError) as exec_info:
-        extract_sas(result, "dataset_1", "s1")
+        extract_sas(result, dataset="dataset_1", species="s1")
 
     assert str(exec_info.value) == (
         "The result doesn't contain a species with name 's1'.\n"


### PR DESCRIPTION
Just a little helper function to easily extract a single SAS which can then be used as clp guidance.
Requested by @ism200 

### Change summary

- [👌 Allow passing of prepare argument to load_dataset ascii](https://github.com/glotaran/pyglotaran/commit/dcd3fabf40609f536deb48eee1c4e75d11bf31fb)
- [✨ Added 'extract_sas' helper function](https://github.com/glotaran/pyglotaran/commit/3de4c4b899f5a036b882fac31dda581f547474d4)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
