### PR TITLE
♻️🚇 Use GITHUB_OUTPUT instead of set-output in github actions

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -52,7 +52,8 @@ jobs:
               ref = merge_sha_by_pr_nr(int(pr_nr))
           else:
               ref = os.getenv("GITHUB_REF_NAME")
-          print(f"::set-output name=ref::{ref}")
+          with open(os.getenv("GITHUB_OUTPUT"), "a", encoding="utf8") as f:
+              f.writelines([f"ref={ref}"])
       - uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.repo }}

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       pr_nr:
-        description: "pyglotaran branch/tag to run the examples against"
+        description: "PR number to create doxygen docs for, if omitted current branch is used."
         required: false
         default: ""
       repo:
-        description: "pyglotaran branch/tag to run the examples against"
+        description: "Repository doxygen docs for."
         required: true
         default: "glotaran/pyglotaran"
 

--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -54,7 +54,7 @@ jobs:
           asv run upstream/main^..upstream/main --machine gh_action
           asv run HEAD^..HEAD --machine gh_action
           asv publish
-          echo ::set-output name=last_tag::$last_tag
+          echo "last_tag=$last_tag" >> $GITHUB_OUTPUT
 
       - name: Checkout benchmark result repo
         uses: actions/checkout@v3

--- a/.github/workflows/pr_benchmark_reaction.yml
+++ b/.github/workflows/pr_benchmark_reaction.yml
@@ -49,14 +49,23 @@ jobs:
         id: bench_diff
         shell: python
         run: |
+          import os
           from pathlib import Path
 
-          comment_file_path = Path("pr-diff-comment.txt")
-          print(f"::set-output name=comment::{comment_file_path.read_text()}")
-          comment_file_path.unlink()
-          origin_pr_nr_file_path = Path("origin_pr_nr.txt")
-          print(f"::set-output name=pr_nr::{origin_pr_nr_file_path.read_text()}")
-          origin_pr_nr_file_path.unlink()
+          with open(os.getenv("GITHUB_OUTPUT"), "a", encoding="utf8") as f:
+              comment_file_path = Path("pr-diff-comment.txt")
+              f.writelines(
+                  [
+                      "comment<<EOF",
+                      *comment_file_path.read_text().splitlines(),
+                      "EOF",
+                  ]
+              )
+              comment_file_path.unlink()
+
+              origin_pr_nr_file_path = Path("origin_pr_nr.txt")
+              f.writelines([f"pr_nr={origin_pr_nr_file_path.read_text()}"])
+              origin_pr_nr_file_path.unlink()
 
       - name: Show PR Number and Comment
         shell: python
@@ -64,6 +73,7 @@ jobs:
           print(f"PR Number:\n{ ${{ steps.bench_diff.outputs.pr_nr }} }")
           print("Comment Body:")
           print("""${{ steps.bench_diff.outputs.comment }}""")
+
       - name: Comment on PR
         uses: hasura/comment-progress@v2
         with:

--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,6 @@
 - ✨ Add optimization history to result and iteration column to parameter history (#1134)
 - ♻️ Complete refactor of model and parameter packages using attrs (#1135)
 
-
 ### 👌 Minor Improvements:
 
 - 👌🎨 Wrap model section in result markdown in details tag for notebooks (#1098)
@@ -47,6 +46,7 @@
 - 🔧 Set sourcery-ai target python version to 3.8 (#1095)
 - 🚇🩹🔧 Fix manifest check (#1099)
 - ♻️ Refactor: optimization (#1060)
+- ♻️🚇 Use GITHUB_OUTPUT instead of set-output in github actions (#1166)
 
 (changes-0_6_0)=
 


### PR DESCRIPTION
GitHub deprecated the usage of `set-output` in favor of using the environment file located at `$GITHUB_OUTPUT`.
The old syntax already gives warnings and will be switched off 31st May 2023.
This change makes the CI more future proof.

Ref.: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
### Change summary

- [♻️🚇 Use GITHUB_OUTPUT instead of set-output in github actions](https://github.com/glotaran/pyglotaran/pull/1166/commits/0395bcce1b1f895a3b59d4509a9b000bb04fe115)
- [📚🩹 Fixed input description for doxygen workflow](https://github.com/glotaran/pyglotaran/pull/1166/commits/a69fe7504b0104987acd701f2837a1faa41789f8)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
