### PR TITLE
🚧 Add pinned version of odfpy to requirements_dev.txt

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,7 @@
 - 🚇🩹🔧 Fix manifest check (#1099)
 - ♻️ Refactor: optimization (#1060)
 - ♻️🚇 Use GITHUB_OUTPUT instead of set-output in github actions (#1166)
+- 🚧 Add pinned version of odfpy to requirements_dev.txt (#1164)
 
 (changes-0_6_0)=
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,6 +9,7 @@ click==8.1.3
 netCDF4==1.6.1
 numba==0.56.4
 numpy==1.23.4
+odfpy==1.4.1
 openpyxl==3.0.10
 pandas==1.5.1
 rich==12.6.0


### PR DESCRIPTION
While setting up a new local environment for pyglotaran I found that the runtime dependency `odfpy` had no pinned version in `requirements_dev.txt`.

### Change summary

- [🚧 Added pinned version of odfpy to requirements_dev.txt](https://github.com/glotaran/pyglotaran/commit/2cc6ee7c0631a0b8ea69a8d0a338865d06465daa)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)