### PR TITLE
⬆️ Combined updates

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -134,7 +134,7 @@ jobs:
           pytest --cov=./ --cov-report term --cov-report xml --cov-config pyproject.toml glotaran
 
       - name: Codecov Upload
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
 

--- a/.github/workflows/codeowners_validator.yml
+++ b/.github/workflows/codeowners_validator.yml
@@ -25,7 +25,7 @@ jobs:
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v3
       - name: GitHub CODEOWNERS Validator
-        uses: mszostok/codeowners-validator@v0.7.1
+        uses: mszostok/codeowners-validator@v0.7.2
         with:
           checks: "files,owners,duppatterns"
           experimental_checks: "notowned"

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           doxyfile-path: "docs/Doxyfile.ini"
       - name: Upload Doxygen Docs Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: doxygen_docs_pyglotaran
           path: doxygen_docs_pyglotaran

--- a/.github/workflows/full_benchmark.yml
+++ b/.github/workflows/full_benchmark.yml
@@ -64,7 +64,7 @@ jobs:
           ref: main
 
       - name: Download result artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: benchmark-results
           path: results

--- a/.github/workflows/full_benchmark.yml
+++ b/.github/workflows/full_benchmark.yml
@@ -45,7 +45,7 @@ jobs:
           pushd benchmark
           asv run 0d41d63ca3ca33bb0b70e25fe76ab0c16f6d2e1d..main --machine gh_action
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: benchmark-results
           path: benchmark/.asv/results

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,7 +77,7 @@ jobs:
           path: comparison-results
 
       - name: Download result artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: example-results
           path: comparison-results-current

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,13 +50,13 @@ jobs:
         run: |
           pip freeze
       - name: Upload Example Plots Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: example-plots
           path: ${{ steps.example-run.outputs.plots-path }}
 
       - name: Upload Example Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: example-results
           path: ~/pyglotaran_examples_results

--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -125,7 +125,7 @@ jobs:
           Path("benchmark/.asv/html/origin_pr_nr.txt").write_text(pr_nr)
 
       - name: Upload PR html results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: benchmark-pr-html
           path: benchmark/.asv/html

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,7 +9,7 @@ netCDF4==1.5.8
 numba==0.55.1
 numpy==1.21.5
 openpyxl==3.0.9
-pandas==1.4.1
+pandas==1.4.2
 rich==12.2.0
 ruamel.yaml==0.17.21
 scipy==1.8.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ numba==0.55.1
 numpy==1.21.5
 openpyxl==3.0.9
 pandas==1.4.1
-rich==12.0.1
+rich==12.2.0
 ruamel.yaml==0.17.21
 scipy==1.8.0
 sdtfile==2022.2.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ wheel>=0.30.0
 
 # glotaran setup dependencies
 asteval==0.9.26
-click==8.0.4
+click==8.1.2
 netCDF4==1.5.8
 numba==0.55.1
 numpy==1.21.5


### PR DESCRIPTION
Combines PRs:
- Bump actions/upload-artifact from 2 to 3 #1056
- Bump actions/download-artifact from 2 to 3 #1055
- Bump codecov/codecov-action from 2 to 3 #1054
- Bump mszostok/codeowners-validator from 0.7.1 to 0.7.2 #1053
- Bump pandas from 1.4.1 to 1.4.2 #1052
- Bump rich from 12.0.1 to 12.2.0 #1051
- Bump click from 8.0.4 to 8.1.2 #1039 

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
