### PR TITLE
🚇🩹 Fix wrong comparison in pr_benchmark workflow

### DIFF
--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -78,7 +78,7 @@ jobs:
 
           pr_nr = os.environ.get("PR_NR")
           diff_release_main = subprocess.run(
-              ["asv", "--config=benchmark/asv.conf.json", "compare", "${{steps.benchmark_run.outputs.last_tag}}", "HEAD"],
+              ["asv", "--config=benchmark/asv.conf.json", "compare", "${{steps.benchmark_run.outputs.last_tag}}", "upstream/main"],
               capture_output=True,
           )
           diff_main_PR = subprocess.run(

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,8 @@
 
 ### 🚧 Maintenance
 
+🚇🩹 Fix wrong comparison in pr_benchmark workflow (#1097)
+
 (changes-0_6_0)=
 
 ## 🚀 0.6.0 (2022-06-06)


### PR DESCRIPTION
In #1060 we just found that there is an error in the comparison of the last tag and the main branch in the `pr_benchmark` workflow. Instead of comparing the last tag to main, it compares it against the PR HEAD

### Change summary

- [🚇🩹 Fixed release and main comparison using HEAD instead of main](https://github.com/glotaran/pyglotaran/commit/3728a0f104627f9d5167b4a48b4acfda2a862e93)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)