### PR TITLE
👌🎨 Wrap model section in result markdown in details tag for notebooks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
 
 ### 👌 Minor Improvements:
 
+- 👌🎨 Wrap model section in result markdown in details tag for notebooks (#1098)
+
 ### 🩹 Bug fixes
 
 ### 📚 Documentation

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -174,7 +174,7 @@ class Result:
         with_model: bool = True,
         *,
         base_heading_level: int = 1,
-        model_is_detail: bool = False,
+        wrap_model_in_details: bool = False,
     ) -> MarkdownStr:
         """Format the model as a markdown text.
 
@@ -184,7 +184,7 @@ class Result:
             If `True`, the model will be printed with initial and optimized parameters filled in.
         base_heading_level : int
             The level of the base heading.
-        model_is_detail: bool
+        wrap_model_in_details: bool
             Wraps model into details tag. Defaults to ``False``
 
         Returns
@@ -238,7 +238,7 @@ class Result:
                 initial_parameters=self.initial_parameters,
                 base_heading_level=base_heading_level,
             )
-            if model_is_detail is False:
+            if wrap_model_in_details is False:
                 result_table = f"{result_table}\n\n{model_md}"
             else:
                 result_table = f"{result_table}\n\n<br><details>\n\n{model_md}\n</details>"
@@ -255,7 +255,7 @@ class Result:
         str
             The scheme as markdown string.
         """
-        return str(self.markdown(base_heading_level=3, model_is_detail=True))
+        return str(self.markdown(base_heading_level=3, wrap_model_in_details=True))
 
     def __str__(self) -> str:
         """Overwrite of ``__str__``."""

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -169,7 +169,13 @@ class Result:
 
         return replace(self.scheme, parameters=self.optimized_parameters)
 
-    def markdown(self, with_model: bool = True, base_heading_level: int = 1) -> MarkdownStr:
+    def markdown(
+        self,
+        with_model: bool = True,
+        *,
+        base_heading_level: int = 1,
+        model_is_detail: bool = False,
+    ) -> MarkdownStr:
         """Format the model as a markdown text.
 
         Parameters
@@ -178,6 +184,8 @@ class Result:
             If `True`, the model will be printed with initial and optimized parameters filled in.
         base_heading_level : int
             The level of the base heading.
+        model_is_detail: bool
+            Wraps model into details tag. Defaults to ``False``
 
         Returns
         -------
@@ -230,7 +238,10 @@ class Result:
                 initial_parameters=self.initial_parameters,
                 base_heading_level=base_heading_level,
             )
-            result_table = f"{result_table}\n\n{model_md}"
+            if model_is_detail is False:
+                result_table = f"{result_table}\n\n{model_md}"
+            else:
+                result_table = f"{result_table}\n\n<br><details>\n\n{model_md}\n</details>"
 
         return MarkdownStr(result_table)
 
@@ -244,7 +255,7 @@ class Result:
         str
             The scheme as markdown string.
         """
-        return str(self.markdown(base_heading_level=3))
+        return str(self.markdown(base_heading_level=3, model_is_detail=True))
 
     def __str__(self) -> str:
         """Overwrite of ``__str__``."""

--- a/glotaran/project/test/test_result.py
+++ b/glotaran/project/test/test_result.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import numpy as np
@@ -29,16 +30,19 @@ def dummy_result():
 
 def test_result_ipython_rendering(dummy_result: Result):
     """Autorendering in ipython"""
+    details_pattern = re.compile(r".+<br><details>\n\n### Model.+<\/details>", re.DOTALL)
 
     rendered_obj = format_display_data(dummy_result)[0]
 
     assert "text/markdown" in rendered_obj
     assert rendered_obj["text/markdown"].startswith("| Optimization Result")
+    assert details_pattern.match(rendered_obj["text/markdown"]) is not None
 
     rendered_markdown_return = format_display_data(dummy_result.markdown())[0]
 
     assert "text/markdown" in rendered_markdown_return
     assert rendered_markdown_return["text/markdown"].startswith("| Optimization Result")
+    assert details_pattern.match(rendered_markdown_return["text/markdown"]) is None
 
 
 def test_result_markdown_nested_parameters():


### PR DESCRIPTION
This change makes the markdown rendering of the result in notebooks/ipython less overwhelming by hiding the model in a details tag which can be expanded.

Requested by @ism200 

## Before
![image](https://user-images.githubusercontent.com/9513634/174325203-b3c35c54-b7d0-482c-a8a0-f6f9263e838b.png)

## After
### Hidden
![image](https://user-images.githubusercontent.com/9513634/174324950-f8e91599-764c-43b3-a1f6-d9348401f112.png)

### Expanded
![image](https://user-images.githubusercontent.com/9513634/174325017-0453a75d-6a74-474f-833a-4dd9843d9f30.png)

### Change summary

- [👌🎨 Wrap model section in result markdown in details tag for notebooks](https://github.com/glotaran/pyglotaran/commit/5d6bf3ca5a90446cc547253e3343a2f2127a194a)
- [🧪 Added test for details tag in ipython render but not in call to markdown](https://github.com/glotaran/pyglotaran/pull/1098/commits/08a0eae633883381393db0de24fe5765951ca91f) 

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

