### PR TITLE
🚧 Set version to 0.7.0.dev0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,23 @@
 # Changelog
 
+(changes-0_7_0)=
+
+## 🚀 0.7.0 (Unreleased)
+
+### ✨ Features
+
+### 👌 Minor Improvements:
+
+### 🩹 Bug fixes
+
+### 📚 Documentation
+
+### 🗑️ Deprecations (due in 0.9.0)
+
+### 🗑️❌ Deprecated functionality removed in this release
+
+### 🚧 Maintenance
+
 (changes-0_6_0)=
 
 ## 🚀 0.6.0 (2022-06-06)

--- a/glotaran/__init__.py
+++ b/glotaran/__init__.py
@@ -4,7 +4,7 @@ from glotaran.plugin_system.base_registry import load_plugins
 
 load_plugins()
 
-__version__ = "0.6.0"
+__version__ = "0.7.0.dev0"
 
 examples = deprecate_submodule(
     deprecated_module_name="glotaran.examples",


### PR DESCRIPTION
Since `0.6.0` got finally released we should use a dev version again.

### Change summary

- [🚧 Changed version from 0.6.0 to 0.7.0.dev0](https://github.com/glotaran/pyglotaran/commit/50c319f3bb9d113d92ca84eb4acb7b5b05c53dae)
- [🚧📚 Added 0.7.0 section boilerplate to the changelog](https://github.com/glotaran/pyglotaran/commit/fd2d21a52cf25f138db46f507d96d0b143a464c9)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)