### PR TITLE
🚇🩹🔧 Fix manifest check

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -153,7 +153,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          python -m pip install -U pip wheel
+          python -m pip install -U pip wheel 'setuptools>=62.4.0'
       - name: Build dist
         run: |
           python setup.py sdist bdist_wheel

--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install check manifest
-        run: python -m pip install check-manifest
+        run: python -m pip install check-manifest 'setuptools>=62.4.0'
       - name: Run check manifest
         run: check-manifest
 

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 
 - 🚇🩹 Fix wrong comparison in pr_benchmark workflow (#1097)
 - 🔧 Set sourcery-ai target python version to 3.8 (#1095)
+- 🚇🩹🔧 Fix manifest check (#1099)
 
 (changes-0_6_0)=
 


### PR DESCRIPTION
Recently the [manifest-check CI test started to fail](https://github.com/glotaran/pyglotaran/runs/6938429155?check_suite_focus=true), while I don't completely understand what is going on there it seems to be some kind of version mismatch between setuptools and distutils (python builtin) in the CI python env.
Raising the requirement for setuptool to be at least the current version fixes this issue (might also work with a lower version, but `56.0.0` was the one installed in the broken env).

### Change summary

- [🩹🔧 Upgradegrade setuptools to >=62.4.0](https://github.com/glotaran/pyglotaran/commit/3edd7f0e9fe577037533472ea6da958cc1e72527)
- [🔧 Upgrade setuptools in the deploy step just to be on the save side](https://github.com/glotaran/pyglotaran/commit/1b2cc3df72e61891ebf786184dcd29f33f98aaa5)


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
