### PR TITLE
✨🚇 Add official python 3.11 support

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -117,7 +117,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -131,7 +131,7 @@ Before you submit a pull request, check that it meets these guidelines:
 1.  The pull request should include tests.
 2.  If the pull request adds functionality, the docs should be updated. Put
     your new functionality into a function with a `docstring`_.
-3.  The pull request should work for Python 3.10
+3.  The pull request should work for Python 3.10 and 3.11
     Check your Github Actions ``https://github.com/<your_name_here>/pyglotaran/actions``
     and make sure that the tests pass for all supported Python versions.
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 ### ✨ Features
 
+- ✨ Python 3.11 support (#1161)
+
 ### 👌 Minor Improvements:
 
 ### 🩹 Bug fixes

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -7,7 +7,7 @@ Installation
 Prerequisites
 -------------
 
-* Python 3.6 or later
+* Python 3.10 or 3.11
 
 Windows
 +++++++

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ asteval==0.9.29
 attrs == 23.1.0
 click==8.1.3
 netCDF4==1.6.3
-numba==0.56.4
+numba==0.57.0
 numpy==1.23.5
 odfpy==1.4.1
 openpyxl==3.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     sdtfile>=2020.8.3
     tabulate>=0.8.9
     xarray>=2022.3.0
-python_requires = >=3.10, <3.11
+python_requires = >=3.10, <3.12
 tests_require = pytest
 zip_safe = True
 


### PR DESCRIPTION
Since python 3.11 came out some time ago we should also see we can already support it (mostly dependency issue).

### Change summary

- ✨🚇 Added python 3.11 CI tests

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
