### PR TITLE
🩹 Fix model markdown render for items without label

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@
 - 🩹 Fix for crash described in #1183 when doing an optimization using more than 30 datasets (#1184)
 - 🩹 Fix pretty_format_numerical for negative values (#1192)
 - 🩹 Fix yaml result saving with relative paths (#1199)
+- 🩹 Fix model markdown render for items without label (#1213)
 <!-- Fix within the 0.7.0 release cycle, therefore hidden:
 - 🩹 Fix the matrix provider alignment/reduction ('grouping') issues introduced in #1175 (#1190)
   -->

--- a/glotaran/model/item.py
+++ b/glotaran/model/item.py
@@ -228,7 +228,7 @@ def item_to_markdown(
                     value.label if isinstance(value, Parameter) else value
                 ).markdown(parameters, initial_parameters)
 
-        property_md = indent(f"* *{name.replace('_', ' ').title()}*: {value}\n", "  ")
+        property_md = indent(f"- _{name.replace('_', ' ').title()}_: {value}\n", "  ")
 
         md += property_md
 

--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -497,7 +497,7 @@ class Model:
                 item_str = item_to_markdown(
                     item, parameters=parameters, initial_parameters=initial_parameters
                 ).split("\n")
-                string += f"* **{getattr(item, 'label', '')}**\n"
+                string += f"* **{getattr(item, 'label', '&nbsp;')}**\n"
                 for s in item_str[1:]:
                     string += f"  {s}\n"
             string += "\n"

--- a/glotaran/model/model.py
+++ b/glotaran/model/model.py
@@ -497,9 +497,9 @@ class Model:
                 item_str = item_to_markdown(
                     item, parameters=parameters, initial_parameters=initial_parameters
                 ).split("\n")
-                string += f"* **{getattr(item, 'label', '&nbsp;')}**\n"
+                string += f"- **{getattr(item, 'label', '&nbsp;')}**\n"
                 for s in item_str[1:]:
-                    string += f"  {s}\n"
+                    string += f"{s}\n"
             string += "\n"
         return MarkdownStr(string)
 

--- a/glotaran/model/test/expected_model_markdown.md
+++ b/glotaran/model/test/expected_model_markdown.md
@@ -1,0 +1,97 @@
+# Model
+
+## Dataset Groups
+
+- **testgroup**
+
+  - _Label_: testgroup
+  - _Residual Function_: non_negative_least_squares
+  - _Link Clp_: True
+
+- **default**
+  - _Label_: default
+  - _Residual Function_: variable_projection
+
+## Weights
+
+- **&nbsp;**
+  - _Datasets_: ['d1', 'd2']
+  - _Global Interval_: (1, 4)
+  - _Model Interval_: (2, 3)
+  - _Value_: 5.4
+
+## Test Item
+
+- **t1**
+
+  - _Label_: t1
+  - _Param_: foo
+  - _Param List_: ['bar', 'baz']
+  - _Param Dict_: {('s1', 's2'): 'baz'}
+  - _Megacomplex_: m1
+  - _Number_: 42
+
+- **t2**
+  - _Label_: t2
+  - _Param_: baz
+  - _Param List_: ['foo']
+  - _Param Dict_: {}
+  - _Megacomplex_: m2
+  - _Number_: 7
+
+## Megacomplex
+
+- **m1**
+
+  - _Label_: m1
+  - _Type_: simple
+  - _Dimension_: model
+  - _Test Item_: t2
+
+- **m2**
+  - _Label_: m2
+  - _Type_: dataset
+  - _Dimension_: model2
+
+## Test Item Dataset
+
+- **t1**
+
+  - _Label_: t1
+  - _Param_: foo
+  - _Param List_: ['bar', 'baz']
+  - _Param Dict_: {('s1', 's2'): 'baz'}
+  - _Megacomplex_: m1
+  - _Number_: 42
+
+- **t2**
+  - _Label_: t2
+  - _Param_: baz
+  - _Param List_: ['foo']
+  - _Param Dict_: {}
+  - _Megacomplex_: m2
+  - _Number_: 7
+
+## Dataset
+
+- **dataset1**
+
+  - _Label_: dataset1
+  - _Group_: default
+  - _Force Index Dependent_: False
+  - _Megacomplex_: ['m1']
+  - _Scale_: scale_1
+  - _Test Item Dataset_: t1
+  - _Test Property Dataset1_: 1
+  - _Test Property Dataset2_: bar
+
+- **dataset2**
+  - _Label_: dataset2
+  - _Group_: testgroup
+  - _Force Index Dependent_: False
+  - _Megacomplex_: ['m2']
+  - _Global Megacomplex_: ['m1']
+  - _Scale_: scale_2
+  - _Test Item Dataset_: t2
+  - _Test Property Dataset1_: 1
+  - _Test Property Dataset2_: bar

--- a/glotaran/model/test/test_model.py
+++ b/glotaran/model/test/test_model.py
@@ -1,4 +1,4 @@
-from textwrap import dedent
+from pathlib import Path
 
 import pytest
 
@@ -315,111 +315,13 @@ def test_model_as_dict():
 
 
 def test_model_markdown(test_model: Model):
-    md = test_model.markdown()
-    expected = dedent(
-        """\
-        # Model
-
-        ## Dataset Groups
-
-        * **testgroup**
-            * *Label*: testgroup
-            * *Residual Function*: non_negative_least_squares
-            * *Link Clp*: True
-
-        * **default**
-            * *Label*: default
-            * *Residual Function*: variable_projection
-
-
-        ## Weights
-
-        * **&nbsp;**
-            * *Datasets*: ['d1', 'd2']
-            * *Global Interval*: (1, 4)
-            * *Model Interval*: (2, 3)
-            * *Value*: 5.4
-
-
-        ## Test Item
-
-        * **t1**
-            * *Label*: t1
-            * *Param*: foo
-            * *Param List*: ['bar', 'baz']
-            * *Param Dict*: {('s1', 's2'): 'baz'}
-            * *Megacomplex*: m1
-            * *Number*: 42
-
-        * **t2**
-            * *Label*: t2
-            * *Param*: baz
-            * *Param List*: ['foo']
-            * *Param Dict*: {}
-            * *Megacomplex*: m2
-            * *Number*: 7
-
-
-        ## Megacomplex
-
-        * **m1**
-            * *Label*: m1
-            * *Type*: simple
-            * *Dimension*: model
-            * *Test Item*: t2
-
-        * **m2**
-            * *Label*: m2
-            * *Type*: dataset
-            * *Dimension*: model2
-
-
-        ## Test Item Dataset
-
-        * **t1**
-            * *Label*: t1
-            * *Param*: foo
-            * *Param List*: ['bar', 'baz']
-            * *Param Dict*: {('s1', 's2'): 'baz'}
-            * *Megacomplex*: m1
-            * *Number*: 42
-
-        * **t2**
-            * *Label*: t2
-            * *Param*: baz
-            * *Param List*: ['foo']
-            * *Param Dict*: {}
-            * *Megacomplex*: m2
-            * *Number*: 7
-
-
-        ## Dataset
-
-        * **dataset1**
-            * *Label*: dataset1
-            * *Group*: default
-            * *Force Index Dependent*: False
-            * *Megacomplex*: ['m1']
-            * *Scale*: scale_1
-            * *Test Item Dataset*: t1
-            * *Test Property Dataset1*: 1
-            * *Test Property Dataset2*: bar
-
-        * **dataset2**
-            * *Label*: dataset2
-            * *Group*: testgroup
-            * *Force Index Dependent*: False
-            * *Megacomplex*: ['m2']
-            * *Global Megacomplex*: ['m1']
-            * *Scale*: scale_2
-            * *Test Item Dataset*: t2
-            * *Test Property Dataset1*: 1
-            * *Test Property Dataset2*: bar
-
-
-        """
+    md = test_model.markdown().replace("\n\n\n", "\n\n").replace("\n\n", "\n")
+    expected = (
+        (Path(__file__).parent / "expected_model_markdown.md")
+        .read_text(encoding="utf8")
+        .replace("\n\n\n", "\n\n")
+        .replace("\n\n", "\n")
     )
-    print(md)
     # Preprocessing to remove trailing whitespace after '* *Matrix*:'
     expected = "\n".join([line.rstrip(" ") for line in str(expected).split("\n")])
     result = "\n".join([line.rstrip(" ") for line in str(md).split("\n")])

--- a/glotaran/model/test/test_model.py
+++ b/glotaran/model/test/test_model.py
@@ -334,7 +334,7 @@ def test_model_markdown(test_model: Model):
 
         ## Weights
 
-        * ****
+        * **&nbsp;**
             * *Datasets*: ['d1', 'd2']
             * *Global Interval*: (1, 4)
             * *Model Interval*: (2, 3)


### PR DESCRIPTION
This fixes model markdown render for items without label (e.g. weight) due to invalid markdown.
The problem was that the default value when the `label` is missing was `""` which resulted in `****` meaning `hline` and breaking the indented code below, using `"&nbsp;"` as default fixes this problem.

I used this opportunity to extract the expected markdown code to a markdown file which allows previewing it in your editor (if it supports markdown preview) and early catch reader errors, changing the markdown syntax in the way [prettier](https://prettier.io/) would format it (editor autoformat kicked in and why not 😅).

## Old

```md
## Weights

* ****
    * *Datasets*: ['d1', 'd2']
    * *Global Interval*: (1, 4)
    * *Model Interval*: (2, 3)
    * *Value*: 5.4
```

<details>
<summary>Rendered</summary>

## Weights

* ****
    * *Datasets*: ['d1', 'd2']
    * *Global Interval*: (1, 4)
    * *Model Interval*: (2, 3)
    * *Value*: 5.4
</details>

## New
```md
## Weights

- **&nbsp;**
  - _Datasets_: ['d1', 'd2']
  - _Global Interval_: (1, 4)
  - _Model Interval_: (2, 3)
  - _Value_: 5.4
```

<details>
<summary>Rendered</summary>

## Weights

- **&nbsp;**
  - _Datasets_: ['d1', 'd2']
  - _Global Interval_: (1, 4)
  - _Model Interval_: (2, 3)
  - _Value_: 5.4
</details>

### Change summary

- [🩹 Fixed model markdown for items without label](https://github.com/glotaran/pyglotaran/commit/bad0762b995e5a3b92576b71d5c2e0aca165e3ee)
- [👌 Factored out expected markdown string to file so it can be rendered](https://github.com/glotaran/pyglotaran/commit/6e8c78eb2a9b519bf891673ca84ed8d9169a5649)
- [👌 Upgraded markdown syntax for list and bold indicator (* -> - and * -> _)](https://github.com/glotaran/pyglotaran/commit/6e8c78eb2a9b519bf891673ca84ed8d9169a5649)


### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
