### PR TITLE
🔧 Set sourcery-ai target python version to 3.8

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -5,6 +5,7 @@ refactor:
     - simplify-boolean-comparison
     - simplify-len-comparison
     - remove-unnecessary-cast
+  python_version: "3.8"
 
 metrics:
   quality_threshold: 25.0

--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,8 @@
 
 ### 🚧 Maintenance
 
-🚇🩹 Fix wrong comparison in pr_benchmark workflow (#1097)
+- 🚇🩹 Fix wrong comparison in pr_benchmark workflow (#1097)
+- 🔧 Set sourcery-ai target python version to 3.8 (#1095)
 
 (changes-0_6_0)=
 


### PR DESCRIPTION
We do not want sourcery to introduce code that isn't compatible with python 3.8, like the [merge syntax added in python 3.9
](https://docs.python.org/3.9/whatsnew/3.9.html#dictionary-merge-update-operators), as it tried to do [here](https://github.com/glotaran/pyglotaran/pull/1078/commits/20474b9e625a1881e79024e176fdc2e676dd36d8#diff-97392e0b8f76dfbef3b4da24549019509f1c3723cf8373c9e23985eea46b0584R31).
[The default python version of sourcery is python 3.9](https://docs.sourcery.ai/Configuration/Project-Settings/)

### Change summary

- [🔧 Set sourcery-ai target python version to 3.8](https://github.com/glotaran/pyglotaran/commit/728bf439585b1b3aebb88c73ebdb090e078fc655)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)