### PR TITLE
🩹 Fix result data overwritten when using multiple dataset_groups

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@
 
 ### 🩹 Bug fixes
 
+- 🩹 Fix result data overwritten when using multiple dataset_groups (#1147)
+
 ### 📚 Documentation
 
 ### 🗑️ Deprecations (due in 0.9.0)

--- a/glotaran/optimization/optimization_group.py
+++ b/glotaran/optimization/optimization_group.py
@@ -131,7 +131,11 @@ class OptimizationGroup:
         dict[str, xr.Dataset]
             The datasets with the results.
         """
-        result_datasets = {label: data.copy() for label, data in self._data.items()}
+        result_datasets = {
+            label: data.copy()
+            for label, data in self._data.items()
+            if label in self._dataset_group.dataset_models.keys()
+        }
 
         global_matrices, matrices = self._matrix_provider.get_result()
         clps, residuals = self._estimation_provider.get_result()

--- a/glotaran/optimization/test/test_multiple_goups.py
+++ b/glotaran/optimization/test/test_multiple_goups.py
@@ -65,3 +65,7 @@ def test_multiple_groups():
     for label, param in result.optimized_parameters.all():
         if param.vary:
             assert np.allclose(param.value, wanted_parameters.get(label).value, rtol=1e-1)
+
+    for dataset in result.data.values():
+        assert "weighted_root_mean_square_error" in dataset.attrs
+        assert "fitted_data" in dataset.data_vars


### PR DESCRIPTION
This fixes a bug when using multiple `dataset_groups`, where each `OptimizationGroup` (one per `dataset_group`) overwrites previous results from different `dataset_group` with the input data.

### Change summary

- [🧪 Extended test reproducing overwriting existing result dataset](https://github.com/glotaran/pyglotaran/commit/0c416264f30499122d87725c16fef502d5a1a5bb)
- [🩹 Filter datasets in create_result_data.create_result_data to used ones](https://github.com/glotaran/pyglotaran/commit/6ab5280980b1b58f02d810919b013c2cd2725475)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
