### PR TITLE
🧹 Upgrade syntax to py310 using pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: pyupgrade
         types: [file]
         types_or: [python, pyi]
-        args: [--py38-plus]
+        args: [--py310-plus]
         exclude: "glotaran.model.item"
 
   - repo: https://github.com/MarcoGorelli/absolufy-imports

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,1 @@
-sonar.cpd.exclusions=**/test_*.py
+sonar.cpd.exclusions=**/test_*.py,glotaran/plugin_system/*_io_registration.py

--- a/changelog.md
+++ b/changelog.md
@@ -49,6 +49,7 @@
 - ♻️🚇 Use GITHUB_OUTPUT instead of set-output in github actions (#1166)
 - 🚧 Add pinned version of odfpy to requirements_dev.txt (#1164)
 - ♻️ Use validation action and validation as a git submodule (#1165)
+- 🧹 Upgrade syntax to py310 using pyupgrade
 
 (changes-0_6_0)=
 

--- a/glotaran/builtin/io/yml/test/test_model_parser.py
+++ b/glotaran/builtin/io/yml/test/test_model_parser.py
@@ -1,4 +1,3 @@
-from os.path import abspath
 from os.path import dirname
 from os.path import join
 
@@ -15,7 +14,7 @@ from glotaran.model import OnlyConstraint
 from glotaran.model import Weight
 from glotaran.model import ZeroConstraint
 
-THIS_DIR = dirname(abspath(__file__))
+THIS_DIR = dirname(__file__)
 
 
 @pytest.fixture

--- a/glotaran/builtin/io/yml/utils.py
+++ b/glotaran/builtin/io/yml/utils.py
@@ -8,9 +8,9 @@ from ruamel.yaml import YAML
 from ruamel.yaml.compat import StringIO
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from collections.abc import Sequence
     from typing import Any
-    from typing import Mapping
-    from typing import Sequence
 
     from ruamel.yaml.nodes import ScalarNode
     from ruamel.yaml.representer import BaseRepresenter

--- a/glotaran/cli/commands/optimize.py
+++ b/glotaran/cli/commands/optimize.py
@@ -1,5 +1,4 @@
 import sys
-import typing
 
 import click
 
@@ -53,7 +52,7 @@ from glotaran.project.scheme import Scheme
 @util.signature_analysis
 def optimize_cmd(
     dataformat: str,
-    data: typing.List[str],
+    data: list[str],
     out: str,
     outformat: str,
     nfev: int,

--- a/glotaran/cli/commands/util.py
+++ b/glotaran/cli/commands/util.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Iterable
+from collections.abc import Iterable
 
 import click
 from click import echo

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -740,10 +740,11 @@ def deprecate_submodule(
 
     .. # noqa: DAR402
     """
-    if module_load_overwrite == "":
-        new_module = import_module(new_module_name)
-    else:
-        new_module = import_module(module_load_overwrite)
+    new_module = (
+        import_module(module_load_overwrite)
+        if module_load_overwrite
+        else import_module(new_module_name)
+    )
 
     deprecated_module = ModuleType(
         deprecated_module_name,

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 import os
 import re
 import sys
+from collections.abc import Callable
+from collections.abc import Hashable
+from collections.abc import Mapping
+from collections.abc import MutableMapping
 from functools import wraps
 from importlib import import_module
 from importlib.metadata import distribution
 from types import ModuleType
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
-from typing import Hashable
-from typing import Mapping
-from typing import MutableMapping
 from typing import TypeVar
 from typing import cast
 from warnings import warn
@@ -26,8 +26,8 @@ DecoratedCallable = TypeVar(
 )  # decorated function or class
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from typing import NoReturn
-    from typing import Sequence
 
 
 class OverDueDeprecation(Exception):

--- a/glotaran/deprecation/modules/builtin_io_yml.py
+++ b/glotaran/deprecation/modules/builtin_io_yml.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING
 from glotaran.deprecation import deprecate_dict_entry
 
 if TYPE_CHECKING:
+    from collections.abc import MutableMapping
     from typing import Any
-    from typing import MutableMapping
 
 
 def model_spec_deprecations(spec: MutableMapping[Any, Any]) -> None:

--- a/glotaran/deprecation/modules/test/__init__.py
+++ b/glotaran/deprecation/modules/test/__init__.py
@@ -9,10 +9,10 @@ import pytest
 from glotaran.deprecation.deprecation_utils import GlotaranApiDeprecationWarning
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Mapping
+    from collections.abc import Sequence
     from typing import Any
-    from typing import Callable
-    from typing import Mapping
-    from typing import Sequence
 
     from _pytest.recwarn import WarningsRecorder
 

--- a/glotaran/deprecation/test/test_deprecation_utils.py
+++ b/glotaran/deprecation/test/test_deprecation_utils.py
@@ -20,9 +20,9 @@ from glotaran.deprecation.deprecation_utils import raise_deprecation_error
 from glotaran.deprecation.deprecation_utils import warn_deprecated
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable
+    from collections.abc import Mapping
     from typing import Any
-    from typing import Hashable
-    from typing import Mapping
 
     from _pytest.monkeypatch import MonkeyPatch
     from _pytest.recwarn import WarningsRecorder

--- a/glotaran/io/interface.py
+++ b/glotaran/io/interface.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
     from typing import Literal
     from typing import Union
 

--- a/glotaran/io/prepare_dataset.py
+++ b/glotaran/io/prepare_dataset.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 
 if TYPE_CHECKING:
-    from typing import Hashable
+    from collections.abc import Hashable
 
 
 def prepare_time_trace_dataset(

--- a/glotaran/model/dataset_model.py
+++ b/glotaran/model/dataset_model.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from typing import TYPE_CHECKING
-from typing import Generator
 
 import xarray as xr
 

--- a/glotaran/model/megacomplex.py
+++ b/glotaran/model/megacomplex.py
@@ -1,8 +1,8 @@
 """This module contains the megacomplex."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
-from typing import Callable
 from typing import ClassVar
 
 import numpy as np

--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -1,11 +1,11 @@
 """This module contains the model."""
 from __future__ import annotations
 
+from collections.abc import Callable
+from collections.abc import Generator
+from collections.abc import Mapping
 from typing import Any
-from typing import Callable
 from typing import ClassVar
-from typing import Generator
-from typing import Mapping
 from uuid import uuid4
 
 from attr import asdict

--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -276,7 +276,7 @@ class Model:
                 dataset_types |= {
                     dataset_model_type,
                 }
-            attributes.update(_create_attributes_for_item(megacomplex))
+            attributes |= _create_attributes_for_item(megacomplex)
 
         dataset_type = (
             DatasetModel

--- a/glotaran/parameter/parameters.py
+++ b/glotaran/parameter/parameters.py
@@ -1,10 +1,10 @@
 """The parameters class."""
 from __future__ import annotations
 
+from collections.abc import Generator
 from textwrap import indent
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Generator
 
 import asteval
 import numpy as np

--- a/glotaran/plugin_system/base_registry.py
+++ b/glotaran/plugin_system/base_registry.py
@@ -12,18 +12,17 @@ from typing import TYPE_CHECKING
 from warnings import warn
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import MutableMapping
+    from collections.abc import Sequence
     from typing import Any
-    from typing import Callable
-    from typing import MutableMapping
-    from typing import Sequence
-    from typing import Type
     from typing import TypeVar
 
     from glotaran.io.interface import DataIoInterface
     from glotaran.io.interface import ProjectIoInterface
     from glotaran.model.megacomplex import Megacomplex
 
-    _PluginType = TypeVar("_PluginType", Type[Megacomplex], DataIoInterface, ProjectIoInterface)
+    _PluginType = TypeVar("_PluginType", type[Megacomplex], DataIoInterface, ProjectIoInterface)
     _PluginInstantiableType = TypeVar(
         "_PluginInstantiableType", DataIoInterface, ProjectIoInterface
     )

--- a/glotaran/plugin_system/data_io_registration.py
+++ b/glotaran/plugin_system/data_io_registration.py
@@ -31,8 +31,8 @@ from glotaran.plugin_system.io_plugin_utils import protect_from_overwrite
 from glotaran.utils.ipython import MarkdownStr
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Any
-    from typing import Callable
     from typing import Literal
 
     from glotaran.io.interface import DataLoader

--- a/glotaran/plugin_system/io_plugin_utils.py
+++ b/glotaran/plugin_system/io_plugin_utils.py
@@ -3,19 +3,19 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from functools import partial
 from functools import wraps
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import TypeVar
 from typing import cast
 
 DecoratedFunc = TypeVar("DecoratedFunc", bound=Callable[..., Any])  # decorated function
 
 if TYPE_CHECKING:
-    from typing import Iterable
-    from typing import Iterator
+    from collections.abc import Iterable
+    from collections.abc import Iterator
 
     from glotaran.typing import StrOrPath
 

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -33,8 +33,8 @@ from glotaran.plugin_system.io_plugin_utils import protect_from_overwrite
 from glotaran.utils.ipython import MarkdownStr
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Any
-    from typing import Callable
     from typing import Literal
 
     from glotaran.model import Model

--- a/glotaran/plugin_system/test/test_base_registry.py
+++ b/glotaran/plugin_system/test/test_base_registry.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from copy import copy
 from typing import TYPE_CHECKING
-from typing import MutableMapping
-from typing import Type
 from typing import cast
 from warnings import warn
 
@@ -66,7 +65,7 @@ mock_registry_data_io = cast(
 mock_registry_project_io = cast(
     MutableMapping[str, ProjectIoInterface], copy(mock_registry_data_io)
 )
-mock_registry_model = cast(MutableMapping[str, Type[Megacomplex]], copy(mock_registry_data_io))
+mock_registry_model = cast(MutableMapping[str, type[Megacomplex]], copy(mock_registry_data_io))
 
 
 @pytest.mark.parametrize(

--- a/glotaran/plugin_system/test/test_project_io_registration.py
+++ b/glotaran/plugin_system/test/test_project_io_registration.py
@@ -32,8 +32,8 @@ from glotaran.plugin_system.project_io_registration import set_project_plugin
 from glotaran.plugin_system.project_io_registration import show_project_io_method_help
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Any
-    from typing import Callable
 
     from _pytest.capture import CaptureFixture
     from _pytest.monkeypatch import MonkeyPatch

--- a/glotaran/project/dataclass_helpers.py
+++ b/glotaran/project/dataclass_helpers.py
@@ -13,8 +13,8 @@ from typing import TYPE_CHECKING
 from glotaran.utils.io import relative_posix_path
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Any
-    from typing import Callable
     from typing import TypeVar
 
     from glotaran.typing.protocols import FileLoadable

--- a/glotaran/project/generators/generator.py
+++ b/glotaran/project/generators/generator.py
@@ -1,8 +1,8 @@
 """The glotaran generator module."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
-from typing import Callable
 from typing import TypedDict
 from typing import cast
 

--- a/glotaran/project/project_registry.py
+++ b/glotaran/project/project_registry.py
@@ -1,9 +1,9 @@
 """The glotaran registry module."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
-from typing import Callable
 
 from glotaran.utils.ipython import MarkdownStr
 

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -6,7 +6,6 @@ from dataclasses import field
 from dataclasses import replace
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import List
 from typing import cast
 
 import numpy as np
@@ -32,8 +31,8 @@ from glotaran.utils.ipython import MarkdownStr
 
 if TYPE_CHECKING:
 
-    from typing import Callable
-    from typing import Mapping
+    from collections.abc import Callable
+    from collections.abc import Mapping
 
     from glotaran.typing import StrOrPath
 
@@ -285,7 +284,7 @@ class Result:
             Paths to all the saved files.
         """
         return cast(
-            List[str],
+            list[str],
             save_result(
                 result_path=path,
                 result=self,

--- a/glotaran/project/scheme.py
+++ b/glotaran/project/scheme.py
@@ -15,9 +15,9 @@ from glotaran.utils.ipython import MarkdownStr
 
 if TYPE_CHECKING:
 
-    from typing import Callable
+    from collections.abc import Callable
+    from collections.abc import Mapping
     from typing import Literal
-    from typing import Mapping
 
     import xarray as xr
 

--- a/glotaran/testing/plugin_system.py
+++ b/glotaran/testing/plugin_system.py
@@ -9,8 +9,8 @@ from unittest import mock
 from glotaran.plugin_system.base_registry import __PluginRegistry
 
 if TYPE_CHECKING:
-    from typing import Generator
-    from typing import MutableMapping
+    from collections.abc import Generator
+    from collections.abc import MutableMapping
 
     from glotaran.io.interface import DataIoInterface
     from glotaran.io.interface import ProjectIoInterface

--- a/glotaran/testing/plugin_system.py
+++ b/glotaran/testing/plugin_system.py
@@ -50,8 +50,11 @@ def _monkeypatch_plugin_registry(
     """
     if test_registry is not None:
         initila_plugins = (
-            __PluginRegistry.__dict__[register_name] if not create_new_registry else {}
+            {}
+            if create_new_registry
+            else __PluginRegistry.__dict__[register_name]
         )
+
 
         with mock.patch.object(
             __PluginRegistry, register_name, {**initila_plugins, **test_registry}

--- a/glotaran/testing/plugin_system.py
+++ b/glotaran/testing/plugin_system.py
@@ -49,12 +49,7 @@ def _monkeypatch_plugin_registry(
     monkeypatch_plugin_registry_project_io
     """
     if test_registry is not None:
-        initila_plugins = (
-            {}
-            if create_new_registry
-            else __PluginRegistry.__dict__[register_name]
-        )
-
+        initila_plugins = {} if create_new_registry else __PluginRegistry.__dict__[register_name]
 
         with mock.patch.object(
             __PluginRegistry, register_name, {**initila_plugins, **test_registry}

--- a/glotaran/typing/protocols.py
+++ b/glotaran/typing/protocols.py
@@ -6,9 +6,9 @@ from typing import Protocol
 from typing import TypeVar
 
 if TYPE_CHECKING:
-    from typing import Callable
-    from typing import Mapping
-    from typing import Sequence
+    from collections.abc import Callable
+    from collections.abc import Mapping
+    from collections.abc import Sequence
 
     from glotaran.typing.types import StrOrPath
 

--- a/glotaran/typing/types.py
+++ b/glotaran/typing/types.py
@@ -1,7 +1,7 @@
 """Glotaran types module containing commonly used types."""
+from collections.abc import Mapping
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Mapping
-from typing import Sequence
 from typing import TypeVar
 from typing import Union
 

--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -17,7 +17,7 @@ from glotaran.plugin_system.data_io_registration import load_dataset
 from glotaran.typing.types import DatasetMappable
 
 if TYPE_CHECKING:
-    from typing import Iterator
+    from collections.abc import Iterator
 
     import pandas as pd
 


### PR DESCRIPTION
Since we upgraded to py310+ we can also make use of the syntax improvements.
The changes are made by simply telling `pyupgrade` that we use python 3.10+ syntax in  `.pre-commit-config.yaml`

### Change summary

- [🧹 Upgrade syntax to py310 using pyupgrade](https://github.com/glotaran/pyglotaran/commit/f56cb8ae4c3f57ce77177b5a0530a311e9edf215)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)