### PR TITLE
👌🚇 Change integration tests to use self managed examples action

### DIFF
--- a/.github/test_result_consistency.py
+++ b/.github/test_result_consistency.py
@@ -280,6 +280,8 @@ def map_result_files(file_glob_pattern: str) -> dict[str, list[tuple[Path, Path]
         compare_results_path = get_compare_results_path()
     current_result_path = get_current_result_path()
     for expected_result_file in compare_results_path.rglob(file_glob_pattern):
+        if expected_result_file.name == "parameter_history.csv":
+            continue
         key = (
             expected_result_file.relative_to(compare_results_path)
             .parent.as_posix()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,25 +9,26 @@ on:
   workflow_dispatch:
 
 jobs:
+  create-example-list:
+    name: Create Example List
+    runs-on: ubuntu-latest
+    outputs:
+      example-list: ${{ steps.create-example-list.outputs.example-list }}
+    steps:
+      - name: Set example list output
+        id: create-example-list
+        uses: glotaran/pyglotaran-examples@main
+        with:
+          example_name: set example list
+          set_example_list: true
+
   run-examples:
     name: "Run Example: "
     runs-on: ubuntu-latest
+    needs: [create-example-list]
     strategy:
       matrix:
-        example_name:
-          [
-            quick-start,
-            fluorescence,
-            transient-absorption,
-            transient-absorption-two-datasets,
-            spectral-constraints,
-            spectral-guidance,
-            two-datasets,
-            sim-3d-disp,
-            sim-3d-nodisp,
-            sim-3d-weight,
-            sim-6d-disp,
-          ]
+        example_name: ${{fromJson(needs.create-example-list.outputs.example-list)}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8

--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 - 🚇👌 Exclude dependabot push CI runs (#978)
 - 🚇👌 Exclude sourcery AI push CI runs (#1014)
 - 👌📚🚇 Auto remove notebook written data when building docs (#1019)
+- 👌🚇 Change integration tests to use self managed examples action (#1034)
 
 ## 0.5.1 (2021-12-31)
 


### PR DESCRIPTION
The examples action which creates the results for result consistency checks has a [new feature to create the list of possible examples](https://github.com/glotaran/pyglotaran-examples/pull/54) that way we don't need to manually manage [this list](https://github.com/glotaran/pyglotaran/blob/c8b993b753a4fe9cba64a1c5bd0fb461f3dac05c/.github/workflows/integration-tests.yml#L17), which currently is missing the DOAS example.

### Change summary

- [👌🚇 Changed integration tests to use self managed examples action](https://github.com/glotaran/pyglotaran/commit/77b03e4a44663b4b357b50d554d3bb5f9d34bb1f)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [ ] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
