### PR TITLE
📚🚧✨ Make changelog linkable (use explicit anchors)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 0.6.0 (2022-06-06)
+(changes-0_6_0)=
+
+## 🚀 0.6.0 (2022-06-06)
 
 ### ✨ Features
 
@@ -64,7 +66,9 @@
 - 👌🚇 Change integration tests to use self managed examples action (#1034)
 - 🚇🧹 Exclude pre-commit bot branch from CI runs on push (#1085)
 
-## 0.5.1 (2021-12-31)
+(changes-0_5_1)=
+
+## 🚀 0.5.1 (2021-12-31)
 
 ### 🩹 Bug fixes
 
@@ -76,7 +80,9 @@
 - 🚧 Forward port Improve result comparison workflow and v0.4 changelog (#938)
 - 🚧 Forward port of #936 test_result_consistency
 
-## 0.5.0 (2021-12-01)
+(changes-0_5_0)=
+
+## 🚀 0.5.0 (2021-12-01)
 
 ### ✨ Features
 
@@ -153,7 +159,9 @@
 - 🧹 Move megacomplex integration tests from root level to megacomplexes (#894)
 - 🩹 Fix artifact download in pr_benchmark_reaction workflow (#907)
 
-## 0.4.2 (2021-12-31)
+(changes-0_4_2)=
+
+## 🚀 0.4.2 (2021-12-31)
 
 ### 🩹 Bug fixes
 
@@ -164,7 +172,9 @@
 - 🚇🚧 Updated 'gold standard' result comparison reference ([old](https://github.com/glotaran/pyglotaran-examples/commit/9b8591c668ad7383a908b853339966d5a5f7fe43) -> [new](https://github.com/glotaran/pyglotaran-examples/commit/fc5a5ca0c7fd8b224c85027b510a15717c696c7b))
 - 🚇 Refine test_result_consistency (#936).
 
-## 0.4.1 (2021-09-07)
+(changes-0_4_1)=
+
+## 🚀 0.4.1 (2021-09-07)
 
 ### ✨ Features
 
@@ -175,7 +185,9 @@
 - Fix unintended saving of sub-optimal parameters (0ece818, backport from #747)
 - Improve ordering in k_matrix involved_compartments function (#791)
 
-## 0.4.0 (2021-06-25)
+(changes-0_4_0)=
+
+## 🚀 0.4.0 (2021-06-25)
 
 ### ✨ Features
 
@@ -223,46 +235,64 @@
 - `glotaran.analysis.scheme` -> `glotaran.project.scheme`
 - `model.simulate` -> `glotaran.analysis.simulation.simulate(model, ...)`
 
-## 0.3.3 (2021-03-18)
+(changes-0_3_3)=
+
+## 🚀 0.3.3 (2021-03-18)
 
 - Force recalculation of SVD attributes in `scheme._prepare_data` (#597)
 - Remove unneeded check in `spectral_penalties._get_area` Fixes (#598)
 - Added python 3.9 support (#450)
 
-## 0.3.2 (2021-02-28)
+(changes-0_3_2)=
+
+## 🚀 0.3.2 (2021-02-28)
 
 - Re-release of version 0.3.1 due to packaging issue
 
-## 0.3.1 (2021-02-28)
+(changes-0_3_1)=
+
+## 🚀 0.3.1 (2021-02-28)
 
 - Added compatibility for numpy 1.20 and raised minimum required numpy version to 1.20 (#555)
 - Fixed excessive memory consumption in result creation due to full SVD computation (#574)
 - Added feature parameter history (#557)
 - Moved setup logic to `setup.cfg` (#560)
 
-## 0.3.0 (2021-02-11)
+(changes-0_3_0)=
+
+## 🚀 0.3.0 (2021-02-11)
 
 - Significant code refactor with small API changes to parameter relation specification (see docs)
 - Replaced lmfit with scipy.optimize
 
-## 0.2.0 (2020-12-02)
+(changes-0_2_0)=
+
+## 🚀 0.2.0 (2020-12-02)
 
 - Large refactor with significant improvements but also small API changes (see docs)
 - Removed doas plugin
 
-## 0.1.0 (2020-07-14)
+(changes-0_1_0)=
+
+## 🚀 0.1.0 (2020-07-14)
 
 - Package was renamed to `pyglotaran` on PyPi
 
-## 0.0.8 (2018-08-07)
+(changes-0_0_8)=
+
+## 🚀 0.0.8 (2018-08-07)
 
 - Changed `nan_policiy` to `omit`
 
-## 0.0.7 (2018-08-07)
+(changes-0_0_7)=
+
+## 🚀 0.0.7 (2018-08-07)
 
 - Added support for multiple shapes per compartment.
 
-## 0.0.6 (2018-08-07)
+(changes-0_0_6)=
+
+## 🚀 0.0.6 (2018-08-07)
 
 - First release on PyPI, support for Windows installs added.
 - Pre-Alpha Development


### PR DESCRIPTION
This makes the links explicitly named (permanent) instead of iterating over an index which lead to moving links
Ref.: https://myst-parser.readthedocs.io/en/latest/intro.html#cross-referencing

### Change summary

- [📚🚧✨ Added crossreferences to changelog version sections](https://github.com/glotaran/pyglotaran/commit/e0f203b7c90682faf5d9f0d61d08e5c5f7c08121)

<!-- Documentation changes, only needed if bigger changes were made  -->

- [changelog latest #id1](https://pyglotaran.readthedocs.io/en/latest/changelog.html#id1)
- [changelog 0.5.0 #id1](https://pyglotaran.readthedocs.io/en/v0.5.0/changelog.html#id1) 

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
