### PR TITLE
🩹 Show validation problem if parameters are missing values (default: NaN)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 
 - 🩹 Fix Crash in optimization_group_calculator_linked when using guidance spectra (#950)
 - 🩹 ParameterGroup.get degrades full_label of nested Parameters with nesting over 2 (#1043)
+- 🩹 Show validation problem if parameters are missing values (default: NaN) (#1076)
 
 ### 📚 Documentation
 

--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -291,8 +291,8 @@ class Model:
             if group not in groups:
                 try:
                     groups[group] = DatasetGroup(model=self.dataset_group_models[group])
-                except KeyError:
-                    raise ValueError(f"Unknown dataset group '{group}'")
+                except KeyError as e:
+                    raise ValueError(f"Unknown dataset group '{group}'") from e
             groups[group].dataset_models[dataset_model.label] = dataset_model
         return groups
 
@@ -367,7 +367,7 @@ class Model:
         }
         return len(global_dimensions) == 1 and len(model_dimensions) == 1
 
-    def problem_list(self, parameters: ParameterGroup = None) -> list[str]:
+    def problem_list(self, parameters: ParameterGroup | None = None) -> list[str]:
         """
         Returns a list with all problems in the model and missing parameters if specified.
 

--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -388,6 +388,13 @@ class Model:
                 for item in items.values():
                     problems += item.validate(self, parameters=parameters)
 
+        if parameters is not None and len(parameters.missing_parameter_value_labels) != 0:
+            label_prefix = "\n    - "
+            problems.append(
+                f"Parameter definition is missing values for the labels:"
+                f"{label_prefix}{label_prefix.join(parameters.missing_parameter_value_labels)}"
+            )
+
         return problems
 
     def validate(self, parameters: ParameterGroup = None, raise_exception: bool = False) -> str:

--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -397,7 +397,9 @@ class Model:
 
         return problems
 
-    def validate(self, parameters: ParameterGroup = None, raise_exception: bool = False) -> str:
+    def validate(
+        self, parameters: ParameterGroup = None, raise_exception: bool = False
+    ) -> MarkdownStr:
         """
         Returns a string listing all problems in the model and missing parameters if specified.
 
@@ -410,14 +412,14 @@ class Model:
         result = ""
 
         if problems := self.problem_list(parameters):
-            result = f"Your model has {len(problems)} problems:\n"
+            result = f"Your model has {len(problems)} problem{'s' if len(problems) > 1 else ''}:\n"
             for p in problems:
                 result += f"\n * {p}"
             if raise_exception:
                 raise ModelError(result)
         else:
             result = "Your model is valid."
-        return result
+        return MarkdownStr(result)
 
     def valid(self, parameters: ParameterGroup = None) -> bool:
         """Returns `True` if the number problems in the model is 0, else `False`

--- a/glotaran/model/test/test_model.py
+++ b/glotaran/model/test/test_model.py
@@ -380,14 +380,14 @@ def test_model_validate_missing_parameters():
     )
     expected = dedent(
         """\
-            Your model has 1 problems:
+            Your model has 1 problem:
 
              * Parameter definition is missing values for the labels:
                 - b.missing_value_1
                 - b.missing_value_2
                 - kinetic.j.missing_value_3"""
     )
-    assert model.validate(parameters) == expected
+    assert str(model.validate(parameters)) == expected
 
 
 def test_items(test_model: Model):

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -173,7 +173,7 @@ class Parameter(_SupportsArray):
         else:
             values = sanitize_parameter_list(value)
             param.label = _retrieve_item_from_list_by_type(values, str, label)
-            param.value = float(_retrieve_item_from_list_by_type(values, (int, float), 0))
+            param.value = float(_retrieve_item_from_list_by_type(values, (int, float), np.nan))
             options = _retrieve_item_from_list_by_type(values, dict, None)
 
         if default_options:

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -585,6 +585,21 @@ class ParameterGroup(dict):
                     )
                 parameter.value = value
 
+    @property
+    def missing_parameter_value_labels(self) -> list[str]:
+        """List of full labels where the value is a NaN.
+
+        This property is used to validate that all parameters have starting values.
+
+        Returns
+        -------
+        str
+            List full labels with missing value.
+        """
+        parameter_df = self.to_dataframe(as_optimized=False)
+        parameter_nan_value_mask = parameter_df["value"].isna()
+        return parameter_df[parameter_nan_value_mask]["label"].to_list()
+
     def markdown(self, float_format: str = ".3e") -> MarkdownStr:
         """Format the :class:`ParameterGroup` as markdown string.
 

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -490,6 +490,7 @@ class ParameterGroup(dict):
         """
         root = f"{root}{self.label}{separator}" if root is not None else ""
         for label, p in self._parameters.items():
+            p.full_label = f"{root}{label}"
             yield (f"{root}{label}", p)
         for _, l in self.items():
             yield from l.all(root=root, separator=separator)

--- a/glotaran/parameter/parameter_group.py
+++ b/glotaran/parameter/parameter_group.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from copy import copy
 from textwrap import indent
 from typing import TYPE_CHECKING
@@ -132,10 +133,8 @@ class ParameterGroup(dict):
 
         for i, item in enumerate(parameter_list):
             if isinstance(item, (str, int, float)):
-                try:
+                with contextlib.suppress(ValueError):
                     item = float(item)
-                except Exception:
-                    pass
             if isinstance(item, (float, int, list)):
                 root.add_parameter(
                     Parameter.from_list_or_value(item, label=str(i + 1), default_options=defaults)
@@ -444,14 +443,14 @@ class ParameterGroup(dict):
         for element in path:
             try:
                 group = group[element]
-            except KeyError:
-                raise ParameterNotFoundException(path, label)
+            except KeyError as e:
+                raise ParameterNotFoundException(path, label) from e
         try:
             parameter = group._parameters[label]
             parameter.full_label = full_label
             return parameter
-        except KeyError:
-            raise ParameterNotFoundException(path, label)
+        except KeyError as e:
+            raise ParameterNotFoundException(path, label) from e
 
     def copy(self) -> ParameterGroup:
         """Create a copy of the :class:`ParameterGroup`.

--- a/glotaran/parameter/test/test_parameter_group.py
+++ b/glotaran/parameter/test/test_parameter_group.py
@@ -93,6 +93,9 @@ def test_parameter_group_from_dict_nested():
 
     assert params.get("kinetic.j.1").full_label == "kinetic.j.1"
 
+    roundtrip_df = ParameterGroup.from_dataframe(params.to_dataframe()).to_dataframe()
+    assert all(roundtrip_df.label == params.to_dataframe().label)
+
 
 def test_parameter_group_to_array():
     params = """

--- a/glotaran/parameter/test/test_parameter_group.py
+++ b/glotaran/parameter/test/test_parameter_group.py
@@ -342,3 +342,27 @@ def test_parameter_group_to_from_df():
         assert got.non_negative == wanted.non_negative
         assert got.value == wanted.value
         assert got.vary == wanted.vary
+
+
+def test_missing_parameter_value_labels():
+    """Full labels of all parameters with missing values (NaN) get listed."""
+    parameter_group = load_parameters(
+        dedent(
+            """\
+            b:
+                - ["missing_value_1",]
+                - ["missing_value_2"]
+                - ["2", 0.75]
+            kinetic:
+                j:
+                    - ["missing_value_3"]
+            """
+        ),
+        format_name="yml_str",
+    )
+
+    assert parameter_group.missing_parameter_value_labels == [
+        "b.missing_value_1",
+        "b.missing_value_2",
+        "kinetic.j.missing_value_3",
+    ]

--- a/glotaran/project/scheme.py
+++ b/glotaran/project/scheme.py
@@ -119,12 +119,12 @@ class Scheme:
         """
         return self.model.problem_list(self.parameters)
 
-    def validate(self) -> str:
+    def validate(self) -> MarkdownStr:
         """Return a string listing all problems in the model and missing parameters.
 
         Returns
         -------
-        str
+        MarkdownStr
             A user-friendly string containing all the problems of a model if any.
             Defaults to 'Your model is valid.' if no problems are found.
         """

--- a/glotaran/project/scheme.py
+++ b/glotaran/project/scheme.py
@@ -150,9 +150,7 @@ class Scheme:
         """
         model_markdown_str = self.model.markdown(parameters=self.parameters)
 
-        markdown_str = "\n\n"
-        markdown_str += "__Scheme__\n\n"
-
+        markdown_str = "\n\n__Scheme__\n\n"
         if self.non_negative_least_squares is not None:
             markdown_str += f"* *non_negative_least_squares*: {self.non_negative_least_squares}\n"
         markdown_str += (


### PR DESCRIPTION
This change fixes false positive reporting of a `Model` with parameters or `Scheme` as valid when parameters are missing values and default to `np.nan`.
One use case where a user would want missing parameters is in a teaching exercise where students have to fill in missing parameters.
The other use case would be that a user started editing the parameters file but didn't finish and forgot some values.

As a demo you can use [this notebook](https://github.com/ism200/PE2022/blob/3a5173cce2cf417f605a586c62beedb7a1af4e49/BRC-case-study/BRC_VIS-global-case-study-pretty.ipynb).

### Change summary

- [👌 Don't set default parameter value to zero](https://github.com/glotaran/pyglotaran/commit/e725f4b62e89dd54afd46cb7a92cdf36f2a0318e)
- [🧹 Improved typing and exception raising](https://github.com/glotaran/pyglotaran/commit/2e4416287c15b44f4368eb4e040bd46a3db7b438)
- [🩹 Fix degraded label with nesting over 2](https://github.com/glotaran/pyglotaran/commit/a051427ffd69ea54450618582ec2a96a17c2918f)
- [✨ Added missing_parameter_value_labels property to ParameterGroup](https://github.com/glotaran/pyglotaran/commit/aa17bf01a92aa35e4f04827e612fd302d93dd687)
- [✨ Added missing parameters check to model validation](https://github.com/glotaran/pyglotaran/commit/4a96db257fb49ca8eda7bff79fba335771bf66af)
- [👌 Improved validation output](https://github.com/glotaran/pyglotaran/commit/2acf3ecbc5f411ca9cabadf9de657f6cb13efcca)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
