### PR TITLE
👌📚🚇 Auto remove notebook written data when building docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
 - 🔧🚇 Only run check-manifest on the CI (#967)
 - 🚇👌 Exclude dependabot push CI runs (#978)
 - 🚇👌 Exclude sourcery AI push CI runs (#1014)
+- 👌📚🚇 Auto remove notebook written data when building docs (#1019)
 
 ## 0.5.1 (2021-12-31)
 

--- a/docs/remove_notebook_written_data.py
+++ b/docs/remove_notebook_written_data.py
@@ -6,7 +6,6 @@ the tests pass w/o using ``allow_overwrite=True`` all over the docs.
 If you use ``tox`` to run the tests (``tox`` or ``tox -e docs-notebooks``)
 this script will be run before the tests.
 """
-import os
 from pathlib import Path
 
 NOTEBOOK_PATH = Path(__file__).parent / "source/notebooks"
@@ -24,8 +23,8 @@ def remove_files(path: Path, glob_pattern: str):
     glob_pattern : str
         Glob pattern of the files
     """
-    for file in (path).glob(glob_pattern):
-        os.remove(file)
+    for file in path.glob(glob_pattern):
+        file.unlink()
 
 
 if __name__ == "__main__":

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,13 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 
+import subprocess
+import sys
+from pathlib import Path
+
 import glotaran
+
+DOC_FOLDER = Path(__file__).parent.parent
 
 # -- Project information -----------------------------------------------------
 
@@ -303,3 +309,7 @@ extlinks = {
     "scipydoc": ("https://docs.scipy.org/doc/scipy/reference/generated/scipy.%s.html", "scipy."),
     "xarraydoc": ("https://xarray.pydata.org/en/stable/generated/xarray.%s.html", "xarray."),
 }
+
+# cleanup notebook data
+
+subprocess.run([sys.executable, DOC_FOLDER / "remove_notebook_written_data.py"], check=True)

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,6 @@ direct = true
 commands =
     python docs/remove_notebook_written_data.py
     py.test -vv --nbval docs/source/notebooks
-    python docs/remove_notebook_written_data.py
 
 [testenv:docs-links]
 direct = true


### PR DESCRIPTION
Currently [docs on main are failing](https://readthedocs.org/projects/pyglotaran/builds/16338003/) due to an existing `*.nc` file produced when running the notebook. This most likely is due to caching done by read the docs.
To (hopefully) prevent this error the docs (`conf.py`) should clean the file before building.

### Change summary

- [👌📚🚇 Auto remove notebook written data when building docs](https://github.com/glotaran/pyglotaran/commit/eab81f788c894807c80dff4858d55d7470993834)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
