### PR TITLE
🩹 Fix missing installation of clp-guide megacomplex as plugin

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
 - 👌🧹 Add suffix to rate and lifetime and guard for missing datasets (#1022)
 - ♻️ Move simulation to own module (#1041)
 - ♻️ Move optimization to new module glotaran.optimization (#1047)
+- 🩹 Fix missing installation of clp-guide megacomplex as plugin (#1066)
 
 ### 🩹 Bug fixes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ glotaran.plugins.data_io =
     nc = glotaran.builtin.io.netCDF.netCDF
 glotaran.plugins.megacomplexes =
     baseline = glotaran.builtin.megacomplexes.baseline
+    clp_guide = glotaran.builtin.megacomplexes.clp_guide
     coherent_artifact = glotaran.builtin.megacomplexes.coherent_artifact
     damped_oscillation = glotaran.builtin.megacomplexes.damped_oscillation
     decay = glotaran.builtin.megacomplexes.decay


### PR DESCRIPTION
This bug wasn't cough by the test since the tests import `glotaran.builtin.megacomplexes.clp_guide` which is equivalent to installing the plugin.

When normally using it the error was:
```python
ValueError: Unknown megacomplex type 'clp-guide'. Known megacomplex types are: 
['baseline', 'coherent-artifact', 'damped-oscillation', 'decay', 'decay-parallel', 'decay-sequential', 
'glotaran.builtin.megacomplexes.baseline.baseline_megacomplex.BaselineMegacomplex', 
'glotaran.builtin.megacomplexes.coherent_artifact.coherent_artifact_megacomplex.CoherentArtifactMegacomplex', 
'glotaran.builtin.megacomplexes.damped_oscillation.damped_oscillation_megacomplex.DampedOscillationMegacomplex', 
'glotaran.builtin.megacomplexes.decay.decay_megacomplex.DecayMegacomplex', 
'glotaran.builtin.megacomplexes.decay.decay_parallel_megacomplex.DecayParallelMegacomplex', 
'glotaran.builtin.megacomplexes.decay.decay_sequential_megacomplex.DecaySequentialMegacomplex', 
'glotaran.builtin.megacomplexes.spectral.spectral_megacomplex.SpectralMegacomplex', 'spectral']
```

### Change summary

- Added `clp_guide` as plugin to `setup.cfg`

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)