### PR TITLE
✨ Allow usage of subfolders in project API for parameters, models and data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 - 👌 Allow more natural column names in pandas parameters file reading (#1174)
 - ✨ Integrate plugin system into Project (#1229)
 - 👌 Make yaml the default plugin when passing a folder to save_result and load_result (#1230)
+- ✨ Allow usage of subfolders in project API for parameters, models and data (#1232)
 
 ### 🩹 Bug fixes
 

--- a/glotaran/project/project.py
+++ b/glotaran/project/project.py
@@ -166,14 +166,11 @@ class Project:
         ------
         ValueError
             Raised if the dataset does not exist.
+
+
+        .. # noqa: DAR402
         """
-        try:
-            return self._data_registry.load_item(dataset_name)
-        except ValueError as err:
-            raise ValueError(
-                f"Dataset {dataset_name!r} does not exist. "
-                f"Known Datasets are: {list(self._data_registry.items.keys())}"
-            ) from err
+        return self._data_registry.load_item(dataset_name)
 
     def import_data(
         self,
@@ -238,14 +235,11 @@ class Project:
         ------
         ValueError
             Raised if the model does not exist.
+
+
+        .. # noqa: DAR402
         """
-        try:
-            return self._model_registry.load_item(name)
-        except ValueError as err:
-            raise ValueError(
-                f"Model {name!r} does not exist. "
-                f"Known Models are: {list(self._model_registry.items.keys())}"
-            ) from err
+        return self._model_registry.load_item(name)
 
     def generate_model(
         self,
@@ -329,15 +323,11 @@ class Project:
         Parameters
             The loaded parameters.
 
+
         .. # noqa: D414
+        .. # noqa: DAR402
         """
-        try:
-            return self._parameter_registry.load_item(parameters_name)
-        except ValueError as err:
-            raise ValueError(
-                f"Parameters '{parameters_name}' does not exist. "
-                f"Known Parameters are: {list(self._parameter_registry.items.keys())}"
-            ) from err
+        return self._parameter_registry.load_item(parameters_name)
 
     def generate_parameters(
         self,

--- a/glotaran/project/project_data_registry.py
+++ b/glotaran/project/project_data_registry.py
@@ -24,6 +24,7 @@ class ProjectDataRegistry(ProjectRegistry):
             directory / "data",
             supported_file_extensions_data_io("load_dataset"),
             load_dataset,
+            item_name="Dataset",
         )
 
     def import_data(

--- a/glotaran/project/project_model_registry.py
+++ b/glotaran/project/project_model_registry.py
@@ -22,7 +22,10 @@ class ProjectModelRegistry(ProjectRegistry):
             The registry directory.
         """
         super().__init__(
-            directory / "models", supported_file_extensions_project_io("load_model"), load_model
+            directory / "models",
+            supported_file_extensions_project_io("load_model"),
+            load_model,
+            item_name="Model",
         )
 
     def generate_model(

--- a/glotaran/project/project_parameter_registry.py
+++ b/glotaran/project/project_parameter_registry.py
@@ -28,6 +28,7 @@ class ProjectParameterRegistry(ProjectRegistry):
             directory / "parameters",
             supported_file_extensions_project_io("load_parameters"),
             load_parameters,
+            item_name="Parameters",
         )
 
     def generate_parameters(

--- a/glotaran/project/project_registry.py
+++ b/glotaran/project/project_registry.py
@@ -12,7 +12,9 @@ from glotaran.utils.ipython import MarkdownStr
 class ProjectRegistry:
     """A registry base class."""
 
-    def __init__(self, directory: Path, file_suffix: str | Iterable[str], loader: Callable):
+    def __init__(
+        self, directory: Path, file_suffix: str | Iterable[str], loader: Callable, item_name: str
+    ):
         """Initialize a registry.
 
         Parameters
@@ -29,6 +31,7 @@ class ProjectRegistry:
             (file_suffix,) if isinstance(file_suffix, str) else tuple(file_suffix)
         )
         self._loader: Callable = loader
+        self._item_name = item_name
 
         self._create_directory_if_not_exist()
 
@@ -102,7 +105,8 @@ class ProjectRegistry:
         if name in self.items:
             return self._loader(self.items[name])
         raise ValueError(
-            f"No Item with name '{name}' exists. Known items are: {list(self.items.keys())}"
+            f"{self._item_name} '{name}' does not exist. "
+            f"Known {self._item_name.rstrip('s')}s are: {list(self.items.keys())}"
         )
 
     def markdown(self, join_indentation: int = 0) -> MarkdownStr:

--- a/glotaran/project/project_registry.py
+++ b/glotaran/project/project_registry.py
@@ -117,7 +117,7 @@ class ProjectRegistry:
             The items of the registry.
         """
         items = {}
-        for path in self._directory.rglob("*"):
+        for path in sorted(self._directory.rglob("*")):
             if self.is_item(path) is True:
                 rel_parent_path = path.parent.relative_to(self._directory)
                 item_key = (rel_parent_path / path.stem).as_posix()

--- a/glotaran/project/project_result_registry.py
+++ b/glotaran/project/project_result_registry.py
@@ -28,6 +28,7 @@ class ProjectResultRegistry(ProjectRegistry):
             directory / "results",
             [],
             lambda path: load_result(path / "result.yml", format_name="yml"),
+            item_name="Result",
         )
 
     def is_item(self, path: Path) -> bool:


### PR DESCRIPTION
This change allows using of files in subfolders for (parameters, models and data) with the project API. 
It handles the ambiguity of files (same file name different extensions next to each other) gracefully by creating unique names and warning the user.

### Change summary

- [♻️ Factor out item name to be an init parameter](https://github.com/glotaran/pyglotaran/commit/0b5e545e99f109e4fca47593bbab6404ee82e10c)
- [✨ Allow usage of subfolders in project parameters, models and data](https://github.com/glotaran/pyglotaran/commit/2ca3ddcc221a3b6c2d10332d53f5ccd5e8af18fd)
- 👌 Gracefully handle and warn the user about ambiguity due to files with the same name but different extensions next to each other
- [♻️ Sort file paths when globbing to make errors deterministic](https://github.com/glotaran/pyglotaran/commit/fb4c1afba79e1f4d999b3200da56de1cc2ab4cb0)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
