### PR TITLE
🩹 Fix yaml result saving with relative paths

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 - 🩹 Fix for normalization issue described in #1157 (multi-gaussian irfs and multiple time ranges (streak))
 - 🩹 Fix for crash described in #1183 when doing an optimization using more than 30 datasets (#1184)
 - 🩹 Fix pretty_format_numerical for negative values (#1192)
+- 🩹 Fix yaml result saving with relative paths (#1199)
 <!-- Fix within the 0.7.0 release cycle, therefore hidden:
 - 🩹 Fix the matrix provider alignment/reduction ('grouping') issues introduced in #1175 (#1190)
   -->

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -1,6 +1,7 @@
 """Module containing the YAML Data and Project IO plugins."""
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -214,8 +215,11 @@ class YmlProjectIo(ProjectIoInterface):
         save_model(result.scheme.model, model_path, allow_overwrite=True)
         paths.append(model_path.as_posix())
 
+        # The source_path attribute of the datasets only gets changed for `result.data`
+        # Which why we overwrite the data attribute on a copy of `result.scheme`
+        scheme = replace(result.scheme, data=result.data)
         scheme_path = result_folder / "scheme.yml"
-        save_scheme(result.scheme, scheme_path, allow_overwrite=True)
+        save_scheme(scheme, scheme_path, allow_overwrite=True)
         paths.append(scheme_path.as_posix())
 
         result_dict = asdict(result, folder=result_folder)

--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -9,6 +9,7 @@ import os
 from collections.abc import Mapping
 from collections.abc import MutableMapping
 from collections.abc import Sequence
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -19,6 +20,7 @@ from glotaran.plugin_system.data_io_registration import load_dataset
 from glotaran.typing.types import DatasetMappable
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from collections.abc import Iterator
 
     import pandas as pd
@@ -188,6 +190,37 @@ def load_datasets(dataset_mappable: DatasetMappable) -> DatasetMapping:
         the ``source_path`` attr.
     """
     return DatasetMapping.loader(dataset_mappable)
+
+
+@contextmanager
+def chdir_context(folder_path: StrOrPath) -> Generator[Path, None, None]:
+    """Context manager to change directory to ``folder_path``.
+
+    Parameters
+    ----------
+    folder_path: StrOrPath
+        Path to change to.
+
+    Yields
+    ------
+    Generator[Path, None, None]
+        Resolved path of ``folder_path``.
+
+    Raises
+    ------
+    ValueError
+        If ``folder_path`` is an existing file.
+    """
+    original_dir = Path(os.curdir).resolve()
+    folder_path = Path(folder_path)
+    if folder_path.is_file() is True:
+        raise ValueError("Value of 'folder_path' needs to be a folder but was an existing file.")
+    folder_path.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chdir(folder_path)
+        yield folder_path.resolve()
+    finally:
+        os.chdir(original_dir)
 
 
 def relative_posix_path(source_path: StrOrPath, base_path: StrOrPath | None = None) -> str:

--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -226,6 +226,8 @@ def chdir_context(folder_path: StrOrPath) -> Generator[Path, None, None]:
 def relative_posix_path(source_path: StrOrPath, base_path: StrOrPath | None = None) -> str:
     """Ensure that ``source_path`` is a posix path, relative to ``base_path`` if defined.
 
+    For ``source_path`` to be converted to a relative path it either needs to a an absolute path or
+    ``base_path`` needs to be a parent directory of ``source_path``.
     On Windows if ``source_path`` and ``base_path`` are on different drives, it will return
     the absolute posix path to the file.
 
@@ -234,17 +236,20 @@ def relative_posix_path(source_path: StrOrPath, base_path: StrOrPath | None = No
     source_path : StrOrPath
         Path which should be converted to a relative posix path.
     base_path : StrOrPath, optional
-        Base path the resulting path string should be relative to., by default None
+        Base path the resulting path string should be relative to. Defaults to ``None``.
 
     Returns
     -------
     str
         ``source_path`` as posix path relative to ``base_path`` if defined.
     """
-    source_path = Path(source_path).as_posix()
-    if base_path is not None and os.path.isabs(source_path):
+    source_path = Path(source_path)
+    if base_path is not None and (
+        source_path.is_absolute() or Path(base_path).resolve() in source_path.resolve().parents
+    ):
         with contextlib.suppress(ValueError):
-            source_path = os.path.relpath(source_path, Path(base_path).as_posix())
+            source_path = os.path.relpath(source_path.as_posix(), Path(base_path).as_posix())
+
     return Path(source_path).as_posix()
 
 

--- a/glotaran/utils/test/test_io.py
+++ b/glotaran/utils/test/test_io.py
@@ -204,6 +204,14 @@ def test_relative_posix_path(tmp_path: Path, rel_file_path: str):
 
     assert rel_result_no_common == f"../{rel_file_path}"
 
+    result_folder = tmp_path / "results"
+    with chdir_context(result_folder):
+        original_rel_path = relative_posix_path(rel_file_path, result_folder)
+        assert original_rel_path == rel_file_path
+
+        original_rel_path = relative_posix_path(rel_file_path, "not_a_parent")
+        assert original_rel_path == rel_file_path
+
 
 def test_chdir_context(tmp_path: Path):
     """Original Path is restored even after exception is thrown."""


### PR DESCRIPTION
This fixes a bug when saving a result as yaml using a relative path, which added wrong file paths and broke loading the result. 
We didn't discover this bug since all the examples use absolute paths.

To reproduce the issue use the following code snipped (e.g. in a notebook)
```python
from glotaran.optimization.optimize import optimize
from glotaran.testing.simulated_data.parallel_spectral_decay import SCHEME

result = optimize(SCHEME)

result.save("results/result.yaml")
```

This generates the following files:
```
results
├── dataset_1.nc
├── initial_parameters.csv
├── model.yml
├── optimization_history.csv
├── optimized_parameters.csv
├── parameter_history.csv
├── result.md
├── result.yaml
└── scheme.yml
```

On main the paths pointing to other files used `result.yaml` and `scheme.yml` use a relative path to the current dir instead of relative to `result.yaml`.

`result.yaml`
```yaml
number_of_function_evaluations: 3
success: true
termination_reason: '`ftol` termination condition is satisfied.'
glotaran_version: 0.7.0.dev0
free_parameter_labels:
- rates.species_1
- rates.species_2
- rates.species_3
- irf.center
- irf.width
scheme: results/scheme.yml
initial_parameters: results/initial_parameters.csv
optimized_parameters: results/optimized_parameters.csv
parameter_history: results/parameter_history.csv
optimization_history: results/optimization_history.csv
data:
  dataset_1: results/dataset_1.nc
chi_square: 15.08817310748813
degrees_of_freedom: 151195
number_of_data_points: 151200
number_of_jacobian_evaluations: 3
number_of_parameters: 5
optimality: 8.405348253083255e-06
reduced_chi_square: 9.979280470576494e-05
root_mean_square_error: 0.009989634863485499
```
`scheme.yml`
```yaml
model: results/model.yml
parameters: results/initial_parameters.csv
data:
  dataset_1: dataset_1.nc
clp_link_tolerance: 0.0
clp_link_method: nearest
maximum_number_function_evaluations: null
add_svd: true
ftol: 1e-08
gtol: 1e-08
xtol: 1e-08
optimization_method: TrustRegionReflection
result_path: null
```

With this change, the paths are relative to the parent folder of `result.yaml`.

`result.yaml`
```yaml
number_of_function_evaluations: 3
success: true
termination_reason: '`ftol` termination condition is satisfied.'
glotaran_version: 0.7.0.dev0
free_parameter_labels:
- rates.species_1
- rates.species_2
- rates.species_3
- irf.center
- irf.width
scheme: scheme.yml
initial_parameters: initial_parameters.csv
optimized_parameters: optimized_parameters.csv
parameter_history: parameter_history.csv
optimization_history: optimization_history.csv
data:
  dataset_1: dataset_1.nc
chi_square: 15.207098066318238
degrees_of_freedom: 151195
number_of_data_points: 151200
number_of_jacobian_evaluations: 3
number_of_parameters: 5
optimality: 3.0616701279760627e-06
reduced_chi_square: 0.00010057937144957332
root_mean_square_error: 0.010028926734679705
```

`scheme.yml`
```yaml
model: model.yml
parameters: initial_parameters.csv
data:
  dataset_1: dataset_1.nc
clp_link_tolerance: 0.0
clp_link_method: nearest
maximum_number_function_evaluations: null
add_svd: true
ftol: 1e-08
gtol: 1e-08
xtol: 1e-08
optimization_method: TrustRegionReflection
result_path: null
```
### Change summary

- [✨ Added chdir_context context manager for testing with relative paths](https://github.com/glotaran/pyglotaran/commit/ad96e6f70588baec4e8246ff840839fcf7726770)
- [🧪 Added failing test to reproduce save_result issue with relative paths](https://github.com/glotaran/pyglotaran/commit/e5f083bd376cc5667cebbddcd8853479ff6f9634)
- [🩹 Fix wrong paths in result.yml when using relative path](https://github.com/glotaran/pyglotaran/commit/2f1643b41fe7ac6515b86603721fc549aa4f0648)
- [🧪 Added test where scheme data input path is different than save path](https://github.com/glotaran/pyglotaran/pull/1199/commits/3cb18c46af7a05f448b507b095746381ef1e0176)
- [🩹 Fixed dataset path in saved scheme](https://github.com/glotaran/pyglotaran/pull/1199/commits/febe078984c659977977bcfc58407fb97839de14)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
