### PR TITLE
👌 Make yaml the default plugin when passing a folder to save_result and load_result

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 - 👌🎨 Wrap model section in result markdown in details tag for notebooks (#1098)
 - 👌 Allow more natural column names in pandas parameters file reading (#1174)
 - ✨ Integrate plugin system into Project (#1229)
+- 👌 Make yaml the new default plugin when passing a folder to save_result (#1230)
 
 ### 🩹 Bug fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,7 @@
 - 👌🎨 Wrap model section in result markdown in details tag for notebooks (#1098)
 - 👌 Allow more natural column names in pandas parameters file reading (#1174)
 - ✨ Integrate plugin system into Project (#1229)
-- 👌 Make yaml the new default plugin when passing a folder to save_result (#1230)
+- 👌 Make yaml the default plugin when passing a folder to save_result and load_result (#1230)
 
 ### 🩹 Bug fixes
 

--- a/glotaran/builtin/io/yml/test/test_save_result.py
+++ b/glotaran/builtin/io/yml/test/test_save_result.py
@@ -108,6 +108,14 @@ def test_save_result_yml(tmp_path: Path, dummy_result: Result, path_is_absolute:
         assert expected_result in got
 
 
+def test_save_result_yml_result_path_is_folder(tmp_path: Path, dummy_result: Result):
+    """Save the result passing a folder instead of a file path"""
+    save_path = tmp_path / "testresult"
+    save_result(result_path=save_path, result=dummy_result)
+
+    assert (save_path / "result.yml").is_file()
+
+
 @pytest.mark.parametrize("path_is_absolute", (True, False))
 def test_save_result_yml_roundtrip(tmp_path: Path, dummy_result: Result, path_is_absolute: bool):
     """Save and reloaded Result should be the same."""

--- a/glotaran/builtin/io/yml/test/test_save_result.py
+++ b/glotaran/builtin/io/yml/test/test_save_result.py
@@ -110,10 +110,12 @@ def test_save_result_yml(tmp_path: Path, dummy_result: Result, path_is_absolute:
 
 def test_save_result_yml_result_path_is_folder(tmp_path: Path, dummy_result: Result):
     """Save the result passing a folder instead of a file path"""
-    save_path = tmp_path / "testresult"
-    save_result(result_path=save_path, result=dummy_result)
+    result_folder = tmp_path / "testresult"
+    save_result(result_path=result_folder, result=dummy_result)
 
-    assert (save_path / "result.yml").is_file()
+    assert (result_folder / "result.yml").is_file()
+
+    load_result(result_folder)
 
 
 @pytest.mark.parametrize("path_is_absolute", (True, False))

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -164,7 +164,10 @@ class YmlProjectIo(ProjectIoInterface):
         Result
             :class:`Result` instance created from the saved format.
         """
-        spec = self._load_yml(result_path)
+        result_file_path = Path(result_path)
+        if result_file_path.suffix not in [".yml", ".yaml"]:
+            result_file_path = result_file_path / "result.yml"
+        spec = self._load_yml(result_file_path.as_posix())
         return fromdict(Result, spec, folder=Path(result_path).parent)
 
     def save_result(

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -168,7 +168,7 @@ class YmlProjectIo(ProjectIoInterface):
         if result_file_path.suffix not in [".yml", ".yaml"]:
             result_file_path = result_file_path / "result.yml"
         spec = self._load_yml(result_file_path.as_posix())
-        return fromdict(Result, spec, folder=Path(result_path).parent)
+        return fromdict(Result, spec, folder=result_file_path.parent)
 
     def save_result(
         self,

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -201,7 +201,10 @@ class YmlProjectIo(ProjectIoInterface):
         list[str]
             List of file paths which were created.
         """
-        result_folder = Path(result_path).parent
+        result_file_path = Path(result_path)
+        if result_file_path.suffix not in [".yml", ".yaml"]:
+            result_file_path = result_file_path / "result.yml"
+        result_folder = result_file_path.parent
         paths = save_result(
             result,
             result_folder,
@@ -223,8 +226,8 @@ class YmlProjectIo(ProjectIoInterface):
         paths.append(scheme_path.as_posix())
 
         result_dict = asdict(result, folder=result_folder)
-        write_dict(result_dict, file_name=result_path)
-        paths.append(result_path)
+        write_dict(result_dict, file_name=result_file_path)
+        paths.append(result_file_path.as_posix())
 
         return paths
 

--- a/glotaran/plugin_system/data_io_registration.py
+++ b/glotaran/plugin_system/data_io_registration.py
@@ -26,7 +26,7 @@ from glotaran.plugin_system.base_registry import set_plugin
 from glotaran.plugin_system.base_registry import show_method_help
 from glotaran.plugin_system.base_registry import supported_file_extensions
 from glotaran.plugin_system.io_plugin_utils import bool_table_repr
-from glotaran.plugin_system.io_plugin_utils import inferr_file_format
+from glotaran.plugin_system.io_plugin_utils import infer_file_format
 from glotaran.plugin_system.io_plugin_utils import not_implemented_to_value_error
 from glotaran.plugin_system.io_plugin_utils import protect_from_overwrite
 from glotaran.utils.ipython import MarkdownStr
@@ -194,7 +194,7 @@ def load_dataset(
     xr.Dataset
         Data loaded from the file.
     """
-    io = get_data_io(format_name or inferr_file_format(file_name))
+    io = get_data_io(format_name or infer_file_format(file_name))
     dataset = io.load_dataset(Path(file_name).as_posix(), **kwargs)
 
     if isinstance(dataset, xr.DataArray):
@@ -238,7 +238,7 @@ def save_dataset(
         to get the implementation with the proper help and autocomplete.
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
-    io = get_data_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
+    io = get_data_io(format_name or infer_file_format(file_name, needs_to_exist=False))
     if "loader" in dataset.attrs:
         del dataset.attrs["loader"]
     io.save_dataset(file_name=Path(file_name).as_posix(), dataset=dataset, **kwargs)

--- a/glotaran/plugin_system/io_plugin_utils.py
+++ b/glotaran/plugin_system/io_plugin_utils.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from glotaran.typing import StrOrPath
 
 
-def inferr_file_format(
+def infer_file_format(
     file_path: StrOrPath, *, needs_to_exist: bool = True, allow_folder=False
 ) -> str:
     """Inferr format of a file if it exists.
@@ -87,7 +87,7 @@ def not_implemented_to_value_error(func: DecoratedFunc) -> DecoratedFunc:
         try:
             return func(*args, **kwargs)
         except NotImplementedError as error:
-            raise ValueError(error.args)
+            raise ValueError(error.args) from error
 
     return cast(DecoratedFunc, wrapper)
 

--- a/glotaran/plugin_system/io_plugin_utils.py
+++ b/glotaran/plugin_system/io_plugin_utils.py
@@ -125,7 +125,7 @@ def protect_from_overwrite(path: str | os.PathLike[str], *, allow_overwrite: boo
         raise FileExistsError(f"The file {path!r} already exists. \n{user_info}")
     elif path.is_dir() and os.listdir(str(path)):
         raise FileExistsError(
-            f"The folder {path!r} already exists and is not empty. \n{user_info}"
+            f"The folder {path.as_posix()!r} already exists and is not empty. \n{user_info}"
         )
 
 

--- a/glotaran/plugin_system/io_plugin_utils.py
+++ b/glotaran/plugin_system/io_plugin_utils.py
@@ -57,7 +57,7 @@ def inferr_file_format(
         return file_format.lstrip(".")
 
     if allow_folder:
-        return "legacy"
+        return "yml"
     else:
         raise ValueError(
             f"Cannot determine format of file {file_path!r}, please provide an explicit format."

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -28,7 +28,7 @@ from glotaran.plugin_system.base_registry import set_plugin
 from glotaran.plugin_system.base_registry import show_method_help
 from glotaran.plugin_system.base_registry import supported_file_extensions
 from glotaran.plugin_system.io_plugin_utils import bool_table_repr
-from glotaran.plugin_system.io_plugin_utils import inferr_file_format
+from glotaran.plugin_system.io_plugin_utils import infer_file_format
 from glotaran.plugin_system.io_plugin_utils import not_implemented_to_value_error
 from glotaran.plugin_system.io_plugin_utils import protect_from_overwrite
 from glotaran.utils.ipython import MarkdownStr
@@ -222,7 +222,7 @@ def load_model(file_name: StrOrPath, format_name: str | None = None, **kwargs: A
     Model
         Model instance created from the file.
     """
-    io = get_project_io(format_name or inferr_file_format(file_name))
+    io = get_project_io(format_name or infer_file_format(file_name))
     model = io.load_model(Path(file_name).as_posix(), **kwargs)
     model.source_path = Path(file_name).as_posix()
     return model
@@ -258,7 +258,7 @@ def save_model(
         of the project io plugin.
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
-    io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
+    io = get_project_io(format_name or infer_file_format(file_name, needs_to_exist=False))
     io.save_model(file_name=Path(file_name).as_posix(), model=model, **kwargs)
     if update_source_path is True:
         model.source_path = Path(file_name).as_posix()
@@ -285,7 +285,7 @@ def load_parameters(file_name: StrOrPath, format_name: str | None = None, **kwar
 
     .. # noqa: D414
     """
-    io = get_project_io(format_name or inferr_file_format(file_name))
+    io = get_project_io(format_name or infer_file_format(file_name))
     parameters = io.load_parameters(
         Path(file_name).as_posix(),
         **kwargs,
@@ -324,7 +324,7 @@ def save_parameters(
         of the project io plugin.
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
-    io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
+    io = get_project_io(format_name or infer_file_format(file_name, needs_to_exist=False))
     io.save_parameters(file_name=Path(file_name).as_posix(), parameters=parameters, **kwargs)
     if update_source_path is True:
         parameters.source_path = Path(file_name).as_posix()
@@ -349,7 +349,7 @@ def load_scheme(file_name: StrOrPath, format_name: str | None = None, **kwargs: 
     Scheme
         :class:`Scheme` instance created from the file.
     """
-    io = get_project_io(format_name or inferr_file_format(file_name))
+    io = get_project_io(format_name or infer_file_format(file_name))
 
     scheme = io.load_scheme(Path(file_name).as_posix(), **kwargs)
     scheme.source_path = Path(file_name).as_posix()
@@ -386,7 +386,7 @@ def save_scheme(
         of the project io plugin.
     """
     protect_from_overwrite(file_name, allow_overwrite=allow_overwrite)
-    io = get_project_io(format_name or inferr_file_format(file_name, needs_to_exist=False))
+    io = get_project_io(format_name or infer_file_format(file_name, needs_to_exist=False))
     io.save_scheme(file_name=Path(file_name).as_posix(), scheme=scheme, **kwargs)
     if update_source_path is True:
         scheme.source_path = Path(file_name).as_posix()
@@ -412,7 +412,7 @@ def load_result(result_path: StrOrPath, format_name: str | None = None, **kwargs
     Result
         :class:`Result` instance created from the saved format.
     """
-    io = get_project_io(format_name or inferr_file_format(result_path))
+    io = get_project_io(format_name or infer_file_format(result_path))
 
     result = io.load_result(Path(result_path).as_posix(), **kwargs)
     result.source_path = Path(result_path).as_posix()
@@ -459,7 +459,7 @@ def save_result(
     """
     protect_from_overwrite(result_path, allow_overwrite=allow_overwrite)
     io = get_project_io(
-        format_name or inferr_file_format(result_path, needs_to_exist=False, allow_folder=True)
+        format_name or infer_file_format(result_path, needs_to_exist=False, allow_folder=True)
     )
     paths = io.save_result(
         result_path=Path(result_path).as_posix(),

--- a/glotaran/plugin_system/project_io_registration.py
+++ b/glotaran/plugin_system/project_io_registration.py
@@ -412,7 +412,7 @@ def load_result(result_path: StrOrPath, format_name: str | None = None, **kwargs
     Result
         :class:`Result` instance created from the saved format.
     """
-    io = get_project_io(format_name or infer_file_format(result_path))
+    io = get_project_io(format_name or infer_file_format(result_path, allow_folder=True))
 
     result = io.load_result(Path(result_path).as_posix(), **kwargs)
     result.source_path = Path(result_path).as_posix()

--- a/glotaran/plugin_system/test/test_io_plugin_utils.py
+++ b/glotaran/plugin_system/test/test_io_plugin_utils.py
@@ -57,7 +57,7 @@ def test_inferr_file_format_allow_folder(tmp_path: Path, is_file: bool):
     if is_file:
         file_path.touch()
 
-    assert infer_file_format(file_path, allow_folder=True) == "legacy"
+    assert infer_file_format(file_path, allow_folder=True) == "yml"
 
 
 def test_inferr_file_format_none_existing_file():

--- a/glotaran/plugin_system/test/test_io_plugin_utils.py
+++ b/glotaran/plugin_system/test/test_io_plugin_utils.py
@@ -6,7 +6,7 @@ import pytest
 
 from glotaran.plugin_system.io_plugin_utils import bool_str_repr
 from glotaran.plugin_system.io_plugin_utils import bool_table_repr
-from glotaran.plugin_system.io_plugin_utils import inferr_file_format
+from glotaran.plugin_system.io_plugin_utils import infer_file_format
 from glotaran.plugin_system.io_plugin_utils import not_implemented_to_value_error
 from glotaran.plugin_system.io_plugin_utils import protect_from_overwrite
 
@@ -36,7 +36,7 @@ def test_inferr_file_format(tmp_path: Path, extension: str, expected: str):
     file_path = tmp_path / f"dummy.{extension}"
     file_path.touch()
 
-    assert inferr_file_format(file_path) == expected
+    assert infer_file_format(file_path) == expected
 
 
 def test_inferr_file_format_no_extension(tmp_path: Path):
@@ -47,7 +47,7 @@ def test_inferr_file_format_no_extension(tmp_path: Path):
     with pytest.raises(
         ValueError, match="Cannot determine format of file .+?, please provide an explicit format"
     ):
-        inferr_file_format(file_path)
+        infer_file_format(file_path)
 
 
 @pytest.mark.parametrize("is_file", (True, False))
@@ -57,13 +57,13 @@ def test_inferr_file_format_allow_folder(tmp_path: Path, is_file: bool):
     if is_file:
         file_path.touch()
 
-    assert inferr_file_format(file_path, allow_folder=True) == "legacy"
+    assert infer_file_format(file_path, allow_folder=True) == "legacy"
 
 
 def test_inferr_file_format_none_existing_file():
     """Raise error if file does not exists."""
     with pytest.raises(ValueError, match="There is no file "):
-        inferr_file_format("none-existing-file.yml")
+        infer_file_format("none-existing-file.yml")
 
 
 def test_not_implemented_to_value_error():


### PR DESCRIPTION
Since the yaml plugin is currently the only plugin that allows for full result saving and saves a superset (additional `model.yml`, `scheme.yml` and `result.yml`) of the files saved by `legacy` (due to deprecation in `0.8.0` ) it is reasonable to make it the default.
This allows users to omit the now superfluous `result.yml` when saving a result.

**Note:**
Changing the default of ``load_result`` is also save since the plugins ``legacy``|``folder`` did not and do not have a ``load_result`` method.

Now you can use:
```python
save_result(result, result_folder)
```
or
```python
result.save(result_folder)
```

Thanks to @joernweissenborn for bringing this to my attention again.


### Change summary

- [👌 Allow passing folder to yaml save_result plugin in addition to file](https://github.com/glotaran/pyglotaran/commit/fc46f3e3de5628e189af2f9f9ce2b2f1de977f2e)
- [👌 Make yaml the new default plugin when passing a folder to save_result](https://github.com/glotaran/pyglotaran/pull/1230/commits/66f624fee03c2719236625c8e1df354216e46582)
- [🧹 Fix typo in internal API](https://github.com/glotaran/pyglotaran/pull/1230/commits/814463703f9f29d21e7831b7042bd47cd061d121)
- [🧹🧪 Updated failing test of infer_file_format](https://github.com/glotaran/pyglotaran/pull/1230/commits/bd71eae59d2579a27e1e17d8758eef1ef8ba0d7c)
- [👌 Make yaml the new default plugin when passing a folder to load_result](https://github.com/glotaran/pyglotaran/pull/1230/commits/020be73dda39a2d361df184d0e238abbac87b58f)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
