### PR TITLE
⬆️ Combined updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.38.2
+    rev: v3.1.0
     hooks:
       - id: pyupgrade
         types: [file]
@@ -32,7 +32,7 @@ repos:
         types_or: [python, pyi]
 
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
         types: [file]
@@ -110,7 +110,7 @@ repos:
         additional_dependencies: [flake8-docstrings, darglint==1.8.0]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.981
+    rev: v0.982
     hooks:
       - id: mypy
         files: "^glotaran/(plugin_system|utils|deprecation|testing|optimization|parameter|project|simulation|model/property.py|builtin/io/pandas)"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ numba==0.56.2
 numpy==1.23.3
 openpyxl==3.0.10
 pandas==1.5.0
-rich==12.5.1
+rich==12.6.0
 ruamel.yaml==0.17.21
 scipy==1.9.1
 sdtfile==2022.9.28

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,7 +15,7 @@ ruamel.yaml==0.17.21
 scipy==1.9.1
 sdtfile==2022.9.28
 tabulate==0.9.0
-xarray==2022.9.0
+xarray==2022.10.0
 
 # documentation dependencies
 -r docs/requirements.txt

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ wheel>=0.30.0
 asteval==0.9.27
 click==8.1.3
 netCDF4==1.6.1
-numba==0.56.2
+numba==0.56.3
 numpy==1.23.4
 openpyxl==3.0.10
 pandas==1.5.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ asteval==0.9.27
 click==8.1.3
 netCDF4==1.6.1
 numba==0.56.2
-numpy==1.23.3
+numpy==1.23.4
 openpyxl==3.0.10
 pandas==1.5.0
 rich==12.6.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ openpyxl==3.0.10
 pandas==1.5.0
 rich==12.6.0
 ruamel.yaml==0.17.21
-scipy==1.9.1
+scipy==1.9.2
 sdtfile==2022.9.28
 tabulate==0.9.0
 xarray==2022.10.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,7 +14,7 @@ rich==12.5.1
 ruamel.yaml==0.17.21
 scipy==1.9.1
 sdtfile==2022.9.28
-tabulate==0.8.10
+tabulate==0.9.0
 xarray==2022.9.0
 
 # documentation dependencies


### PR DESCRIPTION
Combined dependency and pre-commit updates.

### Change summary

- [Bump tabulate from 0.8.10 to 0.9.0](https://github.com/glotaran/pyglotaran/commit/7d9501864ad819b0941e0bd9e7cc9606caaaf1cf)
- [Bump rich from 12.5.1 to 12.6.0](https://github.com/glotaran/pyglotaran/commit/f720a7958fbbed4543e47a296085503177b272b3)
- [[pre-commit.ci] pre-commit autoupdate](https://github.com/glotaran/pyglotaran/commit/a536f54e4a3cd4b10624411361958fab8f015e95)
- [Bump numpy from 1.23.3 to 1.23.4](https://github.com/glotaran/pyglotaran/commit/b6a84bc00107a34e1de95faf5968178e7aaf6daf)
- [Bump xarray from 2022.9.0 to 2022.10.0](https://github.com/glotaran/pyglotaran/commit/6298db3af2a35464b5dfac49158d1caaba6768f8)
- [Bump scipy from 1.9.1 to 1.9.2](https://github.com/glotaran/pyglotaran/commit/e5b3f49bfff99d4cebad9f1088b5b9ba096faa1b)
- [Bump numba from 0.56.2 to 0.56.3](https://github.com/glotaran/pyglotaran/commit/8ff7487fdeeb37e287d05ee3439656cc9bfb67e8)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

closes #1137 
closes #1138 
closes #1140 
closes #1141
closes #1142 
closes #1143 
closes #1144 
