### PR TITLE
🚇🧹 Exclude  pre-commit bot branch from CI runs on push

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -7,6 +7,7 @@ on:
     branches-ignore:
       - "dependabot/**"
       - "sourcery/**"
+      - "pre-commit-ci-update-config"
   pull_request:
 
 jobs:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - "dependabot/**"
       - "sourcery/**"
+      - "pre-commit-ci-update-config"
   pull_request:
   workflow_dispatch:
 

--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,7 @@
 - 🚇👌 Exclude sourcery AI push CI runs (#1014)
 - 👌📚🚇 Auto remove notebook written data when building docs (#1019)
 - 👌🚇 Change integration tests to use self managed examples action (#1034)
+- 🚇🧹 Exclude pre-commit bot branch from CI runs on push (#1085)
 
 ## 0.5.1 (2021-12-31)
 


### PR DESCRIPTION
Same reasoning as for #978 and #1014

### Change summary

- [🚇🧹 Exclude pre-commit bot branch from CI runs on push](https://github.com/glotaran/pyglotaran/commit/8c7b91bc5ea843b5486032b621d6fdbc0031aa6e)
### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
