### PR TITLE
🩹 ParameterGroup.get degrades full_label of nested Parameters with nesting over 2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 ### 🩹 Bug fixes
 
 - 🩹 Fix Crash in optimization_group_calculator_linked when using guidance spectra (#950)
+- 🩹 ParameterGroup.get degrades full_label of nested Parameters with nesting over 2 (#1043)
 
 ### 📚 Documentation
 

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -434,9 +434,9 @@ class ParameterGroup(dict):
             Raised if no parameter with the given label exists.
         """
         # sometimes the spec parser delivers the labels as int
-        label = str(label)  # sourcery skip
+        full_label = str(label)  # sourcery skip
 
-        path = label.split(".")
+        path = full_label.split(".")
         label = path.pop()
 
         # TODO: audit this code
@@ -447,7 +447,9 @@ class ParameterGroup(dict):
             except KeyError:
                 raise ParameterNotFoundException(path, label)
         try:
-            return group._parameters[label]
+            parameter = group._parameters[label]
+            parameter.full_label = full_label
+            return parameter
         except KeyError:
             raise ParameterNotFoundException(path, label)
 

--- a/glotaran/parameter/test/test_parameter_group.py
+++ b/glotaran/parameter/test/test_parameter_group.py
@@ -91,6 +91,8 @@ def test_parameter_group_from_dict_nested():
     assert [p.label for _, p in group.all()] == [f"{i}" for i in range(1, 4)]
     assert [p.value for _, p in group.all()] == list(range(7, 10))
 
+    assert params.get("kinetic.j.1").full_label == "kinetic.j.1"
+
 
 def test_parameter_group_to_array():
     params = """

--- a/glotaran/project/test/test_result.py
+++ b/glotaran/project/test/test_result.py
@@ -12,7 +12,11 @@ from glotaran.io import SAVING_OPTIONS_DEFAULT
 from glotaran.io import SAVING_OPTIONS_MINIMAL
 from glotaran.io import SavingOptions
 from glotaran.project.result import Result
+from glotaran.project.scheme import Scheme
+from glotaran.testing.simulated_data.sequential_spectral_decay import DATASET
 from glotaran.testing.simulated_data.sequential_spectral_decay import SCHEME
+from glotaran.testing.simulated_data.sequential_spectral_decay import SIMULATION_MODEL
+from glotaran.testing.simulated_data.shared_decay import SIMULATION_PARAMETERS
 from glotaran.testing.simulated_data.shared_decay import SPECTRAL_AXIS
 
 
@@ -35,6 +39,19 @@ def test_result_ipython_rendering(dummy_result: Result):
 
     assert "text/markdown" in rendered_markdown_return
     assert rendered_markdown_return["text/markdown"].startswith("| Optimization Result")
+
+
+def test_result_markdown_nested_parameters():
+    """Test not crash of Result.markdown() for nested parameters
+
+    See https://github.com/glotaran/pyglotaran/issues/933
+    """
+    scheme = Scheme(
+        model=SIMULATION_MODEL, parameters=SIMULATION_PARAMETERS, data={"dataset_1": DATASET}
+    )
+    result = optimize(scheme, raise_exception=True)
+
+    assert "shapes.species_1.amplitude" in result.markdown()
 
 
 def test_get_scheme(dummy_result: Result):


### PR DESCRIPTION
This PR started as fix for #933, during which #1042 was discovered.

For the result comparison to succeed we need to update the gold standard (e.g. [manually add the missing `osc` to the labels of the parameter saved in the results](https://github.com/glotaran/pyglotaran-examples/pull/63)).

### Change summary

- [🧪 Added failing test for issue 933](https://github.com/glotaran/pyglotaran/commit/b6b3dd1588ae36fa50467c4712b7702b01ef7cd1)
- [🩹 Fixed issue in ParameterGroup.get with degraded full_label](https://github.com/glotaran/pyglotaran/commit/34ad099a55ac7b073c4efd78966fe477e4c8f9fc)
- [🧪 Added unitest for ParameterGroup.get and label nesting of 3](https://github.com/glotaran/pyglotaran/commit/88350ed95609b9baf67de9dafd429701b37949bb)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #933
closes #1042 
