### PR TITLE
🔧 Make mypy and doc string linters opt out instead of opt in

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,7 +114,6 @@ repos:
     rev: v0.982
     hooks:
       - id: mypy
-        files: "^glotaran/(plugin_system|utils|deprecation|testing|optimization|parameter|project|simulation|model|builtin/io/pandas)"
         exclude: "docs"
         additional_dependencies: [types-all, types-attrs]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,8 @@ repos:
         types_or: [python, pyi]
         additional_dependencies:
           [flake8-pyi, flake8-comprehensions, flake8-print>=5.0.0]
+        args:
+          - "--count"
 
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
@@ -105,6 +107,7 @@ repos:
         alias: flake8-docs
         args:
           - "--select=D,DAR"
+          - "--count"
         name: "flake8 lint docstrings"
         exclude: "docs|setup.py|tests?/|glotaran/builtin/megacomplexes|glotaran/cli|benchmark|glotaran/builtin/io/ascii"
         additional_dependencies: [flake8-docstrings, darglint==1.8.0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,8 +106,7 @@ repos:
         args:
           - "--select=D,DAR"
         name: "flake8 lint docstrings"
-        files: "^glotaran/(plugin_system|utils|deprecation|testing|optimization|parameter|project|simulation|model|builtin/io/pandas)"
-        exclude: "docs|tests?/"
+        exclude: "docs|setup.py|tests?/|glotaran/builtin/megacomplexes|glotaran/cli|benchmark|glotaran/builtin/io/ascii"
         additional_dependencies: [flake8-docstrings, darglint==1.8.0]
 
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/benchmark/benchmarks/unit/analysis/bench_optimize.py
+++ b/benchmark/benchmarks/unit/analysis/bench_optimize.py
@@ -12,7 +12,12 @@ except ImportError:
     from glotaran.simulation import simulate
 
     try:
-        from glotaran.optimization.test.models import MultichannelMulticomponentDecay
+        # isort: off
+        from glotaran.optimization.test.models import (  # type: ignore[attr-defined]
+            MultichannelMulticomponentDecay,
+        )
+
+        # isort: on
     except ImportError:
         # 0.7.0
         from glotaran.optimization.test.suites import MultichannelMulticomponentDecay

--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,7 @@
 - 🧹 Upgrade syntax to py310 using pyupgrade (#1162)
 - 🧹 Remove unused 'type: ignore' (#1168)
 - 🚧 Raise minimum dependency version to releases that support py310 (#1170)
+- 🔧 Make mypy and doc string linters opt out instead of opt in (#1173)
 
 (changes-0_6_0)=
 

--- a/glotaran/__init__.py
+++ b/glotaran/__init__.py
@@ -1,4 +1,4 @@
-"""Glotaran package __init__.py"""
+"""Glotaran package root."""
 from glotaran.deprecation.deprecation_utils import deprecate_submodule
 from glotaran.plugin_system.base_registry import load_plugins
 

--- a/glotaran/builtin/io/__init__.py
+++ b/glotaran/builtin/io/__init__.py
@@ -1,0 +1,1 @@
+"""Package containing the builtin IO plugins."""

--- a/glotaran/builtin/io/netCDF/__init__.py
+++ b/glotaran/builtin/io/netCDF/__init__.py
@@ -1,0 +1,1 @@
+"""Package containing the NetCDF4 Data IO plugin."""

--- a/glotaran/builtin/io/netCDF/netCDF.py
+++ b/glotaran/builtin/io/netCDF/netCDF.py
@@ -45,7 +45,7 @@ class NetCDFDataIo(DataIoInterface):
         file_name: str
             Path of the file to write ``dataset`` to.
         data_filters: list[str] | None
-            List of data variable names that should be written to file. Defaults to None
+            List of data variable names that should be written to file. Defaults to None.
         """
         data_to_save = dataset if data_filters is None else dataset[data_filters]
         data_to_save.to_netcdf(file_name, mode="w")

--- a/glotaran/builtin/io/netCDF/netCDF.py
+++ b/glotaran/builtin/io/netCDF/netCDF.py
@@ -1,3 +1,4 @@
+"""Module containing the NetCDF4 Data IO plugin."""
 from __future__ import annotations
 
 # Needed to prevent a netCDF4 RuntimeWarning at import time
@@ -11,7 +12,20 @@ from glotaran.io import register_data_io
 
 @register_data_io("nc")
 class NetCDFDataIo(DataIoInterface):
+    """Plugin for NetCDF4 data io."""
+
     def load_dataset(self, file_name: str) -> xr.Dataset | xr.DataArray:
+        """Load a ``*.nc`` file into a :xarraydoc:`Dataset` or :xarraydoc:`DataArray`.
+
+        Parameters
+        ----------
+        file_name: str
+            Path to the ``*.nc`` file that should be loaded.
+
+        Returns
+        -------
+        xr.Dataset | xr.DataArray
+        """
         with xr.open_dataset(file_name) as ds:
             return ds.load()
 
@@ -22,6 +36,16 @@ class NetCDFDataIo(DataIoInterface):
         *,
         data_filters: list[str] | None = None,
     ):
+        """Write a :xarraydoc:`Dataset` to the ``*.nc`` at path ``file_name``.
 
+        Parameters
+        ----------
+        dataset: xr.Dataset
+            :xarraydoc:`Dataset` that should be written to file.
+        file_name: str
+            Path of the file to write ``dataset`` to.
+        data_filters: list[str] | None
+            List of data variable names that should be written to file. Defaults to None
+        """
         data_to_save = dataset if data_filters is None else dataset[data_filters]
         data_to_save.to_netcdf(file_name, mode="w")

--- a/glotaran/builtin/io/sdt/__init__.py
+++ b/glotaran/builtin/io/sdt/__init__.py
@@ -1,0 +1,1 @@
+"""Package containing the SDT Data IO plugin."""

--- a/glotaran/builtin/io/sdt/sdt_file_reader.py
+++ b/glotaran/builtin/io/sdt/sdt_file_reader.py
@@ -39,15 +39,15 @@ class SdtDataIo(DataIoInterface):
             Thus for the spectral axis data need to be given by the user.
 
         flim: bool
-            Set true if reading a result from a FLIM measurement. Defaults to False
+            Set true if reading a result from a FLIM measurement. Defaults to False.
 
         dataset_index: int
             If the `*.sdt` file contains multiple datasets the index will used
-            to select the wanted one. Defaults to 0
+            to select the wanted one. Defaults to 0.
 
         swap_axis: bool
             Flag to switch a wavelength explicit `input_df` to time explicit `input_df`,
-            before generating the SpectralTemporalDataset. Defaults to False
+            before generating the SpectralTemporalDataset. Defaults to False.
 
         orig_time_axis_index: int
             Index of the axis which corresponds to the time axis.

--- a/glotaran/builtin/io/sdt/sdt_file_reader.py
+++ b/glotaran/builtin/io/sdt/sdt_file_reader.py
@@ -1,6 +1,4 @@
-"""
-Glotarans module to read files
-"""
+"""Module containing the SDT Data IO plugin."""
 from __future__ import annotations
 
 import warnings
@@ -16,6 +14,8 @@ from glotaran.io.prepare_dataset import prepare_time_trace_dataset
 
 @register_data_io("sdt")
 class SdtDataIo(DataIoInterface):
+    """Plugin for SDT data io."""
+
     def load_dataset(
         self,
         file_name: str,
@@ -26,39 +26,41 @@ class SdtDataIo(DataIoInterface):
         swap_axis: bool = False,
         orig_time_axis_index: int = 2,
     ) -> xr.Dataset:
-        """
-        Reads a `*.sdt` file and returns a pd.DataFrame (`return_dataframe==True`), a
-        SpectralTemporalDataset (`type_of_data=='st'`) or a FLIMDataset (`type_of_data=='flim'`).
+        """Read a `*.sdt` file and returns a :xarraydoc:`Dataset` containing its data.
 
         Parameters
         ----------
         file_name: str
             Path to the sdt file which should be read.
 
-        index: list, np.ndarray
+        index: np.ndarray | None
             This is only needed if `type_of_data=="st"`, since `*.sdt` files,
             which only contain spectral temporal data, lack the spectral information.
             Thus for the spectral axis data need to be given by the user.
 
-        flim:
-            Set true if reading a result from a FLIM measurement.
+        flim: bool
+            Set true if reading a result from a FLIM measurement. Defaults to False
 
-        dataset_index: int: default 0
+        dataset_index: int
             If the `*.sdt` file contains multiple datasets the index will used
-            to select the wanted one
+            to select the wanted one. Defaults to 0
 
-        swap_axis: bool, default False
+        swap_axis: bool
             Flag to switch a wavelength explicit `input_df` to time explicit `input_df`,
-            before generating the SpectralTemporalDataset.
+            before generating the SpectralTemporalDataset. Defaults to False
 
         orig_time_axis_index: int
             Index of the axis which corresponds to the time axis.
             I.e. for data of shape (64, 64, 256), which are a 64x64 pixel map
             with 256 time steps, orig_time_axis_index=2.
 
+        Returns
+        -------
+        xr.Dataset
+
         Raises
-        ______
-        IndexError:
+        ------
+        IndexError
             If the length of the index array is incompatible with the data.
         """
         sdt_parser = SdtFile(file_name)
@@ -80,7 +82,7 @@ class SdtDataIo(DataIoInterface):
         times: np.ndarray = sdt_parser.times[dataset_index]
         raw_data: np.ndarray = sdt_parser.data[dataset_index]
 
-        if index and len(index) is not raw_data.shape[0]:
+        if index and len(index) != raw_data.shape[0]:
             raise IndexError(
                 f"The Dataset contains {raw_data.shape[0]} measurements, but the "
                 f"indices supplied are {len(index)}."

--- a/glotaran/builtin/io/yml/__init__.py
+++ b/glotaran/builtin/io/yml/__init__.py
@@ -1,0 +1,1 @@
+"""Package containing the YAML Data and Project IO plugins."""

--- a/glotaran/builtin/io/yml/utils.py
+++ b/glotaran/builtin/io/yml/utils.py
@@ -1,4 +1,4 @@
-"""Utility functionality module for ``glotaran.builtin.io.yml.yml``."""
+"""Utility module for ``glotaran.builtin.io.yml.yml``."""
 from __future__ import annotations
 
 from pathlib import Path

--- a/glotaran/builtin/io/yml/utils.py
+++ b/glotaran/builtin/io/yml/utils.py
@@ -30,6 +30,7 @@ def write_dict(
         stream = StringIO()
         yaml.dump(data, stream)
         return stream.getvalue()
+    return None
 
 
 def load_dict(source: str | Path, is_file: bool) -> dict[str, Any]:

--- a/glotaran/builtin/io/yml/utils.py
+++ b/glotaran/builtin/io/yml/utils.py
@@ -1,4 +1,4 @@
-"""Utility functionality module for ``glotaran.builtin.io.yml.yml``"""
+"""Utility functionality module for ``glotaran.builtin.io.yml.yml``."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -19,12 +19,30 @@ if TYPE_CHECKING:
 def write_dict(
     data: Mapping[str, Any] | Sequence[Any], file_name: str | Path | None = None, offset: int = 0
 ) -> str | None:
+    """Write a mapping (e.g. ``dict``) or sequence (e.g. ``list``) as ``yaml`` to file or str.
+
+    Parameters
+    ----------
+    data: Mapping[str, Any] | Sequence[Any]
+        Data that should be converted to ``yaml``.
+    file_name: str | Path | None
+        Path of the file to write the ``yaml`` code to.
+        Defaults to None which makes this function return a string.
+    offset: int
+        Block indentation level. Defaults to 0
+        See https://yaml.readthedocs.io/en/latest/detail.html#indentation-of-block-sequences
+
+    Returns
+    -------
+    str | None
+        String if ``file_name`` is ``None`` or ``None`` if ``file_name`` is a valid path.
+    """
     yaml = YAML()
     yaml.representer.add_representer(type(None), _yaml_none_representer)
     yaml.indent(mapping=2, sequence=2, offset=offset)
 
     if file_name is not None:
-        with open(file_name, "w") as f:
+        with open(file_name, "w", encoding="utf8") as f:
             yaml.dump(data, f)
     else:
         stream = StringIO()
@@ -34,6 +52,19 @@ def write_dict(
 
 
 def load_dict(source: str | Path, is_file: bool) -> dict[str, Any]:
+    """Load ``yaml`` code from a file or string and returns the dict interpretation.
+
+    Parameters
+    ----------
+    source: str | Path
+        Path to a file or string containing the ``yaml`` code.
+    is_file: bool
+        Whether or not ``source`` is a file.
+
+    Returns
+    -------
+    dict[str, Any]
+    """
     yaml = YAML()
     yaml.representer.add_representer(type(None), _yaml_none_representer)
     if is_file:

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -1,3 +1,4 @@
+"""Module containing the YAML Data and Project IO plugins."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -29,20 +30,28 @@ if TYPE_CHECKING:
 
 @register_project_io(["yml", "yaml", "yml_str"])
 class YmlProjectIo(ProjectIoInterface):
+    """Plugin for YAML project io."""
+
     def load_model(self, file_name: str) -> Model:
-        """parse_yaml_file reads the given file and parses its content as YML.
+        """Load a :class:`Model` from a model specification in a yaml file.
 
         Parameters
         ----------
-        filename : str
-            filename is the of the file to parse.
+        file_name: str
+            Path to the model file to read.
+
+        Raises
+        ------
+        ValueError
+            If ``megacomplex`` was not provided in the model specification.
+        ValueError
+            If ``default_megacomplex`` was not provided and any megacomplex is missing the type
+            attribute.
 
         Returns
         -------
         Model
-            The content of the file as dictionary.
         """
-
         spec = self._load_yml(file_name)
 
         model_spec_deprecations(spec)
@@ -71,7 +80,8 @@ class YmlProjectIo(ProjectIoInterface):
         return Model.create_class_from_megacomplexes(megacomplex_types)(**spec)
 
     def save_model(self, model: Model, file_name: str):
-        """Save a Model instance to a spec file.
+        """Save a :class:`Model` instance to a specification file.
+
         Parameters
         ----------
         model: Model
@@ -93,17 +103,17 @@ class YmlProjectIo(ProjectIoInterface):
         write_dict(model_dict, file_name=file_name)
 
     def load_parameters(self, file_name: str) -> Parameters:
-        """Create parameters instance from the specs defined in a file.
+        """Load :class:`Parameters` instance from the specification defined in ``file_name``.
+
         Parameters
         ----------
-        file_name : str
-            File containing the parameter specs.
+        file_name: str
+            File containing the parameter specification.
+
         Returns
         -------
         Parameters
-            Parameters instance created from the file.
         """
-
         spec = self._load_yml(file_name)
 
         if isinstance(spec, list):
@@ -112,11 +122,31 @@ class YmlProjectIo(ProjectIoInterface):
             return Parameters.from_dict(spec)
 
     def load_scheme(self, file_name: str) -> Scheme:
+        """Load :class:`Scheme` instance from the specification defined in ``file_name``.
+
+        Parameters
+        ----------
+        file_name: str
+            File containing the scheme specification.
+
+        Returns
+        -------
+        Scheme
+        """
         spec = self._load_yml(file_name)
         scheme_spec_deprecations(spec)
         return fromdict(Scheme, spec, folder=Path(file_name).parent)
 
     def save_scheme(self, scheme: Scheme, file_name: str):
+        """Write a :class:`Scheme` instance to a specification file ``file_name``.
+
+        Parameters
+        ----------
+        scheme: Scheme
+            :class:`Scheme` instance to save to file.
+        file_name: str
+            Path to the file to write the scheme specification to.
+        """
         scheme_dict = asdict(scheme, folder=Path(file_name).parent)
         write_dict(scheme_dict, file_name=file_name)
 
@@ -125,7 +155,7 @@ class YmlProjectIo(ProjectIoInterface):
 
         Parameters
         ----------
-        result_path : str | PathLike[str]
+        result_path : str
             Path containing the result data.
 
         Returns
@@ -142,7 +172,7 @@ class YmlProjectIo(ProjectIoInterface):
         result_path: str,
         saving_options: SavingOptions = SAVING_OPTIONS_DEFAULT,
     ) -> list[str]:
-        """Write a :class:`Result` instance to a spec file and data files.
+        """Write a :class:`Result` instance to a specification file and data files.
 
         Returns a list with paths of all saved items.
         The following files are saved if not configured otherwise:
@@ -158,11 +188,11 @@ class YmlProjectIo(ProjectIoInterface):
 
         Parameters
         ----------
-        result : Result
+        result: Result
             :class:`Result` instance to write.
-        result_path : str | PathLike[str]
+        result_path: str
             Path to write the result data to.
-        saving_options : SavingOptions
+        saving_options: SavingOptions
             Options for saving the the result.
 
         Returns

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -113,7 +113,7 @@ class YmlProjectIo(ProjectIoInterface):
         Returns
         -------
         Parameters
-        """
+        """  # noqa:  D414
         spec = self._load_yml(file_name)
 
         if isinstance(spec, list):

--- a/glotaran/builtin/megacomplexes/coherent_artifact/test/test_coherent_artifact.py
+++ b/glotaran/builtin/megacomplexes/coherent_artifact/test/test_coherent_artifact.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -18,7 +20,7 @@ from glotaran.simulation import simulate
     ("none", "dispersed", "shifted"),
 )
 def test_coherent_artifact(spectral_dependence: str):
-    model_dict = {
+    model_dict: dict[str, dict[str, Any]] = {
         "initial_concentration": {
             "j1": {"compartments": ["s1"], "parameters": ["irf_center"]},
         },
@@ -80,7 +82,7 @@ def test_coherent_artifact(spectral_dependence: str):
         **model_dict
     )
 
-    parameters = Parameters.from_list(parameter_list)
+    parameters = Parameters.from_list(parameter_list)  # type: ignore[arg-type]
 
     time = np.arange(0, 50, 1.5)
     spectral = np.asarray([200, 300, 400])

--- a/glotaran/builtin/megacomplexes/decay/test/test_decay_megacomplex.py
+++ b/glotaran/builtin/megacomplexes/decay/test/test_decay_megacomplex.py
@@ -163,7 +163,7 @@ class ThreeComponentParallel:
                 ["1", 501e-3],
                 ["2", 202e-4],
                 ["3", 105e-5],
-                {"non-negative": True},
+                {"non-negative": True},  # type: ignore[list-item]
             ],
             "irf": [["center", 1.3], ["width", 7.8]],
         }
@@ -223,7 +223,7 @@ class ThreeComponentSequential:
                 ["1", 501e-3],
                 ["2", 202e-4],
                 ["3", 105e-5],
-                {"non-negative": True},
+                {"non-negative": True},  # type: ignore[list-item]
             ],
             "irf": [["center", 1.3], ["width", 7.8]],
         }

--- a/glotaran/io/__init__.py
+++ b/glotaran/io/__init__.py
@@ -1,9 +1,9 @@
-"""Functions for data IO
+"""Functions for data IO.
 
 Note:
 -----
 Since Io functionality is purely plugin based this package mostly
-reexports functions from the pluginsystem from a common place.
+reexports functions from the ``glotaran.plugin_system`` from a common place.
 """
 
 from glotaran.io.interface import SAVING_OPTIONS_DEFAULT

--- a/glotaran/io/interface.py
+++ b/glotaran/io/interface.py
@@ -53,7 +53,7 @@ class DataIoInterface:
 
         Parameters
         ----------
-        format_name : str
+        format_name: str
             Name of the supported format an instance uses.
         """
         self.format = format_name
@@ -65,7 +65,7 @@ class DataIoInterface:
 
         Parameters
         ----------
-        file_name : str
+        file_name: str
             File containing the data.
 
         Returns
@@ -90,9 +90,9 @@ class DataIoInterface:
 
         Parameters
         ----------
-        dataset : xr.Dataset
+        dataset: xr.Dataset
             Dataset to be saved to file.
-        file_name : str
+        file_name: str
             File to write the data to.
 
 
@@ -110,7 +110,7 @@ class ProjectIoInterface:
 
         Parameters
         ----------
-        format_name : str
+        format_name: str
             Name of the supported format an instance uses.
         """
         self.format = format_name
@@ -122,7 +122,7 @@ class ProjectIoInterface:
 
         Parameters
         ----------
-        file_name : str
+        file_name: str
             File containing the model specs.
 
         Returns
@@ -145,7 +145,7 @@ class ProjectIoInterface:
         ----------
         model: Model
             Model instance to save to specs file.
-        file_name : str
+        file_name: str
             File to write the model specs to.
 
 
@@ -161,7 +161,7 @@ class ProjectIoInterface:
 
         Parameters
         ----------
-        file_name : str
+        file_name: str
             File containing the parameter specs.
 
         Returns
@@ -182,9 +182,9 @@ class ProjectIoInterface:
 
         Parameters
         ----------
-        parameters : Parameters
+        parameters: Parameters
             Parameters instance to save to specs file.
-        file_name : str
+        file_name: str
             File to write the parameter specs to.
 
 
@@ -200,7 +200,7 @@ class ProjectIoInterface:
 
         Parameters
         ----------
-        file_name : str
+        file_name: str
             File containing the parameter specs.
 
         Returns
@@ -220,9 +220,9 @@ class ProjectIoInterface:
 
         Parameters
         ----------
-        scheme : Scheme
+        scheme: Scheme
             Scheme instance to save to specs file.
-        file_name : str
+        file_name: str
             File to write the scheme specs to.
 
 
@@ -238,7 +238,7 @@ class ProjectIoInterface:
 
         Parameters
         ----------
-        result_path : str
+        result_path: str
             Path containing the result data.
 
         Returns
@@ -265,11 +265,11 @@ class ProjectIoInterface:
 
         Parameters
         ----------
-        result : Result
+        result: Result
             Result instance to save to specs file.
-        result_path : str
+        result_path: str
             Path to write the result data to.
-        saving_options : SavingOptions
+        saving_options: SavingOptions
             Options for the saved result.
 
 

--- a/glotaran/io/prepare_dataset.py
+++ b/glotaran/io/prepare_dataset.py
@@ -1,3 +1,4 @@
+"""Module containing dataset preparation functionality."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -11,21 +12,30 @@ if TYPE_CHECKING:
 
 def prepare_time_trace_dataset(
     dataset: xr.DataArray | xr.Dataset,
-    weight: np.ndarray = None,
-    irf: np.ndarray | xr.DataArray = None,
+    weight: np.ndarray | None = None,
+    irf: np.ndarray | xr.DataArray | None = None,
 ) -> xr.Dataset:
-    """Prepares a time trace for global analysis.
+    """Prepare a time trace ``dataset`` for global analysis.
 
     Parameters
     ----------
-    dataset :
-        The dataset.
-    weight :
+    dataset: xr.DataArray | xr.Dataset
+        Dataset to add data to.
+    weight: np.ndarray | None
         A weight for the dataset.
-    irf :
+    irf: np.ndarray | xr.DataArray | None
         An IRF for the dataset.
-    """
 
+    Returns
+    -------
+    xr.Dataset
+        Original dataset with added SVD data and weight and/or irf data variables if provided.
+
+    Raises
+    ------
+    ValueError
+        If an IRF with more than one dimensions was provided that isn't a :xarraydoc:`DataArray`.
+    """
     if isinstance(dataset, xr.DataArray):
         dataset = dataset.to_dataset(name="data")
 
@@ -38,7 +48,7 @@ def prepare_time_trace_dataset(
     if irf is not None:
         if isinstance(irf, np.ndarray):
             if len(irf.shape) != 1:
-                raise Exception("IRF with more than one dimension must be `xarray.DataArray`.")
+                raise ValueError("IRF with more than one dimension must be `xarray.DataArray`.")
             dataset["irf"] = (("time",), irf)
         else:
             dataset["irf"] = irf
@@ -51,23 +61,23 @@ def add_svd_to_dataset(
     name: str = "data",
     lsv_dim: Hashable = "time",
     rsv_dim: Hashable = "spectral",
-    data_array: xr.DataArray = None,
-):
+    data_array: xr.DataArray | None = None,
+) -> None:
     """Add the SVD of a dataset inplace as Data variables to the dataset.
 
     The SVD is only computed if it doesn't already exist on the dataset.
 
     Parameters
     ----------
-    dataset : xr.Dataset
+    dataset: xr.Dataset
         Dataset the SVD values should be added to.
-    name : str
+    name: str
         Key to access the datarray inside of the dataset, by default "data"
-    lsv_dim : Hashable
+    lsv_dim: Hashable
         Name of the dimension for the left singular value, by default "time"
-    rsv_dim : Hashable
+    rsv_dim: Hashable
         Name of the dimension for the right singular value, by default "spectral"
-    data_array : xr.DataArray
+    data_array: xr.DataArray | None
         Dataarray to calculate the SVD for, when provided the data extraction
         from the dataset will be skipped, by default None
     """

--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from collections.abc import Generator
+from collections.abc import Iterable
 from collections.abc import Mapping
 from typing import Any
 from typing import ClassVar
@@ -256,7 +257,7 @@ class Model:
 
     @classmethod
     def create_class_from_megacomplexes(
-        cls, megacomplexes: list[type[Megacomplex]]
+        cls, megacomplexes: Iterable[type[Megacomplex]]
     ) -> type[Model]:
         """Create model class for megacomplexes.
 

--- a/glotaran/testing/simulated_data/sequential_spectral_decay.py
+++ b/glotaran/testing/simulated_data/sequential_spectral_decay.py
@@ -10,13 +10,13 @@ from glotaran.testing.simulated_data.shared_decay import SIMULATION_PARAMETERS
 
 SIMULATION_MODEL_YML = generate_model_yml(
     generator_name="spectral_decay_sequential",
-    generator_arguments={"nr_compartments": 3, "irf": True},  # type:ignore[arg-type]
+    generator_arguments={"nr_compartments": 3, "irf": True},
 )
 SIMULATION_MODEL = load_model(SIMULATION_MODEL_YML, format_name="yml_str")
 
 MODEL_YML = generate_model_yml(
     generator_name="decay_sequential",
-    generator_arguments={"nr_compartments": 3, "irf": True},  # type:ignore[arg-type]
+    generator_arguments={"nr_compartments": 3, "irf": True},
 )
 MODEL = load_model(MODEL_YML, format_name="yml_str")
 

--- a/glotaran/typing/protocols.py
+++ b/glotaran/typing/protocols.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
 
 class FileLoadableProtocol(Protocol):
+    """Protocol class that a file loadable class need adherer to."""
+
     loader: Callable[
         [StrOrPath | Sequence[StrOrPath] | Mapping[str, StrOrPath]],
         FileLoadableProtocol,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,32 +26,23 @@ force_single_line = true
 remove_redundant_aliases = true
 
 [tool.interrogate]
-exclude = [
-  "setup.py",
-  "docs",
-  "*test/*",
-  "benchmark/*"
-]
+exclude = ["setup.py", "docs", "*test/*", "benchmark/*"]
 ignore-init-module = true
 fail-under = 63
 
 [tool.nbqa.addopts]
-flake8 = [
-    "--extend-ignore=E402,F404"
-]
+flake8 = ["--extend-ignore=E402,F404"]
 
 
 [tool.coverage.run]
 branch = true
-include = [
-  'glotaran/*',
-]
+include = ['glotaran/*']
 omit = [
   'setup.py',
   '*/tests/*',
   '*/test/*',
-# comment the above line if you want to see if all tests did run
-  ]
+  # comment the above line if you want to see if all tests did run
+]
 
 [tool.coverage.report]
 # Regexes for lines to exclude from consideration
@@ -70,7 +61,7 @@ exclude_lines = [
   # Don't complain if non-runnable code isn't run:
   'if 0:',
   'if __name__ == .__main__.:',
-  'if TYPE_CHECKING:'
+  'if TYPE_CHECKING:',
 ]
 
 [tool.check-manifest]
@@ -94,3 +85,28 @@ ignore = [
   # This is just a file on the CI if not check out with git submodules option
   "validation",
 ]
+
+
+[tool.mypy]
+ignore_missing_imports = true
+scripts_are_modules = true
+show_error_codes = true
+warn_unused_configs = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = "glotaran.builtin.megacomplexes.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+# Should be rewritten anyway see #1171
+module = "glotaran.builtin.io.ascii.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "glotaran.cli.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "benchmark.*"
+ignore_errors = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,38 +96,14 @@ show_error_codes = True
 warn_unused_configs = True
 warn_unused_ignores = True
 
-[mypy-glotaran.*]
+[mypy-glotaran.builtin.megacomplexes.*]
 ignore_errors = True
 
-[mypy-glotaran.plugin_system.*]
-ignore_errors = False
+[mypy-glotaran.builtin.io.ascii.*]
+ignore_errors = True
 
-[mypy-glotaran.utils.*]
-ignore_errors = False
+[mypy-glotaran.cli.*]
+ignore_errors = True
 
-[mypy-glotaran.deprecation.*]
-ignore_errors = False
-
-[mypy-glotaran.optimization.*]
-ignore_errors = False
-
-[mypy-glotaran.optimization.test.*]
-ignore_errors = False
-
-[mypy-glotaran.project.generators.test.*]
-ignore_errors = False
-
-[mypy-glotaran.parameter.*]
-ignore_errors = False
-
-[mypy-glotaran.project.*]
-ignore_errors = False
-
-[mypy-glotaran.simulation.*]
-ignore_errors = False
-
-[mypy-glotaran.model.*]
-ignore_errors = False
-
-[mypy-glotaran.builtin.io.pandas.*]
-ignore_errors = False
+[mypy-benchmark.*]
+ignore_errors = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,22 +88,3 @@ report_level = WARNING
 [darglint]
 docstring_style = numpy
 ignore_regex = test_.+|.*wrapper.*|inject_warn_into_call|.*dummy.*|__(.+?)__
-
-[mypy]
-ignore_missing_imports = True
-scripts_are_modules = True
-show_error_codes = True
-warn_unused_configs = True
-warn_unused_ignores = True
-
-[mypy-glotaran.builtin.megacomplexes.*]
-ignore_errors = True
-
-[mypy-glotaran.builtin.io.ascii.*]
-ignore_errors = True
-
-[mypy-glotaran.cli.*]
-ignore_errors = True
-
-[mypy-benchmark.*]
-ignore_errors = True

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,9 @@ envlist = py{38,39,310}, pre-commit, docs, docs-notebooks, docs-links
 
 
 [flake8]
-extend-ignore = E231, E203
+count = True
+; D414 is needed due to a bug in pydocstyle the sees the returntype `Parameters` as section
+extend-ignore = E231, E203, D414
 max-line-length = 99
 per-file-ignores =
     # imported but unused

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,7 @@ envlist = py{38,39,310}, pre-commit, docs, docs-notebooks, docs-links
 
 
 [flake8]
-; D414 is needed due to a bug in pydocstyle the sees the returntype `Parameters` as section
-extend-ignore = E231, E203, D414
+extend-ignore = E231, E203
 max-line-length = 99
 per-file-ignores =
     # imported but unused
@@ -30,6 +29,8 @@ per-file-ignores =
     docs/source/conf.py: E501
     # Typedef files are formatted differently
     *.pyi: E301, E302, F401
+    # D414 is needed due to a bug in pydocstyle that sees the returntype `Parameters` as nested sections
+    glotaran/io/interface.py: D414
     # Allow printing in test file
     test_*.py: T201
     # Temporarily deactivated since the code will be removed in PR 1060

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ envlist = py{38,39,310}, pre-commit, docs, docs-notebooks, docs-links
 
 
 [flake8]
-count = True
 ; D414 is needed due to a bug in pydocstyle the sees the returntype `Parameters` as section
 extend-ignore = E231, E203, D414
 max-line-length = 99

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ per-file-ignores =
     docs/source/conf.py: E501
     # Typedef files are formatted differently
     *.pyi: E301, E302, F401
-    # D414 is needed due to a bug in pydocstyle that sees the returntype `Parameters` as nested sections
+    # D414 is needed due to a bug in pydocstyle that sees the return type `Parameters` as nested sections
     glotaran/io/interface.py: D414
     # Allow printing in test file
     test_*.py: T201


### PR DESCRIPTION
Changed the `mypy` and `flake8-docs` pre-commit hooks to be opt out instead of opt in and fixed some docstring and typing issues along the way.

### Change summary

- [🔧⌨️ Made mypy optout instead of opt in and fixed some typing issues](https://github.com/glotaran/pyglotaran/commit/aeb4de0db06226c365c5f73adfdac1bcd94a8b61)
- [🔧👌 Moved mypy config from setup.cfg to pyproject.toml](https://github.com/glotaran/pyglotaran/commit/1935679ceeac4af2d270bc4974848726180511ae)
- [🔧👌 Made docstring linter opt out instead of opt in](https://github.com/glotaran/pyglotaran/commit/f1560a35f6cb0e18734ba982136c1a73d0148bd3)
- [🩹 Fix yesqa by moving count from the config to the hook args](https://github.com/glotaran/pyglotaran/commit/ec502da984b12668d4bbff17f232b1cbfd27462b)


<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #1001
