### PR TITLE
🧹 Remove unused 'type: ignore'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -49,7 +49,8 @@
 - ♻️🚇 Use GITHUB_OUTPUT instead of set-output in github actions (#1166)
 - 🚧 Add pinned version of odfpy to requirements_dev.txt (#1164)
 - ♻️ Use validation action and validation as a git submodule (#1165)
-- 🧹 Upgrade syntax to py310 using pyupgrade
+- 🧹 Upgrade syntax to py310 using pyupgrade (#1162)
+- 🧹 Remove unused 'type: ignore' (#1168)
 
 (changes-0_6_0)=
 

--- a/glotaran/deprecation/deprecation_utils.py
+++ b/glotaran/deprecation/deprecation_utils.py
@@ -429,7 +429,7 @@ def deprecate(
         setattr(
             deprecated_object,
             "__new__",
-            inject_warn_into_call(deprecated_object.__new__),  # type: ignore[arg-type]
+            inject_warn_into_call(deprecated_object.__new__),
         )
         return deprecated_object  # type: ignore[return-value]
 

--- a/glotaran/deprecation/modules/test/test_changed_imports.py
+++ b/glotaran/deprecation/modules/test/test_changed_imports.py
@@ -79,7 +79,7 @@ def test_analysis_optimization(recwarn: WarningsRecorder):
     from glotaran.analysis import optimize as analysis_optimize
 
     assert len(recwarn) == 0
-    assert analysis_optimize.optimize == optimize_module.optimize  # type: ignore[attr-defined]
+    assert analysis_optimize.optimize == optimize_module.optimize
 
     check_recwarn(recwarn)
 
@@ -96,7 +96,7 @@ def test_analysis_simulation(recwarn: WarningsRecorder):
     from glotaran.analysis import simulation as analysis_simulation
 
     assert len(recwarn) == 0
-    assert analysis_simulation.simulate == simulation_module.simulate  # type: ignore[attr-defined]
+    assert analysis_simulation.simulate == simulation_module.simulate
 
     check_recwarn(recwarn)
 

--- a/glotaran/deprecation/test/test_deprecation_utils.py
+++ b/glotaran/deprecation/test/test_deprecation_utils.py
@@ -303,7 +303,7 @@ def test_deprecated_decorator_function(recwarn: WarningsRecorder):
     assert dummy.__doc__ == "Dummy docstring for testing."
     assert len(recwarn) == 1
     assert recwarn[0].category == GlotaranApiDeprecationWarning
-    assert recwarn[0].message.args[0] == DEPRECATION_WARN_MESSAGE  # type: ignore [union-attr]
+    assert recwarn[0].message.args[0] == DEPRECATION_WARN_MESSAGE
     assert Path(recwarn[0].filename) == Path(__file__)
 
     dummy()
@@ -334,7 +334,7 @@ def test_deprecated_decorator_class(recwarn: WarningsRecorder):
     assert Foo.__doc__ == "Foo class docstring for testing."
     assert len(recwarn) == 1
     assert recwarn[0].category == GlotaranApiDeprecationWarning
-    assert recwarn[0].message.args[0] == DEPRECATION_WARN_MESSAGE  # type: ignore [union-attr]
+    assert recwarn[0].message.args[0] == DEPRECATION_WARN_MESSAGE
     assert Path(recwarn[0].filename) == Path(__file__)
 
     Foo.from_string("foo")
@@ -522,10 +522,7 @@ def test_deprecate_submodule(recwarn: WarningsRecorder):
 
     from glotaran.deprecation.test.dummy_package import deprecated_module
 
-    assert (
-        deprecated_module.parse_version.__code__  # type: ignore [attr-defined]
-        == parse_version.__code__
-    )
+    assert deprecated_module.parse_version.__code__ == parse_version.__code__
 
     assert len(recwarn) == 1
     assert recwarn[0].category == GlotaranApiDeprecationWarning

--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -332,8 +332,8 @@ class Model:
                     raise ModelError(f"Unknown dataset group '{group}'")
                 groups[group] = DatasetGroup(
                     residual_function=group_model.residual_function,  # type:ignore[call-arg]
-                    link_clp=group_model.link_clp,  # type:ignore[call-arg]
-                    model=self,  # type:ignore[call-arg]
+                    link_clp=group_model.link_clp,
+                    model=self,
                 )
             groups[group].dataset_models[dataset_model.label] = dataset_model
         return groups
@@ -348,7 +348,7 @@ class Model:
         """
         for attr in fields(self.__class__):
             if META_ITEMS in attr.metadata:
-                yield attr.name, getattr(self, attr.name)  # type:ignore[misc]
+                yield attr.name, getattr(self, attr.name)
 
     def iterate_all_items(self) -> Generator[Item, None, None]:
         """Iterate the individual items.

--- a/glotaran/optimization/data_provider.py
+++ b/glotaran/optimization/data_provider.py
@@ -170,11 +170,7 @@ class DataProvider:
         global_dimension : str
             The global dimension.
         """
-        model_weights = [
-            weight
-            for weight in model.weights  # type:ignore[attr-defined]
-            if dataset_label in weight.datasets  # type:ignore[attr-defined]
-        ]
+        model_weights = [weight for weight in model.weights if dataset_label in weight.datasets]
         if not model_weights:
             return
 

--- a/glotaran/optimization/matrix_provider.py
+++ b/glotaran/optimization/matrix_provider.py
@@ -305,15 +305,15 @@ class MatrixProvider:
             The resulting matrix container.
         """
         model = self.group.model
-        if len(model.clp_constraints) == 0:  # type:ignore[attr-defined]
+        if len(model.clp_constraints) == 0:
             return matrix
 
         clp_labels = matrix.clp_labels
         removed_clp_labels = [
             c.target  # type:ignore[attr-defined]
-            for c in model.clp_constraints  # type:ignore[attr-defined]
+            for c in model.clp_constraints
             if c.target in clp_labels  # type:ignore[attr-defined]
-            and self.does_interval_property_apply(c, index)  # type:ignore[arg-type]
+            and self.does_interval_property_apply(c, index)
         ]
         reduced_clp_labels = [c for c in clp_labels if c not in removed_clp_labels]
         mask = [label in reduced_clp_labels for label in clp_labels]

--- a/glotaran/optimization/optimization_history.py
+++ b/glotaran/optimization/optimization_history.py
@@ -115,7 +115,7 @@ class OptimizationHistory:
         """
         return cls(pd.read_csv(path), source_path=Path(path).as_posix())
 
-    loader = from_csv  # type:ignore[assignment]
+    loader = from_csv
 
     def to_csv(self, path: StrOrPath, delimiter: str = ","):
         """Write a ``OptimizationHistory`` to a CSV file and set ``source_path``.

--- a/glotaran/optimization/test/models.py
+++ b/glotaran/optimization/test/models.py
@@ -135,9 +135,9 @@ class ShapedSpectralMegacomplex(Megacomplex):
         model_axis: np.typing.ArrayLike,
         **kwargs,
     ):
-        location = np.asarray(self.location)  # type:ignore[attr-defined]
-        amp = np.asarray(self.amplitude)  # type:ignore[attr-defined]
-        delta = np.asarray(self.delta)  # type:ignore[attr-defined]
+        location = np.asarray(self.location)
+        amp = np.asarray(self.amplitude)
+        delta = np.asarray(self.delta)
 
         array = np.empty((location.size, model_axis.size), dtype=np.float64)
 

--- a/glotaran/parameter/parameter_history.py
+++ b/glotaran/parameter/parameter_history.py
@@ -62,7 +62,7 @@ class ParameterHistory:
         df = pd.read_csv(path)
         return cls.from_dataframe(df)
 
-    loader = from_csv  # type:ignore[assignment]
+    loader = from_csv
 
     @property
     def parameter_labels(self) -> list[str]:

--- a/glotaran/parameter/test/test_parameter.py
+++ b/glotaran/parameter/test/test_parameter.py
@@ -35,7 +35,7 @@ def test_parameter__deep_equals(key_name: str, value_1: Any, value_2: Any):
 @pytest.mark.parametrize("label, expected", (("foo", "foo"), (0, "0"), (1, "1")))
 def test_parameter_label_always_str_or_None(label: str | int, expected: str):
     """Parameter.label is always a string"""
-    parameter = Parameter(label=label)  # type:ignore[arg-type]
+    parameter = Parameter(label=label)
     assert parameter.label == expected
 
 
@@ -46,7 +46,7 @@ def test_parameter_label_always_str_or_None(label: str | int, expected: str):
 def test_parameter_label_error_wrong_label_pattern(label: str | int | float):
     """Error if label can't be casted to a valid label str"""
     with pytest.raises(ValueError, match=f"'{label}' is not a valid parameter label."):
-        Parameter(label=label)  # type:ignore[arg-type]
+        Parameter(label=label)
 
 
 @pytest.mark.parametrize(
@@ -110,19 +110,19 @@ def test_parameter_options():
 def test_parameter_value_not_numeric_error():
     """Error if value isn't numeric."""
     with pytest.raises(TypeError):
-        Parameter(label="", value="foo")  # type:ignore[arg-type]
+        Parameter(label="", value="foo")
 
 
 def test_parameter_maximum_not_numeric_error():
     """Error if maximum isn't numeric."""
     with pytest.raises(TypeError):
-        Parameter(label="", maximum="foo")  # type:ignore[arg-type]
+        Parameter(label="", maximum="foo")
 
 
 def test_parameter_minimum_not_numeric_error():
     """Error if minimum isn't numeric."""
     with pytest.raises(TypeError):
-        Parameter(label="", minimum="foo")  # type:ignore[arg-type]
+        Parameter(label="", minimum="foo")
 
 
 def test_parameter_non_negative():

--- a/glotaran/plugin_system/base_registry.py
+++ b/glotaran/plugin_system/base_registry.py
@@ -264,11 +264,9 @@ def add_instantiated_plugin_to_registry(
     if isinstance(plugin_register_keys, str):
         plugin_register_keys = [plugin_register_keys]
     for plugin_register_key in plugin_register_keys:
-        # The type ignore is needed due to an issue with mypy
-        # ``Cannot instantiate type "Type[Type[DataIoInterface]]"``
         add_plugin_to_registry(
             plugin_register_key=plugin_register_key,
-            plugin=plugin_class(plugin_register_key),  # type:ignore[misc]
+            plugin=plugin_class(plugin_register_key),
             plugin_registry=plugin_registry,
             plugin_set_func_name=plugin_set_func_name,
             instance_identifier=plugin_register_key,

--- a/glotaran/plugin_system/data_io_registration.py
+++ b/glotaran/plugin_system/data_io_registration.py
@@ -190,7 +190,7 @@ def load_dataset(file_name: StrOrPath, format_name: str = None, **kwargs: Any) -
         Data loaded from the file.
     """
     io = get_data_io(format_name or inferr_file_format(file_name))
-    dataset = io.load_dataset(Path(file_name).as_posix(), **kwargs)  # type: ignore[call-arg]
+    dataset = io.load_dataset(Path(file_name).as_posix(), **kwargs)
 
     if isinstance(dataset, xr.DataArray):
         dataset = dataset.to_dataset(name="data")
@@ -239,11 +239,7 @@ def save_dataset(
     if "source_path" in dataset.attrs:
         orig_source_path: str = dataset.attrs["source_path"]
         del dataset.attrs["source_path"]
-    io.save_dataset(  # type: ignore[call-arg]
-        file_name=Path(file_name).as_posix(),
-        dataset=dataset,
-        **kwargs,
-    )
+    io.save_dataset(file_name=Path(file_name).as_posix(), dataset=dataset, **kwargs)
     dataset.attrs["loader"] = load_dataset
     if update_source_path is True or "orig_source_path" not in locals():
         dataset.attrs["source_path"] = Path(file_name).as_posix()

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -220,7 +220,7 @@ def load_model(file_name: StrOrPath, format_name: str = None, **kwargs: Any) -> 
         Model instance created from the file.
     """
     io = get_project_io(format_name or inferr_file_format(file_name))
-    model = io.load_model(Path(file_name).as_posix(), **kwargs)  # type: ignore[call-arg]
+    model = io.load_model(Path(file_name).as_posix(), **kwargs)
     model.source_path = Path(file_name).as_posix()
     return model
 
@@ -256,11 +256,7 @@ def save_model(
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
-    io.save_model(  # type: ignore[call-arg]
-        file_name=Path(file_name).as_posix(),
-        model=model,
-        **kwargs,
-    )
+    io.save_model(file_name=Path(file_name).as_posix(), model=model, **kwargs)
     if update_source_path is True:
         model.source_path = Path(file_name).as_posix()
 
@@ -287,7 +283,7 @@ def load_parameters(file_name: StrOrPath, format_name: str = None, **kwargs) -> 
     .. # noqa: D414
     """
     io = get_project_io(format_name or inferr_file_format(file_name))
-    parameters = io.load_parameters(  # type: ignore[call-arg]
+    parameters = io.load_parameters(
         Path(file_name).as_posix(),
         **kwargs,
     )
@@ -326,11 +322,7 @@ def save_parameters(
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
-    io.save_parameters(  # type: ignore[call-arg]
-        file_name=Path(file_name).as_posix(),
-        parameters=parameters,
-        **kwargs,
-    )
+    io.save_parameters(file_name=Path(file_name).as_posix(), parameters=parameters, **kwargs)
     if update_source_path is True:
         parameters.source_path = Path(file_name).as_posix()
 
@@ -356,7 +348,7 @@ def load_scheme(file_name: StrOrPath, format_name: str = None, **kwargs: Any) ->
     """
     io = get_project_io(format_name or inferr_file_format(file_name))
 
-    scheme = io.load_scheme(Path(file_name).as_posix(), **kwargs)  # type: ignore[call-arg]
+    scheme = io.load_scheme(Path(file_name).as_posix(), **kwargs)
     scheme.source_path = Path(file_name).as_posix()
     return scheme
 
@@ -392,11 +384,7 @@ def save_scheme(
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
     io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
-    io.save_scheme(  # type: ignore[call-arg]
-        file_name=Path(file_name).as_posix(),
-        scheme=scheme,
-        **kwargs,
-    )
+    io.save_scheme(file_name=Path(file_name).as_posix(), scheme=scheme, **kwargs)
     if update_source_path is True:
         scheme.source_path = Path(file_name).as_posix()
 
@@ -423,7 +411,7 @@ def load_result(result_path: StrOrPath, format_name: str = None, **kwargs: Any) 
     """
     io = get_project_io(format_name or inferr_file_format(result_path))
 
-    result = io.load_result(Path(result_path).as_posix(), **kwargs)  # type: ignore[call-arg]
+    result = io.load_result(Path(result_path).as_posix(), **kwargs)
     result.source_path = Path(result_path).as_posix()
     return result
 
@@ -470,7 +458,7 @@ def save_result(
     io = get_project_io(
         format_name or inferr_file_format(result_path, needs_to_exist=False, allow_folder=True)
     )
-    paths = io.save_result(  # type: ignore[call-arg]
+    paths = io.save_result(
         result_path=Path(result_path).as_posix(),
         result=result,
         saving_options=saving_options,

--- a/glotaran/plugin_system/test/test_base_registry.py
+++ b/glotaran/plugin_system/test/test_base_registry.py
@@ -102,7 +102,7 @@ def test_PluginOverwriteWarning():
             "to use 'glotaran.builtin.io.sdt.sdt_file_reader.SdtDataIo' instead."
         )
 
-        assert record[0].message.args[0] == expected  # type: ignore
+        assert record[0].message.args[0] == expected
 
 
 @pytest.mark.parametrize(
@@ -133,9 +133,7 @@ def test_add_plugin_to_register_naming_error():
             r"you provided the name 'bad\.name'."
         ),
     ):
-        add_plugin_to_registry(
-            "bad.name", MockPlugin, mock_registry_model, "set_plugin"  # type:ignore
-        )
+        add_plugin_to_registry("bad.name", MockPlugin, mock_registry_model, "set_plugin")
 
 
 def test_add_plugin_to_register_existing_plugin():
@@ -143,12 +141,7 @@ def test_add_plugin_to_register_existing_plugin():
 
     plugin_registry = copy(mock_registry_data_io)
     with pytest.warns(PluginOverwriteWarning, match="SdtDataIo.+sdt.+YmlProjectIo") as record:
-        add_plugin_to_registry(
-            "sdt",
-            YmlProjectIo("sdt"),
-            plugin_registry,  # type:ignore
-            "set_plugin",
-        )
+        add_plugin_to_registry("sdt", YmlProjectIo("sdt"), plugin_registry, "set_plugin")
         assert len(record) == 1
     assert plugin_registry["glotaran.builtin.io.yml.yml.YmlProjectIo"].format == "sdt"
 

--- a/glotaran/plugin_system/test/test_data_io_registration.py
+++ b/glotaran/plugin_system/test/test_data_io_registration.py
@@ -40,7 +40,7 @@ class MockDataIO(DataIoInterface):
         self, file_name: StrOrPath, *, result_container: dict[str, Any], **kwargs: Any
     ) -> xr.Dataset | xr.DataArray:
         """This docstring is just for help testing of 'load_dataset'."""
-        result_container.update({"file_name": file_name, **kwargs})
+        result_container |= {"file_name": file_name, **kwargs}
         return xr.DataArray([1, 2])
 
     # TODO: Investigate why this raises an [override] type error and read_dataset doesn't

--- a/glotaran/plugin_system/test/test_data_io_registration.py
+++ b/glotaran/plugin_system/test/test_data_io_registration.py
@@ -40,7 +40,7 @@ class MockDataIO(DataIoInterface):
         self, file_name: StrOrPath, *, result_container: dict[str, Any], **kwargs: Any
     ) -> xr.Dataset | xr.DataArray:
         """This docstring is just for help testing of 'load_dataset'."""
-        result_container.update({"file_name": file_name, **kwargs})  # type:ignore
+        result_container.update({"file_name": file_name, **kwargs})
         return xr.DataArray([1, 2])
 
     # TODO: Investigate why this raises an [override] type error and read_dataset doesn't
@@ -214,7 +214,7 @@ def test_protect_from_overwrite_write_functions(tmp_path: Path):
     file_path.touch()
 
     with pytest.raises(FileExistsError, match="The file .+? already exists"):
-        save_dataset(xr.DataArray([1, 2]), str(file_path))  # type:ignore
+        save_dataset(xr.DataArray([1, 2]), str(file_path))
 
 
 @pytest.mark.usefixtures("mocked_registry")
@@ -242,7 +242,7 @@ def test_write_dataset_error(tmp_path: Path):
     file_path = tmp_path / "dummy.foo"
 
     with pytest.raises(ValueError, match="Cannot save data with format: 'foo'"):
-        save_dataset(xr.DataArray([1, 2]), str(file_path), "foo")  # type:ignore
+        save_dataset(xr.DataArray([1, 2]), str(file_path), "foo")
 
     file_path.touch()
 

--- a/glotaran/plugin_system/test/test_project_io_registration.py
+++ b/glotaran/plugin_system/test/test_project_io_registration.py
@@ -57,12 +57,7 @@ class MockProjectIo(ProjectIoInterface):
         mock_obj.func_args = {"file_name": file_name, **kwargs}
         return mock_obj  # type:ignore[return-value]
 
-    def save_model(  # type:ignore[override]
-        self,
-        model: Model,
-        file_name: StrOrPath,
-        **kwargs: Any,
-    ):
+    def save_model(self, model: Model, file_name: StrOrPath, **kwargs: Any):
         model.func_args.update(  # type:ignore[attr-defined]
             **{
                 "file_name": file_name,
@@ -76,12 +71,7 @@ class MockProjectIo(ProjectIoInterface):
         mock_obj.func_args = {"file_name": file_name, **kwargs}
         return mock_obj  # type:ignore[return-value]
 
-    def save_parameters(  # type:ignore[override]
-        self,
-        parameters: Parameters,
-        file_name: StrOrPath,
-        **kwargs: Any,
-    ):
+    def save_parameters(self, parameters: Parameters, file_name: StrOrPath, **kwargs: Any):
         parameters.func_args.update(  # type:ignore[attr-defined]
             **{
                 "file_name": file_name,
@@ -95,12 +85,7 @@ class MockProjectIo(ProjectIoInterface):
         mock_obj.func_args = {"file_name": file_name, **kwargs}
         return mock_obj  # type:ignore[return-value]
 
-    def save_scheme(  # type:ignore[override]
-        self,
-        scheme: Scheme,
-        file_name: StrOrPath,
-        **kwargs: Any,
-    ):
+    def save_scheme(self, scheme: Scheme, file_name: StrOrPath, **kwargs: Any):
         scheme.func_args.update(  # type:ignore[attr-defined]
             **{
                 "file_name": file_name,
@@ -114,7 +99,7 @@ class MockProjectIo(ProjectIoInterface):
         mock_obj.func_args = {"file_name": result_path, **kwargs}
         return mock_obj  # type:ignore[return-value]
 
-    def save_result(  # type:ignore[override]
+    def save_result(
         self,
         result: Result,
         result_path: StrOrPath,
@@ -275,11 +260,7 @@ def test_write_functions(
     mock_obj = MockFileLoadable()
 
     save_function(
-        mock_obj,  # type:ignore
-        file_path,
-        "mock",
-        update_source_path=update_source_path,
-        dummy_arg="baz",
+        mock_obj, file_path, "mock", update_source_path=update_source_path, dummy_arg="baz"
     )
 
     assert mock_obj.func_args == {

--- a/glotaran/project/generators/test/test_genenerate_decay_model.py
+++ b/glotaran/project/generators/test/test_genenerate_decay_model.py
@@ -22,24 +22,20 @@ def test_generate_parallel_model(megacomplex_type: str, irf: bool, spectral: boo
     )
     print(model)
 
-    assert (
-        f"megacomplex_{megacomplex_type}_decay" in model.megacomplex  # type:ignore[attr-defined]
-    )
-    megacomplex = model.megacomplex[  # type:ignore[attr-defined]
-        f"megacomplex_{megacomplex_type}_decay"
-    ]
+    assert f"megacomplex_{megacomplex_type}_decay" in model.megacomplex
+    megacomplex = model.megacomplex[f"megacomplex_{megacomplex_type}_decay"]
     assert isinstance(megacomplex, (DecayParallelMegacomplex, DecaySequentialMegacomplex))
     assert megacomplex.type == f"decay-{megacomplex_type}"
     assert megacomplex.compartments == expected_compartments
     assert megacomplex.rates == [f"rates.species_{i+1}" for i in range(nr_compartments)]
 
-    assert "dataset_1" in model.dataset  # type:ignore[attr-defined]
-    dataset = model.dataset["dataset_1"]  # type:ignore[attr-defined]
+    assert "dataset_1" in model.dataset
+    dataset = model.dataset["dataset_1"]
     assert dataset.megacomplex == [f"megacomplex_{megacomplex_type}_decay"]
 
     if spectral:
-        assert "megacomplex_spectral" in model.megacomplex  # type:ignore[attr-defined]
-        megacomplex = model.megacomplex["megacomplex_spectral"]  # type:ignore[attr-defined]
+        assert "megacomplex_spectral" in model.megacomplex
+        megacomplex = model.megacomplex["megacomplex_spectral"]
         assert isinstance(megacomplex, SpectralMegacomplex)
         assert expected_compartments == list(megacomplex.shape.keys())
         expected_shapes = [f"shape_species_{i+1}" for i in range(nr_compartments)]

--- a/glotaran/project/project.py
+++ b/glotaran/project/project.py
@@ -530,10 +530,7 @@ class Project:
             The created scheme.
         """
         loaded_model = self.load_model(model_name)
-        data = {
-            dataset: self.load_data(dataset)
-            for dataset in loaded_model.dataset  # type:ignore[attr-defined]
-        }
+        data = {dataset: self.load_data(dataset) for dataset in loaded_model.dataset}
         return Scheme(
             model=loaded_model,
             parameters=self.load_parameters(parameters_name),

--- a/glotaran/project/test/test_dataclass_helpers.py
+++ b/glotaran/project/test/test_dataclass_helpers.py
@@ -16,7 +16,7 @@ class DummyFileLoadable:
         self.data = {"foo": val}
 
     @classmethod
-    def loader(  # type:ignore[override]
+    def loader(
         cls: type[DummyFileLoadable],
         file_path: str,
     ) -> DummyFileLoadable:

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -102,7 +102,7 @@ def test_generate_model(project_folder: Path, project_file: Path):
     assert project.has_models
 
     model = project.load_model("test_model")
-    assert "megacomplex_parallel_decay" in model.megacomplex  # type:ignore[attr-defined]
+    assert "megacomplex_parallel_decay" in model.megacomplex
 
     comapartments = load_dict(model_file, is_file=True)["megacomplex"][
         "megacomplex_parallel_decay"
@@ -196,7 +196,7 @@ def test_create_scheme(project_file: Path):
     )
 
     assert "dataset_1" in scheme.data
-    assert "dataset_1" in scheme.model.dataset  # type:ignore[attr-defined]
+    assert "dataset_1" in scheme.model.dataset
     assert scheme.maximum_number_function_evaluations == 1
 
 
@@ -324,7 +324,7 @@ def test_generators_allow_overwrite(project_folder: Path, project_file: Path):
         "test_model", "decay_parallel", {"nr_compartments": 3}, allow_overwrite=True
     )
     new_model = project.load_model("test")
-    assert "megacomplex_parallel_decay" in new_model.megacomplex  # type:ignore[attr-defined]
+    assert "megacomplex_parallel_decay" in new_model.megacomplex
 
     comapartments = load_dict(model_file, is_file=True)["megacomplex"][
         "megacomplex_parallel_decay"

--- a/glotaran/utils/sanitize.py
+++ b/glotaran/utils/sanitize.py
@@ -95,7 +95,7 @@ def sanity_scientific_notation_conversion(d: dict[str, Any] | list[Any]):
     """
     if not isinstance(d, (dict, list)):
         return
-    for k, v in d.items() if isinstance(d, dict) else enumerate(d):  # type: ignore[attr-defined]
+    for k, v in d.items() if isinstance(d, dict) else enumerate(d):
         if isinstance(v, (list, dict)):
             sanity_scientific_notation_conversion(v)
         if isinstance(v, str):
@@ -116,7 +116,7 @@ def sanitize_dict_values(d: dict[str, Any] | list[Any]):
     """
     if not isinstance(d, (dict, list)):
         return
-    for k, v in d.items() if isinstance(d, dict) else enumerate(d):  # type: ignore[attr-defined]
+    for k, v in d.items() if isinstance(d, dict) else enumerate(d):
         if isinstance(v, list):
             leaf = all(isinstance(el, (str, tuple, float)) for el in v)
             if leaf:

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,8 @@ ignore_regex = test_.+|.*wrapper.*|inject_warn_into_call|.*dummy.*|__(.+?)__
 ignore_missing_imports = True
 scripts_are_modules = True
 show_error_codes = True
+warn_unused_configs = True
+warn_unused_ignores = True
 
 [mypy-glotaran.*]
 ignore_errors = True


### PR DESCRIPTION
Since #1135 improved the static type checking a lot we can remove many `# type: ignore` which aren't needed anymore.

### Change summary

- [🔧👌 Mypy Warn on unused type ignore and config](https://github.com/glotaran/pyglotaran/commit/54c89f50972b076f8fd29ea118f4d93f0e01a255)
- [🧹 Removed unused type:ignore](https://github.com/glotaran/pyglotaran/commit/8abfb232f0d8564e00ff5f075a69380a16c17c66)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)