### PR TITLE
🚧🔧 Add 'extras' and 'full' extras_require installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ If you want to install it via conda, you can run the following command:
 conda install -c conda-forge pyglotaran
 ```
 
+To install pyglotaran together with [pyglotaran-extras](https://github.com/glotaran/pyglotaran-extras) which provides common plotting functionality you can run:
+
+```console
+pip install pyglotaran[extras]
+```
+
 ### From Source
 
 To install from source, e.g. for testing or development purposes, run these commands in your shell/terminal:

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 - ♻️ Move simulation to own module (#1041)
 - ♻️ Move optimization to new module glotaran.optimization (#1047)
 - 🩹 Fix missing installation of clp-guide megacomplex as plugin (#1066)
+- 🚧🔧 Add 'extras' and 'full' extras_require installation options (#1089)
 
 ### 🩹 Bug fixes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,12 @@ glotaran.plugins.project_io =
     xlsx = glotaran.builtin.io.pandas.xlsx
     folder = glotaran.builtin.io.folder.folder_plugin
 
+[options.extras_require]
+extras =
+    pyglotaran-extras>=0.5.0
+full =
+    pyglotaran[extras]
+
 [aliases]
 test = pytest
 


### PR DESCRIPTION
This will allow installing `pyglotaran` together with `pyglotaran-extras` by calling `pip install pyglotaran[extras]` or `pip install pyglotaran[full]`

### Change summary

- [🚧🔧 Added 'extras' and 'full' extras_require install option](https://github.com/glotaran/pyglotaran/commit/b89da55036965739f098dac7f7a4f3f9b6b24596)
- [📚 Added note to readme about installing pyglotaran with extras](https://github.com/glotaran/pyglotaran/pull/1089/commits/a584d15302d1fec9ad2fae27d125231c94473c52)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 📚 Adds documentation of the feature