### PR TITLE
🩹📚 Fix docs CI

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,3 +12,4 @@ jupyterlab>=3.0.0
 matplotlib>=3.0.0
 IPython>=7.2.0
 nbval>=0.9.6
+Jinja2<3.1.0


### PR DESCRIPTION
Currently the [CI for the docs is broken](https://github.com/glotaran/pyglotaran/runs/5691390240?check_suite_focus=true) due to an upstream problem.

The new [Jinja2 release](https://github.com/pallets/jinja/releases/tag/3.1.0) deprecated some exported functionality which is used by `nbconvert` which again is used by `nbsphinx` that adds the notebooks to the docs.
Until [this issue](https://github.com/jupyter/nbconvert/issues/1736) is fixed and there is a new release of `nbconvert` we should pin `Jinja2` in order for the CI to pass.


### Change summary

- [🩹📚 Pin Jinja2< 3.1.0 so notebook docs build](https://github.com/glotaran/pyglotaran/commit/e8ae7bae8a02cda92ac59017b7ab976e4ea10de0)
<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)