### PR TITLE
🩹Fix for crash when running optimization with more than 30 datasets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,8 @@
 
 - 🩹 Fix result data overwritten when using multiple dataset_groups (#1147)
 - 🩹 Fix for normalization issue described in #1157 (multi-gaussian irfs and multiple time ranges (streak))
+- 🩹 Fix for crash described in #1183 when doing an optimization using more than 30 datasets (#1184)
+
 
 ### 📚 Documentation
 

--- a/glotaran/optimization/data_provider.py
+++ b/glotaran/optimization/data_provider.py
@@ -612,9 +612,11 @@ class DataProviderLinked(DataProvider):
         # into an ndarray of shape (len(global,)
         # as an alternative to the more elegant xarray built-in which is limited to 32 datasets
         # aligned_group_labels = aligned_groups.str.join(dim="dataset").data
-        aligned_group_labels = []
-        for _, sub_arr in aligned_groups.groupby("global"):
-            aligned_group_labels.append("".join(sub_arr.values))
+        aligned_group_labels = [
+            "".join(sub_arr.values)
+            for _, sub_arr in aligned_groups.groupby("global")
+        ]
+
         aligned_group_labels = np.asarray(aligned_group_labels)
 
         group_definitions: dict[str, list[str]] = {}

--- a/glotaran/optimization/data_provider.py
+++ b/glotaran/optimization/data_provider.py
@@ -155,7 +155,11 @@ class DataProvider:
         return slice(minimum, maximum)
 
     def add_model_weight(
-        self, model: Model, dataset_label: str, model_dimension: str, global_dimension: str
+        self,
+        model: Model,
+        dataset_label: str,
+        model_dimension: str,
+        global_dimension: str,
     ):
         """Add model weight to data.
 
@@ -532,7 +536,9 @@ class DataProviderLinked(DataProvider):
         aligned_data = xr.concat(
             [
                 xr.DataArray(
-                    self.get_data(label), dims=["model", "global"], coords={"global": axis}
+                    self.get_data(label),
+                    dims=["model", "global"],
+                    coords={"global": axis},
                 )
                 for label, axis in aligned_global_axes.items()
             ],
@@ -602,7 +608,15 @@ class DataProviderLinked(DataProvider):
             dim="dataset",
             fill_value="",
         )
-        aligned_group_labels = aligned_groups.str.join(dim="dataset").data
+        # for every element along the global axis, concatenate all dataset labels
+        # into an ndarray of shape (len(global,)
+        # as an alternative to the more elegant xarray built-in which is limited to 32 datasets
+        # aligned_group_labels = aligned_groups.str.join(dim="dataset").data
+        aligned_group_labels = []
+        for _, sub_arr in aligned_groups.groupby("global"):
+            aligned_group_labels.append("".join(sub_arr.values))
+        aligned_group_labels = np.asarray(aligned_group_labels)
+
         group_definitions: dict[str, list[str]] = {}
         for i, group_label in enumerate(aligned_group_labels):
             if group_label not in group_definitions:
@@ -628,7 +642,9 @@ class DataProviderLinked(DataProvider):
         """
         all_weights = {
             label: xr.DataArray(
-                weight, dims=["model", "global"], coords={"global": aligned_global_axes[label]}
+                weight,
+                dims=["model", "global"],
+                coords={"global": aligned_global_axes[label]},
             )
             for label, weight in self._weight.items()
             if weight is not None

--- a/glotaran/optimization/data_provider.py
+++ b/glotaran/optimization/data_provider.py
@@ -613,8 +613,7 @@ class DataProviderLinked(DataProvider):
         # as an alternative to the more elegant xarray built-in which is limited to 32 datasets
         # aligned_group_labels = aligned_groups.str.join(dim="dataset").data
         aligned_group_labels = [
-            "".join(sub_arr.values)
-            for _, sub_arr in aligned_groups.groupby("global")
+            "".join(sub_arr.values) for _, sub_arr in aligned_groups.groupby("global")
         ]
 
         aligned_group_labels = np.asarray(aligned_group_labels)


### PR DESCRIPTION
Fixes issue where when using more than 32 datasets the xarray operation .str.join across the dataset dimension would crash.

### Change summary

- 🩹 Fix for crash when doing an optimization using more than 30 datasets

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
<!-- bug fix, no new feature
- [ ] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 📚 Adds documentation of the feature
-->

### Closes issues

closes #1183
