### PR TITLE
🩹 Fix `Project.import_data` path resolving for different script and cwd

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@
 - 🩹 Fix yaml result saving with relative paths (#1199)
 - 🩹 Fix model markdown render for items without label (#1213)
 - 🩹 Fix wrong file loading due to partial filename matching in Project (#1212)
+- 🩹 Fix `Project.import_data` path resolving for different script and cwd (#1214)
 <!-- Fix within the 0.7.0 release cycle, therefore hidden:
 - 🩹 Fix the matrix provider alignment/reduction ('grouping') issues introduced in #1175 (#1190)
   -->

--- a/glotaran/plugin_system/data_io_registration.py
+++ b/glotaran/plugin_system/data_io_registration.py
@@ -231,7 +231,7 @@ def save_dataset(
         by default True
     **kwargs : Any
         Additional keyword arguments passes to the ``write_dataset`` implementation
-        of the data io plugin. If you aren't sure about those use ``get_datawriter``
+        of the data io plugin. If you aren't sure about those use ``get_datasaver``
         to get the implementation with the proper help and autocomplete.
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)

--- a/glotaran/plugin_system/test/test_data_io_registration.py
+++ b/glotaran/plugin_system/test/test_data_io_registration.py
@@ -217,10 +217,11 @@ def test_protect_from_overwrite_write_functions(tmp_path: Path):
         save_dataset(xr.DataArray([1, 2]), str(file_path))
 
 
+@pytest.mark.parametrize("sub_dir", ("", "sub_dir"))
 @pytest.mark.usefixtures("mocked_registry")
-def test_write_dataset(tmp_path: Path):
+def test_write_dataset(tmp_path: Path, sub_dir: str):
     """All args and kwargs are passes correctly."""
-    file_path = tmp_path / "dummy.mock"
+    file_path = tmp_path / sub_dir / "dummy.mock"
 
     result: dict[str, Any] = {}
     save_dataset(

--- a/glotaran/plugin_system/test/test_project_io_registration.py
+++ b/glotaran/plugin_system/test/test_project_io_registration.py
@@ -241,6 +241,7 @@ def test_load_functions(tmp_path: Path, load_function: Callable[..., Any]):
     assert result.source_path == Path(file_path).as_posix()
 
 
+@pytest.mark.parametrize("sub_dir", ("", "sub_dir"))
 @pytest.mark.parametrize(
     "save_function",
     (
@@ -253,10 +254,10 @@ def test_load_functions(tmp_path: Path, load_function: Callable[..., Any]):
 @pytest.mark.parametrize("update_source_path", (True, False))
 @pytest.mark.usefixtures("mocked_registry")
 def test_write_functions(
-    tmp_path: Path, save_function: Callable[..., Any], update_source_path: bool
+    tmp_path: Path, save_function: Callable[..., Any], update_source_path: bool, sub_dir: str
 ):
     """All args and kwargs are passes correctly."""
-    file_path = tmp_path / "model.mock"
+    file_path = tmp_path / "sub_dir" / "model.mock"
     mock_obj = MockFileLoadable()
 
     save_function(

--- a/glotaran/project/project_data_registry.py
+++ b/glotaran/project/project_data_registry.py
@@ -46,6 +46,9 @@ class ProjectDataRegistry(ProjectRegistry):
         """
         path = Path(path)
 
+        if path.is_absolute() is False:
+            path = (self.directory.parent / path).resolve()
+
         name = name or path.stem
         data_path = self.directory / f"{name}.nc"
 


### PR DESCRIPTION
This fixes a bug in `Project.import_data` causing a `ValueError` when using a relative path and the directory of the script is not the current working directory.
This is the case in editors when the script is not at the folder root or when calling it from python (e.g. `python myproject/script1.py`)

In addition, I improved the saving functionality of the plugin system to create parent folders for files.
Before that trying to save a file to a location with a nonexisting parent folder caused a massive traceback from the undelaying writer implementation.

<details>
<summary>
Example traceback
</summary>

```python
save_dataset(result.data["dataset1"], "nonexisting_folder/dataset1.nc")
```

```python
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
File c:\Anaconda3\envs\pyglotaran310\lib\site-packages\xarray\backends\file_manager.py:209, in CachingFileManager._acquire_with_cache_info(self, needs_lock)
    208 try:
--> 209     file = self._cache[self._key]
    210 except KeyError:

File c:\Anaconda3\envs\pyglotaran310\lib\site-packages\xarray\backends\lru_cache.py:55, in LRUCache.__getitem__(self, key)
     54 with self._lock:
---> 55     value = self._cache[key]
     56     self._cache.move_to_end(key)

KeyError: [<class 'netCDF4._netCDF4.Dataset'>, ('d:\\Dropbox\\Dropbox\\uni\\master\\thesis\\case_studies\\ArticialLego-2022-12-16\\ArticialLego\\pyglotaran\\nonexisting_folder\\dataset1.nc',), 'a', (('clobber', True), ('diskless', False), ('format', 'NETCDF4'), ('persist', False)), '81707b57-1609-4544-91a9-094f02f41e67']

During handling of the above exception, another exception occurred:

PermissionError                           Traceback (most recent call last)
Cell In [20], line 3
      1 from glotaran.io import save_dataset
----> 3 save_dataset(result.data["dataset1"], "nonexisting_folder/dataset1.nc")

File D:\git\pyglotaran\glotaran\plugin_system\io_plugin_utils.py:87, in not_implemented_to_value_error.<locals>.wrapper(*args, **kwargs)
     84 @wraps(func)
     85 def wrapper(*args: Any, **kwargs: Any) -> Any:
     86     try:
---> 87         return func(*args, **kwargs)
     88     except NotImplementedError as error:
     89         raise ValueError(error.args)

File D:\git\pyglotaran\glotaran\plugin_system\data_io_registration.py:241, in save_dataset(dataset, file_name, format_name, data_filters, allow_overwrite, update_source_path, **kwargs)
    239 if "loader" in dataset.attrs:
    240     del dataset.attrs["loader"]
--> 241 io.save_dataset(file_name=Path(file_name).as_posix(), dataset=dataset, **kwargs)
    242 dataset.attrs["loader"] = load_dataset
    243 if update_source_path is True or "source_path" not in dataset.attrs:

File D:\git\pyglotaran\glotaran\builtin\io\netCDF\netCDF.py:51, in NetCDFDataIo.save_dataset(self, dataset, file_name, data_filters)
     39 """Write a :xarraydoc:`Dataset` to the ``*.nc`` at path ``file_name``.
     40 
     41 Parameters
   (...)
     48     List of data variable names that should be written to file. Defaults to None.
     49 """
     50 data_to_save = dataset if data_filters is None else dataset[data_filters]
---> 51 data_to_save.to_netcdf(file_name, mode="w")

File c:\Anaconda3\envs\pyglotaran310\lib\site-packages\xarray\core\dataset.py:1903, in Dataset.to_netcdf(self, path, mode, format, group, engine, encoding, unlimited_dims, compute, invalid_netcdf)
   1900     encoding = {}
   1901 from ..backends.api import to_netcdf
-> 1903 return to_netcdf(  # type: ignore  # mypy cannot resolve the overloads:(
   1904     self,
   1905     path,
   1906     mode=mode,
   1907     format=format,
   1908     group=group,
   1909     engine=engine,
   1910     encoding=encoding,
   1911     unlimited_dims=unlimited_dims,
   1912     compute=compute,
   1913     multifile=False,
   1914     invalid_netcdf=invalid_netcdf,
   1915 )

File c:\Anaconda3\envs\pyglotaran310\lib\site-packages\xarray\backends\api.py:1213, in to_netcdf(dataset, path_or_file, mode, format, group, engine, encoding, unlimited_dims, compute, multifile, invalid_netcdf)
   1209     else:
   1210         raise ValueError(
   1211             f"unrecognized option 'invalid_netcdf' for engine {engine}"
   1212         )
-> 1213 store = store_open(target, mode, format, group, **kwargs)
   1215 if unlimited_dims is None:
   1216     unlimited_dims = dataset.encoding.get("unlimited_dims", None)

File c:\Anaconda3\envs\pyglotaran310\lib\site-packages\xarray\backends\netCDF4_.py:376, in NetCDF4DataStore.open(cls, filename, mode, format, group, clobber, diskless, persist, lock, lock_maker, autoclose)
    370 kwargs = dict(
    371     clobber=clobber, diskless=diskless, persist=persist, format=format
    372 )
    373 manager = CachingFileManager(
    374     netCDF4.Dataset, filename, mode=mode, kwargs=kwargs
    375 )
--> 376 return cls(manager, group=group, mode=mode, lock=lock, autoclose=autoclose)

File c:\Anaconda3\envs\pyglotaran310\lib\site-packages\xarray\backends\netCDF4_.py:323, in NetCDF4DataStore.__init__(self, manager, group, mode, lock, autoclose)
    321 self._group = group
    322 self._mode = mode
--> 323 self.format = self.ds.data_model
    324 self._filename = self.ds.filepath()
    325 self.is_remote = is_remote_uri(self._filename)

File c:\Anaconda3\envs\pyglotaran310\lib\site-packages\xarray\backends\netCDF4_.py:385, in NetCDF4DataStore.ds(self)
    383 @property
    384 def ds(self):
--> 385     return self._acquire()

File c:\Anaconda3\envs\pyglotaran310\lib\site-packages\xarray\backends\netCDF4_.py:379, in NetCDF4DataStore._acquire(self, needs_lock)
    378 def _acquire(self, needs_lock=True):
--> 379     with self._manager.acquire_context(needs_lock) as root:
    380         ds = _nc4_require_group(root, self._group, self._mode)
    381     return ds

File c:\Anaconda3\envs\pyglotaran310\lib\contextlib.py:135, in _GeneratorContextManager.__enter__(self)
    133 del self.args, self.kwds, self.func
    134 try:
--> 135     return next(self.gen)
    136 except StopIteration:
    137     raise RuntimeError("generator didn't yield") from None

File c:\Anaconda3\envs\pyglotaran310\lib\site-packages\xarray\backends\file_manager.py:197, in CachingFileManager.acquire_context(self, needs_lock)
    194 @contextlib.contextmanager
    195 def acquire_context(self, needs_lock=True):
    196     """Context manager for acquiring a file."""
--> 197     file, cached = self._acquire_with_cache_info(needs_lock)
    198     try:
    199         yield file

File c:\Anaconda3\envs\pyglotaran310\lib\site-packages\xarray\backends\file_manager.py:215, in CachingFileManager._acquire_with_cache_info(self, needs_lock)
    213     kwargs = kwargs.copy()
    214     kwargs["mode"] = self._mode
--> 215 file = self._opener(*self._args, **kwargs)
    216 if self._mode == "w":
    217     # ensure file doesn't get overridden when opened again
    218     self._mode = "a"

File src\netCDF4\_netCDF4.pyx:2463, in netCDF4._netCDF4.Dataset.__init__()

File src\netCDF4\_netCDF4.pyx:2026, in netCDF4._netCDF4._ensure_nc_success()

PermissionError: [Errno 13] Permission denied: b'd:\\test\\nonexisting_folder\\dataset1.nc'
```
</details>


### Change summary

- [👌 Change save functions to create parent folder](https://github.com/glotaran/pyglotaran/pull/1214/commits/800e3e54a3ae6a7ef6c4cb77526ff9517a349c7b)
- [🧪 Added failing test for Project.import_data using a relative path](https://github.com/glotaran/pyglotaran/commit/c3e28e4cfcb4327250fba5f5dd87de29d8b7cf64)
- [🩹 Fix Project.import_data path resolving for different scirpt and cwd](https://github.com/glotaran/pyglotaran/commit/f2b27bda3517b0345cd6a9fa55ec877c9ce28f7f)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)