### PR TITLE
🩹🚇 Fix PR Benchmark comments

### DIFF
--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -119,8 +119,6 @@ jobs:
           </details>
           """
 
-          comment = comment.replace("%", "%25").replace("\n", "%0A").replace("\r", "%0D")
-
           Path("benchmark/.asv/html/pr-diff-comment.txt").write_text(comment)
           Path("benchmark/.asv/html/origin_pr_nr.txt").write_text(pr_nr)
 

--- a/.github/workflows/pr_benchmark_reaction.yml
+++ b/.github/workflows/pr_benchmark_reaction.yml
@@ -54,13 +54,7 @@ jobs:
 
           with open(os.getenv("GITHUB_OUTPUT"), "a", encoding="utf8") as f:
               comment_file_path = Path("pr-diff-comment.txt")
-              f.writelines(
-                  [
-                      "comment<<EOF",
-                      *comment_file_path.read_text().splitlines(),
-                      "EOF",
-                  ]
-              )
+              f.write(f"comment<<EOF\n{comment_file_path.read_text().lstrip().rstrip()}\nEOF\n")
               comment_file_path.unlink()
 
               origin_pr_nr_file_path = Path("origin_pr_nr.txt")

--- a/changelog.md
+++ b/changelog.md
@@ -47,7 +47,7 @@
 - 🔧 Set sourcery-ai target python version to 3.8 (#1095)
 - 🚇🩹🔧 Fix manifest check (#1099)
 - ♻️ Refactor: optimization (#1060)
-- ♻️🚇 Use GITHUB_OUTPUT instead of set-output in github actions (#1166)
+- ♻️🚇 Use GITHUB_OUTPUT instead of set-output in github actions (#1166, #1177)
 - 🚧 Add pinned version of odfpy to requirements_dev.txt (#1164)
 - ♻️ Use validation action and validation as a git submodule (#1165)
 - 🧹 Upgrade syntax to py310 using pyupgrade (#1162)


### PR DESCRIPTION
This PR fixes the broken PR benchmark comments.
Since [`pr_benchmark_reaction.yml` workflow runs on ` workflow_run`](https://github.com/glotaran/pyglotaran/blob/8116af0e60c63349cafb309aeac631f64cf7fa8a/.github/workflows/pr_benchmark_reaction.yml#L6) it never uses the workflow from the PR itself but from the default branch this is why this error wasn't discovered in #1166 which introduced the chance to environment files.
For this PR I tested it on my for by making the virtually identical (at least what concerns the benchmark comment) branch [fix-PR-benchmark-comment](https://github.com/s-weigand/pyglotaran/commit/35b1f2dfb62c85644f5554a8e6ed8f0ce995c93e) the default branch and testing with a [dummy PR](https://github.com/s-weigand/pyglotaran/pull/89).
The commit [6272aab](https://github.com/glotaran/pyglotaran/pull/1177/commits/6272aabc45c3ebea842eb45d7f7c806070a33b8d) is the squashed version of [35b1f2](https://github.com/glotaran/pyglotaran/commit/35b1f2dfb62c85644f5554a8e6ed8f0ce995c93e) and [6475cd](https://github.com/glotaran/pyglotaran/commit/6475cddc198975669d8f7c75f95564adc853d647)
Due to the nature of ` workflow_run` workflows, this will only show effect after merging.

### Change summary

- [🩹🚇 Fix PR Benchmark comments](https://github.com/glotaran/pyglotaran/commit/6272aabc45c3ebea842eb45d7f7c806070a33b8d)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 🚧 Added changes to changelog (mandatory for all PR's)