### PR TITLE
✨ Allow import of xarray objects in project API import_data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
 - ✨ Integrate plugin system into Project (#1229)
 - 👌 Make yaml the default plugin when passing a folder to save_result and load_result (#1230)
 - ✨ Allow usage of subfolders in project API for parameters, models and data (#1232)
+- ✨ Allow import of xarray objects in project API import_data (#1235)
 
 ### 🩹 Bug fixes
 

--- a/glotaran/project/project.py
+++ b/glotaran/project/project.py
@@ -149,7 +149,7 @@ class Project:
         """
         return self._data_registry.items
 
-    def load_data(self, dataset_name: str) -> xr.Dataset | xr.DataArray:
+    def load_data(self, dataset_name: str) -> xr.Dataset:
         """Load a dataset.
 
         Parameters
@@ -170,11 +170,14 @@ class Project:
 
         .. # noqa: DAR402
         """
-        return self._data_registry.load_item(dataset_name)
+        dataset = self._data_registry.load_item(dataset_name)
+        if isinstance(dataset, xr.DataArray):
+            dataset = dataset.to_dataset(name="data")
+        return dataset
 
     def import_data(
         self,
-        path: str | Path,
+        dataset: str | Path | xr.Dataset | xr.DataArray,
         name: str | None = None,
         allow_overwrite: bool = False,
         ignore_existing: bool = False,
@@ -183,17 +186,18 @@ class Project:
 
         Parameters
         ----------
-        path : str | Path
-            The path to the dataset.
+        dataset : str | Path | xr.Dataset | xr.DataArray
+            Dataset instance or path to a dataset.
         name : str | None
-            The name of the dataset.
+            The name of the dataset (needs to be provided when dataset is an xarray instance).
+            Defaults to None.
         allow_overwrite: bool
             Whether to overwrite an existing dataset.
         ignore_existing: bool
             Whether to ignore import if the dataset already exists.
         """
         self._data_registry.import_data(
-            path, name=name, allow_overwrite=allow_overwrite, ignore_existing=ignore_existing
+            dataset, name=name, allow_overwrite=allow_overwrite, ignore_existing=ignore_existing
         )
 
     @property

--- a/glotaran/project/project_data_registry.py
+++ b/glotaran/project/project_data_registry.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import xarray as xr
+
 from glotaran.io import load_dataset
 from glotaran.io import save_dataset
 from glotaran.plugin_system.data_io_registration import supported_file_extensions_data_io
@@ -29,7 +31,7 @@ class ProjectDataRegistry(ProjectRegistry):
 
     def import_data(
         self,
-        path: str | Path,
+        dataset: str | Path | xr.Dataset | xr.DataArray,
         name: str | None = None,
         allow_overwrite: bool = False,
         ignore_existing: bool = False,
@@ -38,25 +40,39 @@ class ProjectDataRegistry(ProjectRegistry):
 
         Parameters
         ----------
-        path : str | Path
-            The path to the dataset.
+        dataset : str | Path | xr.Dataset | xr.DataArray
+            Dataset instance or path to a dataset.
         name : str | None
-            The name of the dataset.
+            The name of the dataset (needs to be provided when dataset is an xarray instance).
+            Defaults to None.
         allow_overwrite: bool
             Whether to overwrite an existing dataset.
         ignore_existing: bool
             Whether to ignore import if the dataset already exists.
+
+        Raises
+        ------
+        ValueError
+            When importing from xarray object and not providing a name.
         """
-        path = Path(path)
+        if isinstance(dataset, (xr.DataArray, xr.Dataset)) and name is None:
+            raise ValueError(
+                "When importing data from a 'xarray.Dataset' or 'xarray.DataArray' "
+                "it is required to also pass a name."
+            )
+        if isinstance(dataset, xr.DataArray):
+            dataset = dataset.to_dataset(name="data")
 
-        if path.is_absolute() is False:
-            path = (self.directory.parent / path).resolve()
+        if isinstance(dataset, (str, Path)):
+            dataset = Path(dataset)
 
-        name = name or path.stem
+            if dataset.is_absolute() is False:
+                dataset = (self.directory.parent / dataset).resolve()
+
+            name = name or dataset.stem
+            dataset = load_dataset(dataset)
+
         data_path = self.directory / f"{name}.nc"
-
         if data_path.exists() and ignore_existing:
             return
-
-        dataset = load_dataset(path)
         save_dataset(dataset, data_path, allow_overwrite=allow_overwrite)


### PR DESCRIPTION
This makes data importing with the project API more flexible by allowing direct import from `xarray.Dataset` or `xarray.DataArray`.

```py
from glotaran.project import Project

project = Project.open("my_project")

# my_custom_load_function returns a `xarray.Dataset` or `xarray.DataArray`
my_dataset = my_custom_load_function("dataset.foobar")

project.import_data(my_dataset , name="my_dataset ")
```

### Change summary

- [✨ Allow import of xarray objects in project API import_data](https://github.com/glotaran/pyglotaran/commit/909c7db43ce6318ea99237903143c0321a55ffb0)
### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

