### PR TITLE
🚇Add .venv folder (and derivatives) to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ pyvenv.cfg
 /venv*
 /.env/
 
+# sensitive environment variables
+.env
+
 # TIMP data
 *.RData
 *.Rhistory


### PR DESCRIPTION
This makes it possible to more easily work with python (venv) virtual environments.

Add `.venv*` to .gitignore which captures the [most common](https://docs.python.org/3/tutorial/venv.html) naming pattern for standard python virtual environments:
> A common directory location for a virtual environment is .venv. This name keeps the directory typically hidden in your shell and thus out of the way while giving it a name that explains why the directory exists. It also prevents clashing with .env environment variable definition files that some tooling supports.

<!-- Maintenance commit, does not require further documentation -->
