### PR TITLE
👌 Refine project API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,8 @@ benchmark/.asv
 # https://github.com/glotaran/pyglotaran-examples/tree/comparison-results
 comparison-results
 comparison-results-current
+
+# Quickstart docs output files
+docs/source/notebooks/quickstart/quickstart_project/data
+docs/source/notebooks/quickstart/quickstart_project/results
+docs/source/notebooks/quickstart/quickstart_project/project.gta

--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,8 @@
 - `<model_file>.clp_area_penalties` -> `<model_file>.clp_penalties`
 - `glotaran.ParameterGroup` -> `glotaran.Parameters`
 - Command Line Interface (removed without replacement) (#1228)
+- `Project.generate_model` (removed without replacement)
+- `Project.generate_parameters` (removed without replacement)
 
 ### 🗑️❌ Deprecated functionality removed in this release
 

--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 - 🩹 Fix model markdown render for items without label (#1213)
 - 🩹 Fix wrong file loading due to partial filename matching in Project (#1212)
 - 🩹 Fix `Project.import_data` path resolving for different script and cwd (#1214)
+- 👌 Refine project API (#1240)
 <!-- Fix within the 0.7.0 release cycle, therefore hidden:
 - 🩹 Fix the matrix provider alignment/reduction ('grouping') issues introduced in #1175 (#1190)
   -->

--- a/glotaran/deprecation/modules/test/test_project_project.py
+++ b/glotaran/deprecation/modules/test/test_project_project.py
@@ -1,0 +1,36 @@
+"""Test deprecations for ``glotaran.project.project``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from glotaran.deprecation.modules.test import deprecation_warning_on_call_test_helper
+from glotaran.project.project import Project
+
+
+def test_project_generate_model(tmp_path: Path):
+    """Trow deprecation warning on ``Project.generate_model`` call."""
+    project = Project.open(tmp_path / "deprecated_project")
+    records, _ = deprecation_warning_on_call_test_helper(
+        project.generate_model,
+        args=("generated_test_model", "decay_parallel", {"nr_compartments": 5}),
+        raise_exception=True,
+    )
+
+    assert len(records) == 1
+
+
+@pytest.mark.filterwarnings(
+    "ignore::glotaran.deprecation.deprecation_utils.GlotaranApiDeprecationWarning"
+)
+def test_project_generate_parameters(tmp_path: Path):
+    """Trow deprecation warning on ``Project.generate_parameters`` call."""
+    project = Project.open(tmp_path / "deprecated_project")
+    project.generate_model("generated_test_model", "decay_parallel", {"nr_compartments": 5})
+    records, _ = deprecation_warning_on_call_test_helper(
+        project.generate_parameters, args=("generated_test_model",), raise_exception=True
+    )
+
+    assert len(records) == 1

--- a/glotaran/plugin_system/io_plugin_utils.py
+++ b/glotaran/plugin_system/io_plugin_utils.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 def infer_file_format(
     file_path: StrOrPath, *, needs_to_exist: bool = True, allow_folder=False
 ) -> str:
-    """Inferr format of a file if it exists.
+    """Infer format of a file if it exists.
 
     Parameters
     ----------
@@ -54,10 +54,11 @@ def infer_file_format(
 
     _, file_format = os.path.splitext(file_path)
     if file_format != "":
-        return file_format.lstrip(".")
+        file_format = file_format.lstrip(".")
+        return "yaml" if file_format == "yml" else file_format
 
     if allow_folder:
-        return "yml"
+        return "yaml"
     else:
         raise ValueError(
             f"Cannot determine format of file {file_path!r}, please provide an explicit format."

--- a/glotaran/plugin_system/test/test_io_plugin_utils.py
+++ b/glotaran/plugin_system/test/test_io_plugin_utils.py
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
             "yaml",
         ),
         (
+            "yml",
+            "yaml",
+        ),
+        (
             "sdt",
             "sdt",
         ),
@@ -31,8 +35,8 @@ if TYPE_CHECKING:
         ),
     ),
 )
-def test_inferr_file_format(tmp_path: Path, extension: str, expected: str):
-    """Inferr type from existing files with extension."""
+def test_infer_file_format(tmp_path: Path, extension: str, expected: str):
+    """Infer type from existing files with extension."""
     file_path = tmp_path / f"dummy.{extension}"
     file_path.touch()
 
@@ -51,13 +55,13 @@ def test_inferr_file_format_no_extension(tmp_path: Path):
 
 
 @pytest.mark.parametrize("is_file", (True, False))
-def test_inferr_file_format_allow_folder(tmp_path: Path, is_file: bool):
+def test_infer_file_format_allow_folder(tmp_path: Path, is_file: bool):
     """If there is no extension, return legacy."""
     file_path = tmp_path / "dummy"
     if is_file:
         file_path.touch()
 
-    assert infer_file_format(file_path, allow_folder=True) == "yml"
+    assert infer_file_format(file_path, allow_folder=True) == "yaml"
 
 
 def test_inferr_file_format_none_existing_file():

--- a/glotaran/project/project.py
+++ b/glotaran/project/project.py
@@ -11,11 +11,14 @@ from textwrap import dedent
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
+from warnings import warn
 
 import pandas as pd
 import xarray as xr
 
 from glotaran.builtin.io.yml.utils import load_dict
+from glotaran.deprecation.deprecation_utils import GlotaranApiDeprecationWarning
+from glotaran.deprecation.deprecation_utils import check_overdue
 from glotaran.io.prepare_dataset import add_svd_to_dataset
 from glotaran.model import Model
 from glotaran.parameter import Parameters
@@ -337,6 +340,14 @@ class Project:
         ignore_existing: bool
             Whether to ignore generation of a model file if it already exists.
         """
+        check_overdue("Project.generate_model", "0.8.0")
+        warn(
+            GlotaranApiDeprecationWarning(
+                "Usage of 'Project.generate_model' was deprecated without replacement.\n"
+                "This usage will be an error in version: '0.8.0'."
+            ),
+            stacklevel=2,
+        )
         self._model_registry.generate_model(
             model_name,
             generator_name,
@@ -454,6 +465,14 @@ class Project:
         ignore_existing: bool
             Whether to ignore generation of a parameter file if it already exists.
         """
+        check_overdue("Project.generate_parameters", "0.8.0")
+        warn(
+            GlotaranApiDeprecationWarning(
+                "Usage of 'Project.generate_parameters' was deprecated without replacement.\n"
+                "This usage will be an error in version: '0.8.0'."
+            ),
+            stacklevel=2,
+        )
         model = self.load_model(model_name)
         parameters_name = (
             parameters_name if parameters_name is not None else f"{model_name}_parameters"

--- a/glotaran/project/project.py
+++ b/glotaran/project/project.py
@@ -24,6 +24,7 @@ from glotaran.project.result import Result
 from glotaran.project.scheme import Scheme
 from glotaran.utils.io import make_path_absolute_if_relative
 from glotaran.utils.ipython import MarkdownStr
+from glotaran.utils.ipython import display_file
 
 TEMPLATE = "version: {gta_version}"
 
@@ -248,6 +249,25 @@ class Project:
         .. # noqa: DAR402
         """
         return self._model_registry.load_item(model_name)
+
+    def show_model_definition(self, model_name: str, syntax: str | None = None) -> MarkdownStr:
+        """Show model definition file content with syntax highlighting.
+
+        Parameters
+        ----------
+        model_name: str
+            The name of the model.
+        syntax: str | None
+            Syntax used for syntax highlighting. Defaults to None which means that the syntax is
+            inferred based on the file extension. Pass the value ``""`` to deactivate syntax
+            highlighting.
+
+        Returns
+        -------
+        MarkdownStr
+            Model definition file content with syntax highlighting to render in ipython.
+        """
+        return display_file(self.models[model_name], syntax=syntax)
 
     def generate_model(
         self,

--- a/glotaran/project/project.py
+++ b/glotaran/project/project.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from dataclasses import field
 from importlib.metadata import distribution
@@ -139,12 +140,12 @@ class Project:
         return not self._data_registry.empty
 
     @property
-    def data(self) -> dict[str, Path]:
+    def data(self) -> Mapping[str, Path]:
         """Get all project datasets.
 
         Returns
         -------
-        dict[str, Path]
+        Mapping[str, Path]
             The models of the datasets.
         """
         return self._data_registry.items
@@ -212,12 +213,12 @@ class Project:
         return not self._model_registry.empty
 
     @property
-    def models(self) -> dict[str, Path]:
+    def models(self) -> Mapping[str, Path]:
         """Get all project models.
 
         Returns
         -------
-        dict[str, Path]
+        Mapping[str, Path]
             The models of the project.
         """
         return self._model_registry.items
@@ -299,12 +300,12 @@ class Project:
         return not self._parameter_registry.empty
 
     @property
-    def parameters(self) -> dict[str, Path]:
+    def parameters(self) -> Mapping[str, Path]:
         """Get all project parameters.
 
         Returns
         -------
-        dict[str, Path]
+        Mapping[str, Path]
             The parameters of the project.
         """
         return self._parameter_registry.items
@@ -391,12 +392,12 @@ class Project:
         return not self._result_registry.empty
 
     @property
-    def results(self) -> dict[str, Path]:
+    def results(self) -> Mapping[str, Path]:
         """Get all project results.
 
         Returns
         -------
-        dict[str, Path]
+        Mapping[str, Path]
             The results of the project.
         """
         return self._result_registry.items

--- a/glotaran/project/project.py
+++ b/glotaran/project/project.py
@@ -11,6 +11,7 @@ from textwrap import dedent
 from typing import Any
 from typing import Literal
 
+import pandas as pd
 import xarray as xr
 
 from glotaran.builtin.io.yml.utils import load_dict
@@ -356,6 +357,35 @@ class Project:
         .. # noqa: DAR402
         """
         return self._parameter_registry.load_item(parameters_name)
+
+    def show_parameters_definition(
+        self, parameters_name: str, syntax: str | None = None, *, as_dataframe: bool | None = None
+    ) -> MarkdownStr | pd.DataFrame:
+        """Show parameters definition file content with syntax highlighting.
+
+        Parameters
+        ----------
+        parameters_name: str
+            The name of the parameters.
+        syntax: str | None
+            Syntax used for syntax highlighting. Defaults to None which means that the syntax is
+            inferred based on the file extension. Pass the value ``""`` to deactivate syntax
+            highlighting.
+        as_dataframe: bool | None
+            Whether or not to show the ``Parameters`` definition as pandas.DataFrame (mostly useful
+            for non string formats). Defaults to None which means that it will be inferred to
+            ``True`` for known non string formats like ``xlsx``.
+
+        Returns
+        -------
+        MarkdownStr | pd.DataFrame
+            Parameters definition file content with syntax highlighting to render in ipython.
+        """
+        if as_dataframe is True or (
+            as_dataframe is None and self.parameters[parameters_name].suffix in [".xlsx", ".ods"]
+        ):
+            return self.load_parameters(parameters_name).to_dataframe()
+        return display_file(self.parameters[parameters_name], syntax=syntax)
 
     def generate_parameters(
         self,

--- a/glotaran/project/project.py
+++ b/glotaran/project/project.py
@@ -179,7 +179,7 @@ class Project:
     def import_data(
         self,
         dataset: str | Path | xr.Dataset | xr.DataArray,
-        name: str | None = None,
+        dataset_name: str | None = None,
         allow_overwrite: bool = False,
         ignore_existing: bool = False,
     ):
@@ -189,7 +189,7 @@ class Project:
         ----------
         dataset : str | Path | xr.Dataset | xr.DataArray
             Dataset instance or path to a dataset.
-        name : str | None
+        dataset_name : str | None
             The name of the dataset (needs to be provided when dataset is an xarray instance).
             Defaults to None.
         allow_overwrite: bool
@@ -198,7 +198,10 @@ class Project:
             Whether to ignore import if the dataset already exists.
         """
         self._data_registry.import_data(
-            dataset, name=name, allow_overwrite=allow_overwrite, ignore_existing=ignore_existing
+            dataset,
+            dataset_name=dataset_name,
+            allow_overwrite=allow_overwrite,
+            ignore_existing=ignore_existing,
         )
 
     @property
@@ -223,12 +226,12 @@ class Project:
         """
         return self._model_registry.items
 
-    def load_model(self, name: str) -> Model:
+    def load_model(self, model_name: str) -> Model:
         """Load a model.
 
         Parameters
         ----------
-        name : str
+        model_name : str
             The name of the model.
 
         Returns
@@ -244,7 +247,7 @@ class Project:
 
         .. # noqa: DAR402
         """
-        return self._model_registry.load_item(name)
+        return self._model_registry.load_item(model_name)
 
     def generate_model(
         self,

--- a/glotaran/project/project.py
+++ b/glotaran/project/project.py
@@ -39,7 +39,7 @@ class Project:
     version: str = field(init=False)
 
     file: Path
-    folder: Path | None = field(default=None)
+    folder: Path = field(default=None)  # type:ignore[assignment]
 
     def __post_init__(self):
         """Overwrite of post init."""
@@ -577,11 +577,10 @@ class Project:
         MarkdownStr : str
             The markdown string.
         """
-        folder_as_posix = self.folder.as_posix()  # type:ignore[union-attr]
         md = f"""\
-            # Project _{folder_as_posix}_
+            # Project (_{self.folder.name}_)
 
-            pyglotaran version: {self.version}
+            pyglotaran version: `{self.version}`
 
             ## Data
 

--- a/glotaran/project/project.py
+++ b/glotaran/project/project.py
@@ -543,7 +543,7 @@ class Project:
         result_name: str | None = None,
         maximum_number_function_evaluations: int | None = None,
         clp_link_tolerance: float = 0.0,
-    ):
+    ) -> Result:
         """Optimize a model.
 
         Parameters
@@ -558,6 +558,11 @@ class Project:
             The maximum number of function evaluations.
         clp_link_tolerance : float
             The CLP link tolerance.
+
+        Returns
+        -------
+        Result
+            Result of the optimization.
         """
         from glotaran.optimization.optimize import optimize
 
@@ -568,6 +573,7 @@ class Project:
 
         result_name = result_name or model_name
         self._result_registry.save(result_name, result)
+        return result
 
     def markdown(self) -> MarkdownStr:
         """Format the project as a markdown text.

--- a/glotaran/project/project.py
+++ b/glotaran/project/project.py
@@ -290,6 +290,29 @@ class Project:
         """
         return display_file(self.models[model_name], syntax=syntax)
 
+    def validate(self, model_name: str, parameters_name: str | None = None) -> MarkdownStr:
+        """Check that the model is valid, list all issues in the model if there are any.
+
+        If ``parameters_name`` also consider the ``Parameters`` when validating.
+
+        Parameters
+        ----------
+        model_name: str
+            The name of the model to validate.
+        parameters_name: str | None
+            The name of the parameters to use when validating. Defaults to ``None`` which means
+            that parameters are not considered when validating the model.
+
+        Returns
+        -------
+        MarkdownStr
+            Text indicating if the model is valid or not.
+        """
+        model = self.load_model(model_name)
+        return model.validate(
+            self.load_parameters(parameters_name) if parameters_name is not None else None
+        )
+
     def generate_model(
         self,
         model_name: str,

--- a/glotaran/project/project_data_registry.py
+++ b/glotaran/project/project_data_registry.py
@@ -32,7 +32,7 @@ class ProjectDataRegistry(ProjectRegistry):
     def import_data(
         self,
         dataset: str | Path | xr.Dataset | xr.DataArray,
-        name: str | None = None,
+        dataset_name: str | None = None,
         allow_overwrite: bool = False,
         ignore_existing: bool = False,
     ):
@@ -42,7 +42,7 @@ class ProjectDataRegistry(ProjectRegistry):
         ----------
         dataset : str | Path | xr.Dataset | xr.DataArray
             Dataset instance or path to a dataset.
-        name : str | None
+        dataset_name : str | None
             The name of the dataset (needs to be provided when dataset is an xarray instance).
             Defaults to None.
         allow_overwrite: bool
@@ -55,10 +55,10 @@ class ProjectDataRegistry(ProjectRegistry):
         ValueError
             When importing from xarray object and not providing a name.
         """
-        if isinstance(dataset, (xr.DataArray, xr.Dataset)) and name is None:
+        if isinstance(dataset, (xr.DataArray, xr.Dataset)) and dataset_name is None:
             raise ValueError(
                 "When importing data from a 'xarray.Dataset' or 'xarray.DataArray' "
-                "it is required to also pass a name."
+                "it is required to also pass a ``dataset_name``."
             )
         if isinstance(dataset, xr.DataArray):
             dataset = dataset.to_dataset(name="data")
@@ -69,10 +69,10 @@ class ProjectDataRegistry(ProjectRegistry):
             if dataset.is_absolute() is False:
                 dataset = (self.directory.parent / dataset).resolve()
 
-            name = name or dataset.stem
+            dataset_name = dataset_name or dataset.stem
             dataset = load_dataset(dataset)
 
-        data_path = self.directory / f"{name}.nc"
+        data_path = self.directory / f"{dataset_name}.nc"
         if data_path.exists() and ignore_existing:
             return
         save_dataset(dataset, data_path, allow_overwrite=allow_overwrite)

--- a/glotaran/project/project_registry.py
+++ b/glotaran/project/project_registry.py
@@ -96,6 +96,14 @@ class ItemMapping(Mapping):
         """Protocol method used by ``len``."""
         return len(self.data)
 
+    def __eq__(self, other: object) -> bool:
+        """Protocol method used for equality checks."""
+        if isinstance(other, ItemMapping):
+            return self.data == other.data
+        if isinstance(other, Mapping):  # sourcery skip: assign-if-exp
+            return self.data == other
+        return NotImplemented
+
     def __repr__(self) -> str:
         """Protocol method used to display instance."""
         return repr(self.data)

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -73,6 +73,10 @@ def test_open(project_folder: Path, project_file: Path):
 
     project = project_from_file
 
+    assert (project_folder / "data").is_dir()
+    assert (project_folder / "models").is_dir()
+    assert (project_folder / "parameters").is_dir()
+
     assert project.version == gta_version
     assert not project.has_models
     assert not project.has_data

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -372,6 +372,16 @@ def test_generators_allow_overwrite(project_folder: Path, project_file: Path):
     assert len(list(filter(lambda p: p.label.startswith("rates"), parameters.all()))) == 3
 
 
+def test_show_model_definition(tmp_path: Path):
+    """Syntax is correct inferred and expected file content."""
+    project = Project.open(tmp_path)
+    file_content = "foo:\n  bar"
+
+    (tmp_path / "models/yml_model.yml").write_text(file_content)
+
+    assert str(project.show_model_definition("yml_model")) == "```yaml\nfoo:\n  bar\n```"
+
+
 def test_import_data_relative_paths_script_folder_not_cwd(
     tmp_path: Path, monkeypatch: MonkeyPatch
 ):

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -566,41 +566,69 @@ def test_missing_file_errors(tmp_path: Path, project_folder: Path):
         "it is required to also pass a name."
     )
 
-    with pytest.raises(ValueError) as exc_info:
-        project.load_data("not-existing")
-
-    assert str(exc_info.value) == (
+    no_exist_data_error_msg = (
         "Dataset 'not-existing' does not exist. "
         "Known Datasets are: ['dataset_1', 'dataset_1-bad', 'test_data']"
     )
 
     with pytest.raises(ValueError) as exc_info:
-        project.load_model("not-existing")
+        project.data["not-existing"]
 
-    assert str(exc_info.value) == (
+    assert str(exc_info.value) == no_exist_data_error_msg
+
+    with pytest.raises(ValueError) as exc_info:
+        project.load_data("not-existing")
+
+    assert str(exc_info.value) == no_exist_data_error_msg
+
+    no_exist_model_error_msg = (
         "Model 'not-existing' does not exist. "
         "Known Models are: ['test_model', 'test_model-bad']"
     )
 
     with pytest.raises(ValueError) as exc_info:
-        project.load_parameters("not-existing")
+        project.models["not-existing"]
 
-    assert str(exc_info.value) == (
+    assert str(exc_info.value) == no_exist_model_error_msg
+
+    with pytest.raises(ValueError) as exc_info:
+        project.load_model("not-existing")
+
+    assert str(exc_info.value) == no_exist_model_error_msg
+
+    no_exist_parameters_error_msg = (
         "Parameters 'not-existing' does not exist. "
         "Known Parameters are: ['test_parameters', 'test_parameters-bad']"
     )
 
     with pytest.raises(ValueError) as exc_info:
-        project.load_result("not-existing_run_0000")
+        project.parameters["not-existing"]
+
+    assert str(exc_info.value) == no_exist_parameters_error_msg
+
+    with pytest.raises(ValueError) as exc_info:
+        project.load_parameters("not-existing")
+
+    assert str(exc_info.value) == no_exist_parameters_error_msg
 
     expected_known_results = (
         "Known Results are: "
         "['sequential_run_0000', 'sequential_run_0001', 'test_run_0000', 'test_run_0001']"
     )
 
-    assert str(exc_info.value) == (
+    no_exist_full_result_name_error_msg = (
         f"Result 'not-existing_run_0000' does not exist. {expected_known_results}"
     )
+
+    with pytest.raises(ValueError) as exc_info:
+        project.results["not-existing_run_0000"]
+
+    assert str(exc_info.value) == no_exist_full_result_name_error_msg
+
+    with pytest.raises(ValueError) as exc_info:
+        project.load_result("not-existing_run_0000")
+
+    assert str(exc_info.value) == no_exist_full_result_name_error_msg
 
     with pytest.raises(ValueError) as exc_info:
         project.load_latest_result("not-existing")

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -378,6 +378,21 @@ def test_generators_allow_overwrite(project_folder: Path, project_file: Path):
     assert len(list(filter(lambda p: p.label.startswith("rates"), parameters.all()))) == 3
 
 
+def test_validate(project_file: Path):
+    """Validation works"""
+    project = Project.open(project_file)
+
+    assert str(project.validate("test_model")) == "Your model is valid."
+    assert str(project.validate("test_model", "test_parameters")) == "Your model is valid."
+
+    bad_parameters_path = project_file.parent / "parameters/bad_parameters.yml"
+    bad_parameters_path.write_text("pure_list: [1.0]")
+    assert str(project.validate("test_model", "bad_parameters")).startswith(
+        "Your model has 3 problems"
+    )
+    bad_parameters_path.unlink()
+
+
 def test_show_model_definition(tmp_path: Path):
     """Syntax is correct inferred and expected file content."""
     project = Project.open(tmp_path)

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -21,6 +21,7 @@ from glotaran.io import save_dataset
 from glotaran.io import save_parameters
 from glotaran.project.project import Project
 from glotaran.project.project_registry import AmbiguousNameWarning
+from glotaran.project.project_registry import ItemMapping
 from glotaran.project.result import Result
 from glotaran.testing.simulated_data.sequential_spectral_decay import DATASET as example_dataset
 from glotaran.testing.simulated_data.sequential_spectral_decay import (
@@ -82,6 +83,31 @@ def dummy_results(persistent_result: Path, existing_project: Project):
         "test_run_0001",
     ):
         copytree(persistent_result, existing_project.folder / f"results/{dummy_result_folder}")
+
+
+def test_item_mapping():
+    """Test all protocol methods work as expected"""
+    data = {"foo": Path("foo"), "bar": Path("bar")}
+    item_mapping = ItemMapping(data, "test")
+
+    assert len(item_mapping) == 2
+
+    assert repr(item_mapping) == repr({"bar": Path("bar"), "foo": Path("foo")})
+
+    assert item_mapping["foo"] == Path("foo")
+
+    assert item_mapping == ItemMapping(data, "test")
+    assert item_mapping == ItemMapping(data, "test2")
+    assert item_mapping == data
+
+    assert "foo" in item_mapping
+
+    assert dict(item_mapping.items()) == data
+
+    with pytest.raises(ValueError) as exc_info:
+        item_mapping["baz"]
+
+    assert str(exc_info.value) == ("test 'baz' does not exist. Known tests are: ['bar', 'foo']")
 
 
 def test_init(tmp_path: Path):

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -32,23 +32,23 @@ from glotaran.utils.io import chdir_context
 
 
 @pytest.fixture(scope="module")
-def project_folder(tmpdir_factory):
-    return Path(tmpdir_factory.mktemp("test_project"))
+def project_folder(tmp_path_factory):
+    return tmp_path_factory.mktemp("test_project", numbered=False)
 
 
 @pytest.fixture(scope="module")
 def project_file(project_folder: Path):
-    return Path(project_folder) / "project.gta"
+    return project_folder / "project.gta"
 
 
 @pytest.fixture(scope="module")
-def test_data(tmpdir_factory):
-    path = Path(tmpdir_factory.mktemp("test_project")) / "dataset_1.nc"
+def test_data(project_folder):
+    path = project_folder / "dataset_1.nc"
     save_dataset(example_dataset, path)
     return path
 
 
-def test_init(project_folder: Path, project_file: Path):
+def test_init(project_file: Path):
     """Init project directly."""
     file_only_init = Project(project_file)
     file_and_folder_init = Project(project_file)
@@ -624,9 +624,9 @@ def test_markdown_repr(project_folder: Path, project_file: Path):
     project = Project.open(project_file)
 
     expected = f"""\
-        # Project _{project_folder.as_posix()}_
+        # Project (_test_project_)
 
-        pyglotaran version: {distribution('pyglotaran').version}
+        pyglotaran version: `{distribution('pyglotaran').version}`
 
         ## Data
 

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -200,7 +200,12 @@ def test_import_data(project_folder: Path, project_file: Path, test_data: Path, 
     assert project.has_data
 
     data = project.load_data("dataset_1" if name is None else name)
-    assert data == example_dataset
+    assert data.equals(example_dataset)
+
+    data_with_svd = project.load_data("dataset_1" if name is None else name, add_svd=True)
+    assert "data_left_singular_vectors" in data_with_svd
+    assert "data_singular_values" in data_with_svd
+    assert "data_right_singular_vectors" in data_with_svd
 
 
 @pytest.mark.parametrize(

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -182,12 +182,12 @@ def test_generate_parameters(
 def test_import_data(project_folder: Path, project_file: Path, test_data: Path, name: str | None):
     project = Project.open(project_file)
 
-    project.import_data(test_data, name=name)
+    project.import_data(test_data, dataset_name=name)
     with pytest.raises(FileExistsError):
-        project.import_data(test_data, name=name)
+        project.import_data(test_data, dataset_name=name)
 
-    project.import_data(test_data, name=name, allow_overwrite=True)
-    project.import_data(test_data, name=name, ignore_existing=True)
+    project.import_data(test_data, dataset_name=name, allow_overwrite=True)
+    project.import_data(test_data, dataset_name=name, ignore_existing=True)
 
     data_folder = project_folder / "data"
     assert data_folder.exists()
@@ -212,7 +212,7 @@ def test_import_data(project_folder: Path, project_file: Path, test_data: Path, 
 def test_import_data_xarray(tmp_path: Path, data: xr.Dataset | xr.DataArray):
     """Loaded data are always a dataset."""
     project = Project.open(tmp_path)
-    project.import_data(data, name="test_data")
+    project.import_data(data, dataset_name="test_data")
 
     assert (tmp_path / "data/test_data.nc").is_file() is True
 
@@ -396,10 +396,10 @@ def test_import_data_relative_paths_script_folder_not_cwd(
         project = Project.open("project.gta")
         assert (script_folder / "project.gta").is_file() is True
 
-        project.import_data(f"../{cwd_data_import_path}", name="dataset_1")
+        project.import_data(f"../{cwd_data_import_path}", dataset_name="dataset_1")
         assert (script_folder / "data/dataset_1.nc").is_file() is True
 
-        project.import_data(script_folder_data_import_path, name="dataset_2")
+        project.import_data(script_folder_data_import_path, dataset_name="dataset_2")
         assert (script_folder / "data/dataset_2.nc").is_file() is True
 
 
@@ -555,7 +555,7 @@ def test_missing_file_errors(tmp_path: Path, project_folder: Path):
 
     assert str(exc_info.value) == (
         "When importing data from a 'xarray.Dataset' or 'xarray.DataArray' "
-        "it is required to also pass a name."
+        "it is required to also pass a ``dataset_name``."
     )
 
     with pytest.raises(ValueError) as exc_info:
@@ -563,7 +563,7 @@ def test_missing_file_errors(tmp_path: Path, project_folder: Path):
 
     assert str(exc_info.value) == (
         "When importing data from a 'xarray.Dataset' or 'xarray.DataArray' "
-        "it is required to also pass a name."
+        "it is required to also pass a ``dataset_name``."
     )
 
     no_exist_data_error_msg = (

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -253,12 +253,13 @@ def test_run_optimization(project_folder: Path, project_file: Path, name: str | 
     name = name or "sequential"
 
     for i in range(2):
-        project.optimize(
+        result = project.optimize(
             model_name="sequential",
             parameters_name="sequential",
             maximum_number_function_evaluations=1,
             result_name=name,
         )
+        assert isinstance(result, Result)
         assert project.has_results
         result_name = f"{name}_run_000{i}"
         assert (project_folder / "results" / result_name).exists()

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -128,6 +128,9 @@ def test_open_diff_version(tmp_path: Path):
     assert project.version == "0.1.0"
 
 
+@pytest.mark.filterwarnings(
+    "ignore::glotaran.deprecation.deprecation_utils.GlotaranApiDeprecationWarning"
+)
 def test_generate_model(tmp_path: Path):
     project = Project.open(tmp_path / "test_project")
 
@@ -165,6 +168,9 @@ def test_generate_model(tmp_path: Path):
     )
 
 
+@pytest.mark.filterwarnings(
+    "ignore::glotaran.deprecation.deprecation_utils.GlotaranApiDeprecationWarning"
+)
 @pytest.mark.parametrize("name", ["test_parameter", None])
 @pytest.mark.parametrize("fmt", ["yml", "yaml", "csv"])
 def test_generate_parameters(tmp_path: Path, name: str | None, fmt: Literal["yml", "yaml", "csv"]):
@@ -582,6 +588,9 @@ def test_parameters_subfolder_folders(tmp_path: Path):
             )
 
 
+@pytest.mark.filterwarnings(
+    "ignore::glotaran.deprecation.deprecation_utils.GlotaranApiDeprecationWarning"
+)
 def test_generators_allow_overwrite(existing_project: Project):
     """Overwrite doesn't throw an exception.
     This is the last test not to interfere with other tests.

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from importlib.metadata import distribution
 from pathlib import Path
-from shutil import rmtree
+from shutil import copytree
 from textwrap import dedent
 from typing import Literal
 
@@ -32,62 +32,90 @@ from glotaran.testing.simulated_data.sequential_spectral_decay import (
 from glotaran.utils.io import chdir_context
 
 
-@pytest.fixture(scope="module")
-def project_folder(tmp_path_factory):
-    return tmp_path_factory.mktemp("test_project", numbered=False)
+def create_populated_project(root_path: Path) -> Project:
+    """Helper function to create"""
+    project_folder = root_path / "test_project"
+    project = Project.open(project_folder)
+
+    input_data = project_folder / "data/dataset_1.nc"
+    save_dataset(example_dataset, input_data)
+
+    model_file = project_folder / "models/test_model.yml"
+    model_file.write_text(example_model_yml)
+
+    parameters_file = project_folder / "parameters/test_parameters.csv"
+    save_parameters(example_parameter, parameters_file, allow_overwrite=True)
+
+    # Will cause tests to fails on bad fuzzy matching due to higher string sort order
+    (project_folder / "data/dataset_1-bad.nc").touch()
+    (project_folder / "models/test_model-bad.yml").touch()
+    (project_folder / "parameters/test_parameters-bad.yml").touch()
+    return project
 
 
-@pytest.fixture(scope="module")
-def project_file(project_folder: Path):
-    return project_folder / "project.gta"
+@pytest.fixture
+def existing_project(tmp_path: Path):
+    return create_populated_project(tmp_path)
 
 
-@pytest.fixture(scope="module")
-def test_data(project_folder):
-    path = project_folder / "dataset_1.nc"
-    save_dataset(example_dataset, path)
-    return path
+@pytest.fixture(scope="session")
+def persistent_result(tmp_path_factory: pytest.TempPathFactory):
+    """Create a dummy result once per session."""
+    root_path = tmp_path_factory.mktemp("tmp_project")
+    project = create_populated_project(root_path)
+    project.optimize(
+        model_name="test_model",
+        parameters_name="test_parameters",
+        maximum_number_function_evaluations=1,
+        result_name="tmp",
+    )
+    return root_path / "test_project/results/tmp_run_0000"
 
 
-def test_init(project_file: Path):
+@pytest.fixture
+def dummy_results(persistent_result: Path, existing_project: Project):
+    """Create same results as if ``test_run_optimization`` was run with persistence."""
+    for dummy_result_folder in (
+        "sequential_run_0000",
+        "sequential_run_0001",
+        "test_run_0000",
+        "test_run_0001",
+    ):
+        copytree(persistent_result, existing_project.folder / f"results/{dummy_result_folder}")
+
+
+def test_init(tmp_path: Path):
     """Init project directly."""
-    file_only_init = Project(project_file)
-    file_and_folder_init = Project(project_file)
+    file_only_init = Project(tmp_path / "project.gta")
+    file_and_folder_init = Project(tmp_path / "project.gta")
 
     assert file_only_init == file_and_folder_init
 
 
-def test_create(project_folder: Path):
-    rmtree(project_folder)
-    Project.create(project_folder)
+def test_create(tmp_path: Path):
+    Project.create(tmp_path)
     with pytest.raises(FileExistsError):
-        assert Project.create(project_folder)
+        assert Project.create(tmp_path)
 
 
-def test_open(project_folder: Path, project_file: Path):
-    rmtree(project_folder)
-    project_from_folder = Project.open(project_folder)
+def test_open(tmp_path: Path):
+    project_from_folder = Project.open(tmp_path)
 
-    project_from_file = Project.open(project_file)
+    project_from_file = Project.open(tmp_path / "project.gta")
 
     assert project_from_folder == project_from_file
 
     project = project_from_file
 
-    assert (project_folder / "data").is_dir()
-    assert (project_folder / "models").is_dir()
-    assert (project_folder / "parameters").is_dir()
+    assert (tmp_path / "data").is_dir()
+    assert (tmp_path / "models").is_dir()
+    assert (tmp_path / "parameters").is_dir()
 
     assert project.version == gta_version
     assert not project.has_models
     assert not project.has_data
     assert not project.has_parameters
     assert not project.has_results
-
-    # Will cause following tests to fails on bad fuzzy matching due to higher string sort order
-    (project_folder / "data/dataset_1-bad.nc").touch()
-    (project_folder / "models/test_model-bad.yml").touch()
-    (project_folder / "parameters/test_parameters-bad.yml").touch()
 
 
 def test_open_diff_version(tmp_path: Path):
@@ -100,67 +128,70 @@ def test_open_diff_version(tmp_path: Path):
     assert project.version == "0.1.0"
 
 
-def test_generate_model(project_folder: Path, project_file: Path):
-    project = Project.open(project_file)
+def test_generate_model(tmp_path: Path):
+    project = Project.open(tmp_path / "test_project")
 
-    project.generate_model("test_model", "decay_parallel", {"nr_compartments": 5})
+    project.generate_model("generated_test_model", "decay_parallel", {"nr_compartments": 5})
 
-    model_folder = project_folder / "models"
+    model_folder = tmp_path / "test_project/models"
     assert model_folder.is_dir()
 
     project.generate_model(
-        "test_model", "decay_parallel", {"nr_compartments": 5}, ignore_existing=True
+        "generated_test_model", "decay_parallel", {"nr_compartments": 5}, ignore_existing=True
     )
 
     assert project.get_models_directory() == model_folder
 
-    model_file = model_folder / "test_model.yml"
+    model_file = model_folder / "generated_test_model.yml"
     assert model_file.is_file()
 
     assert project.has_models
 
-    model = project.load_model("test_model")
+    model = project.load_model("generated_test_model")
     assert "megacomplex_parallel_decay" in model.megacomplex
 
-    comapartments = load_dict(model_file, is_file=True)["megacomplex"][
+    compartments = load_dict(model_file, is_file=True)["megacomplex"][
         "megacomplex_parallel_decay"
     ]["compartments"]
 
-    assert len(comapartments) == 5
+    assert len(compartments) == 5
 
     with pytest.raises(FileExistsError) as exc_info:
-        project.generate_model("test_model", "decay_parallel", {"nr_compartments": 5})
+        project.generate_model("generated_test_model", "decay_parallel", {"nr_compartments": 5})
 
-    assert str(exc_info.value) == "Model 'test_model' already exists and `allow_overwrite=False`."
+    assert (
+        str(exc_info.value)
+        == "Model 'generated_test_model' already exists and `allow_overwrite=False`."
+    )
 
 
 @pytest.mark.parametrize("name", ["test_parameter", None])
 @pytest.mark.parametrize("fmt", ["yml", "yaml", "csv"])
-def test_generate_parameters(
-    project_folder: Path, project_file: Path, name: str | None, fmt: Literal["yml", "yaml", "csv"]
-):
-    project = Project.open(project_file)
+def test_generate_parameters(tmp_path: Path, name: str | None, fmt: Literal["yml", "yaml", "csv"]):
+    project = Project.open(tmp_path / "test_project")
+
+    project.generate_model("generated_test_model", "decay_parallel", {"nr_compartments": 5})
 
     assert project.has_models
 
-    project.generate_parameters("test_model", parameters_name=name, format_name=fmt)
+    project.generate_parameters("generated_test_model", parameters_name=name, format_name=fmt)
 
-    parameter_folder = project_folder / "parameters"
+    parameter_folder = tmp_path / "test_project/parameters"
     assert parameter_folder.is_dir()
 
     project.generate_parameters(
-        "test_model", parameters_name=name, format_name=fmt, ignore_existing=True
+        "generated_test_model", parameters_name=name, format_name=fmt, ignore_existing=True
     )
 
-    parameter_file_name = f"{'test_model_parameters' if name is None else name}.{fmt}"
+    parameter_file_name = f"{'generated_test_model_parameters' if name is None else name}.{fmt}"
     parameter_file = parameter_folder / parameter_file_name
     assert parameter_file.is_file()
     assert project.get_parameters_directory() == parameter_folder
 
     assert project.has_parameters
 
-    parameters_key = "test_model_parameters" if name is None else name
-    model = project.load_model("test_model")
+    parameters_key = "generated_test_model_parameters" if name is None else name
+    model = project.load_model("generated_test_model")
     parameters = project.load_parameters(parameters_key)
 
     for parameter in model.get_parameter_labels():
@@ -169,19 +200,20 @@ def test_generate_parameters(
     assert len(list(filter(lambda p: p.label.startswith("rates"), parameters.all()))) == 5
 
     with pytest.raises(FileExistsError) as exc_info:
-        project.generate_parameters("test_model", parameters_name=name, format_name=fmt)
+        project.generate_parameters("generated_test_model", parameters_name=name, format_name=fmt)
 
     assert (
         str(exc_info.value)
         == f"Parameters '{parameters_key}' already exists and `allow_overwrite=False`."
     )
 
-    parameter_file.unlink()
-
 
 @pytest.mark.parametrize("name", ["test_data", None])
-def test_import_data(project_folder: Path, project_file: Path, test_data: Path, name: str | None):
-    project = Project.open(project_file)
+def test_import_data(tmp_path: Path, name: str | None):
+    project = Project.open(tmp_path / "test_project")
+
+    test_data = tmp_path / "import_data.nc"
+    save_dataset(example_dataset, test_data)
 
     project.import_data(test_data, dataset_name=name)
     with pytest.raises(FileExistsError):
@@ -190,19 +222,18 @@ def test_import_data(project_folder: Path, project_file: Path, test_data: Path, 
     project.import_data(test_data, dataset_name=name, allow_overwrite=True)
     project.import_data(test_data, dataset_name=name, ignore_existing=True)
 
-    data_folder = project_folder / "data"
-    assert data_folder.exists()
+    data_folder = tmp_path / "test_project/data"
 
-    data_file_name = f"{'dataset_1' if name is None else name}.nc"
+    data_file_name = f"{'import_data' if name is None else name}.nc"
     data_file = data_folder / data_file_name
     assert data_file.exists()
 
     assert project.has_data
 
-    data = project.load_data("dataset_1" if name is None else name)
+    data = project.load_data("import_data" if name is None else name)
     assert data.equals(example_dataset)
 
-    data_with_svd = project.load_data("dataset_1" if name is None else name, add_svd=True)
+    data_with_svd = project.load_data("import_data" if name is None else name, add_svd=True)
     assert "data_left_singular_vectors" in data_with_svd
     assert "data_singular_values" in data_with_svd
     assert "data_right_singular_vectors" in data_with_svd
@@ -225,11 +256,8 @@ def test_import_data_xarray(tmp_path: Path, data: xr.Dataset | xr.DataArray):
     assert project.load_data("test_data").equals(xr.Dataset({"data": xr.DataArray([1])}))
 
 
-def test_create_scheme(project_file: Path):
-    project = Project.open(project_file)
-
-    project.generate_parameters("test_model", parameters_name="test_parameters")
-    scheme = project.create_scheme(
+def test_create_scheme(existing_project: Project):
+    scheme = existing_project.create_scheme(
         model_name="test_model",
         parameters_name="test_parameters",
         maximum_number_function_evaluations=1,
@@ -240,68 +268,56 @@ def test_create_scheme(project_file: Path):
     assert scheme.maximum_number_function_evaluations == 1
 
 
-@pytest.mark.parametrize("name", ["test", None])
-def test_run_optimization(project_folder: Path, project_file: Path, name: str | None):
-    project = Project.open(project_file)
+@pytest.mark.parametrize("result_name", ["test", None])
+def test_run_optimization(existing_project: Project, result_name: str | None):
+    assert existing_project.has_models
+    assert existing_project.has_parameters
+    assert existing_project.has_data
 
-    model_file = project_folder / "models" / "sequential.yml"
-    model_file.write_text(example_model_yml)
-
-    parameters_file = project_folder / "parameters" / "sequential.csv"
-    save_parameters(example_parameter, parameters_file, allow_overwrite=True)
-
-    data_folder = project_folder / "data"
-    assert data_folder.exists()
-    data_file = data_folder / "dataset_1.nc"
-    data_file.unlink()
-    save_dataset(example_dataset, data_file)
-
-    assert project.has_models
-    assert project.has_parameters
-    assert project.has_data
-
-    name = name or "sequential"
+    result_name = result_name or "sequential"
 
     for i in range(2):
-        result = project.optimize(
-            model_name="sequential",
-            parameters_name="sequential",
+        result = existing_project.optimize(
+            model_name="test_model",
+            parameters_name="test_parameters",
             maximum_number_function_evaluations=1,
-            result_name=name,
+            result_name=result_name,
         )
         assert isinstance(result, Result)
-        assert project.has_results
-        result_name = f"{name}_run_000{i}"
-        assert (project_folder / "results" / result_name).exists()
-    model_file.unlink()
-    parameters_file.unlink()
+        assert existing_project.has_results
+        assert (existing_project.folder / f"results/{result_name}_run_000{i}").exists()
 
 
-def test_load_result(project_folder: Path, project_file: Path, recwarn: WarningsRecorder):
+@pytest.mark.usefixtures("dummy_results")
+def test_load_result(existing_project: Project, recwarn: WarningsRecorder):
     """No warnings if name contains run specifier or latest is true."""
-    project = Project.open(project_file)
 
-    assert project_folder / "results" / "test_run_0000" == project.get_result_path("test_run_0000")
+    assert existing_project.folder / "results/test_run_0000" == existing_project.get_result_path(
+        "test_run_0000"
+    )
 
-    result = project.load_result("test_run_0000")
+    result = existing_project.load_result("test_run_0000")
     assert isinstance(result, Result)
 
-    assert project_folder / "results" / "test_run_0001" == project.get_result_path(
+    assert existing_project.folder / "results/test_run_0001" == existing_project.get_result_path(
         "test", latest=True
     )
 
-    assert isinstance(project.load_result("test", latest=True), Result)
+    assert isinstance(existing_project.load_result("test", latest=True), Result)
 
-    assert project_folder / "results" / "test_run_0001" == project.get_latest_result_path("test")
+    assert (
+        existing_project.folder / "results/test_run_0001"
+        == existing_project.get_latest_result_path("test")
+    )
 
-    assert isinstance(project.load_latest_result("test"), Result)
+    assert isinstance(existing_project.load_latest_result("test"), Result)
 
     assert len(recwarn) == 0
 
 
-def test_load_result_warnings(project_folder: Path, project_file: Path):
+@pytest.mark.usefixtures("dummy_results")
+def test_load_result_warnings(existing_project: Project):
     """Warn when using fallback to latest result."""
-    project = Project.open(project_file)
 
     expected_warning_text = (
         "Result name 'test' is missing the run specifier, "
@@ -310,85 +326,54 @@ def test_load_result_warnings(project_folder: Path, project_file: Path):
     )
 
     with pytest.warns(UserWarning) as recwarn:
-        assert project_folder / "results" / "test_run_0001" == project.get_result_path("test")
+        assert (
+            existing_project.folder / "results/test_run_0001"
+            == existing_project.get_result_path("test")
+        )
 
         assert len(recwarn) == 1
         assert Path(recwarn[0].filename).samefile(__file__)
         assert recwarn[0].message.args[0] == expected_warning_text
 
     with pytest.warns(UserWarning) as recwarn:
-        assert isinstance(project.load_result("test"), Result)
+        assert isinstance(existing_project.load_result("test"), Result)
 
         assert len(recwarn) == 1
         assert Path(recwarn[0].filename).samefile(__file__)
         assert recwarn[0].message.args[0] == expected_warning_text
 
 
-def test_getting_items(project_file: Path):
+@pytest.mark.usefixtures("dummy_results")
+def test_getting_items(existing_project: Project):
     """Warn when using fallback to latest result."""
-    project = Project.open(project_file)
 
-    assert "dataset_1" in project.data
-    assert project.data["dataset_1"].is_file()
+    assert "dataset_1" in existing_project.data
+    assert existing_project.data["dataset_1"].is_file()
 
-    assert "test_model" in project.models
-    assert project.models["test_model"].is_file()
+    assert "test_model" in existing_project.models
+    assert existing_project.models["test_model"].is_file()
 
-    assert "test_parameters" in project.parameters
-    assert project.parameters["test_parameters"].is_file()
+    assert "test_parameters" in existing_project.parameters
+    assert existing_project.parameters["test_parameters"].is_file()
 
-    assert "test_run_0000" in project.results
-    assert project.results["test_run_0000"].is_dir()
-    assert "test_run_0001" in project.results
-    assert project.results["test_run_0001"].is_dir()
-
-
-def test_generators_allow_overwrite(project_folder: Path, project_file: Path):
-    """Overwrite doesn't throw an exception.
-
-    This is the last test not to interfere with other tests.
-    """
-    project = Project.open(project_file)
-
-    model_file = project_folder / "models/test_model.yml"
-    assert model_file.is_file()
-
-    parameter_file = project_folder / "parameters/test_parameters.csv"
-    assert parameter_file.is_file()
-
-    parameters = load_parameters(parameter_file)
-
-    assert len(list(filter(lambda p: p.label.startswith("rates"), parameters.all()))) == 5
-
-    project.generate_model(
-        "test_model", "decay_parallel", {"nr_compartments": 3}, allow_overwrite=True
-    )
-    new_model = project.load_model("test_model")
-    assert "megacomplex_parallel_decay" in new_model.megacomplex
-
-    comapartments = load_dict(model_file, is_file=True)["megacomplex"][
-        "megacomplex_parallel_decay"
-    ]["compartments"]
-
-    assert len(comapartments) == 3
-
-    project.generate_parameters("test_model", "test_parameters", allow_overwrite=True)
-    parameters = load_parameters(parameter_file)
-
-    assert len(list(filter(lambda p: p.label.startswith("rates"), parameters.all()))) == 3
+    assert "test_run_0000" in existing_project.results
+    assert existing_project.results["test_run_0000"].is_dir()
+    assert "test_run_0001" in existing_project.results
+    assert existing_project.results["test_run_0001"].is_dir()
 
 
-def test_validate(project_file: Path):
+def test_validate(existing_project: Project):
     """Validation works"""
-    project = Project.open(project_file)
 
-    assert str(project.validate("test_model")) == "Your model is valid."
-    assert str(project.validate("test_model", "test_parameters")) == "Your model is valid."
+    assert str(existing_project.validate("test_model")) == "Your model is valid."
+    assert (
+        str(existing_project.validate("test_model", "test_parameters")) == "Your model is valid."
+    )
 
-    bad_parameters_path = project_file.parent / "parameters/bad_parameters.yml"
+    bad_parameters_path = existing_project.folder / "parameters/bad_parameters.yml"
     bad_parameters_path.write_text("pure_list: [1.0]")
-    assert str(project.validate("test_model", "bad_parameters")).startswith(
-        "Your model has 3 problems"
+    assert str(existing_project.validate("test_model", "bad_parameters")).startswith(
+        "Your model has 5 problems"
     )
     bad_parameters_path.unlink()
 
@@ -597,7 +582,41 @@ def test_parameters_subfolder_folders(tmp_path: Path):
             )
 
 
-def test_missing_file_errors(tmp_path: Path, project_folder: Path):
+def test_generators_allow_overwrite(existing_project: Project):
+    """Overwrite doesn't throw an exception.
+    This is the last test not to interfere with other tests.
+    """
+
+    model_file = existing_project.folder / "models/test_model.yml"
+    assert model_file.is_file()
+
+    parameter_file = existing_project.folder / "parameters/test_parameters.csv"
+    assert parameter_file.is_file()
+
+    parameters = load_parameters(parameter_file)
+
+    assert len(list(filter(lambda p: p.label.startswith("rates"), parameters.all()))) == 3
+
+    existing_project.generate_model(
+        "test_model", "decay_parallel", {"nr_compartments": 5}, allow_overwrite=True
+    )
+    new_model = existing_project.load_model("test_model")
+    assert "megacomplex_parallel_decay" in new_model.megacomplex
+
+    compartments = load_dict(model_file, is_file=True)["megacomplex"][
+        "megacomplex_parallel_decay"
+    ]["compartments"]
+
+    assert len(compartments) == 5
+
+    existing_project.generate_parameters("test_model", "test_parameters", allow_overwrite=True)
+    parameters = load_parameters(parameter_file)
+
+    assert len(list(filter(lambda p: p.label.startswith("rates"), parameters.all()))) == 5
+
+
+@pytest.mark.usefixtures("dummy_results")
+def test_missing_file_errors(tmp_path: Path, existing_project: Project):
     """Error when accessing non existing files."""
     with pytest.raises(FileNotFoundError) as exc_info:
         Project.open(tmp_path, create_if_not_exist=False)
@@ -607,10 +626,8 @@ def test_missing_file_errors(tmp_path: Path, project_folder: Path):
         == f"Project file {(tmp_path/'project.gta').as_posix()} does not exists."
     )
 
-    project = Project.open(project_folder)
-
     with pytest.raises(ValueError) as exc_info:
-        project.import_data(xr.Dataset({"data": [1]}))
+        existing_project.import_data(xr.Dataset({"data": [1]}))
 
     assert str(exc_info.value) == (
         "When importing data from a 'xarray.Dataset' or 'xarray.DataArray' "
@@ -618,7 +635,7 @@ def test_missing_file_errors(tmp_path: Path, project_folder: Path):
     )
 
     with pytest.raises(ValueError) as exc_info:
-        project.import_data(xr.DataArray([1]))
+        existing_project.import_data(xr.DataArray([1]))
 
     assert str(exc_info.value) == (
         "When importing data from a 'xarray.Dataset' or 'xarray.DataArray' "
@@ -627,16 +644,16 @@ def test_missing_file_errors(tmp_path: Path, project_folder: Path):
 
     no_exist_data_error_msg = (
         "Dataset 'not-existing' does not exist. "
-        "Known Datasets are: ['dataset_1', 'dataset_1-bad', 'test_data']"
+        "Known Datasets are: ['dataset_1', 'dataset_1-bad']"
     )
 
     with pytest.raises(ValueError) as exc_info:
-        project.data["not-existing"]
+        existing_project.data["not-existing"]
 
     assert str(exc_info.value) == no_exist_data_error_msg
 
     with pytest.raises(ValueError) as exc_info:
-        project.load_data("not-existing")
+        existing_project.load_data("not-existing")
 
     assert str(exc_info.value) == no_exist_data_error_msg
 
@@ -646,12 +663,12 @@ def test_missing_file_errors(tmp_path: Path, project_folder: Path):
     )
 
     with pytest.raises(ValueError) as exc_info:
-        project.models["not-existing"]
+        existing_project.models["not-existing"]
 
     assert str(exc_info.value) == no_exist_model_error_msg
 
     with pytest.raises(ValueError) as exc_info:
-        project.load_model("not-existing")
+        existing_project.load_model("not-existing")
 
     assert str(exc_info.value) == no_exist_model_error_msg
 
@@ -661,12 +678,12 @@ def test_missing_file_errors(tmp_path: Path, project_folder: Path):
     )
 
     with pytest.raises(ValueError) as exc_info:
-        project.parameters["not-existing"]
+        existing_project.parameters["not-existing"]
 
     assert str(exc_info.value) == no_exist_parameters_error_msg
 
     with pytest.raises(ValueError) as exc_info:
-        project.load_parameters("not-existing")
+        existing_project.load_parameters("not-existing")
 
     assert str(exc_info.value) == no_exist_parameters_error_msg
 
@@ -680,40 +697,40 @@ def test_missing_file_errors(tmp_path: Path, project_folder: Path):
     )
 
     with pytest.raises(ValueError) as exc_info:
-        project.results["not-existing_run_0000"]
+        existing_project.results["not-existing_run_0000"]
 
     assert str(exc_info.value) == no_exist_full_result_name_error_msg
 
     with pytest.raises(ValueError) as exc_info:
-        project.load_result("not-existing_run_0000")
+        existing_project.load_result("not-existing_run_0000")
 
     assert str(exc_info.value) == no_exist_full_result_name_error_msg
 
     with pytest.raises(ValueError) as exc_info:
-        project.load_latest_result("not-existing")
+        existing_project.load_latest_result("not-existing")
 
     assert str(exc_info.value) == (
         f"Result 'not-existing' does not exist. {expected_known_results}"
     )
 
     with pytest.raises(ValueError) as exc_info:
-        project.get_result_path("not-existing_run_0000")
+        existing_project.get_result_path("not-existing_run_0000")
 
     assert str(exc_info.value) == (
         f"Result 'not-existing_run_0000' does not exist. {expected_known_results}"
     )
 
     with pytest.raises(ValueError) as exc_info:
-        project.get_latest_result_path("not-existing")
+        existing_project.get_latest_result_path("not-existing")
 
     assert str(exc_info.value) == (
         f"Result 'not-existing' does not exist. {expected_known_results}"
     )
 
 
-def test_markdown_repr(project_folder: Path, project_file: Path):
+@pytest.mark.usefixtures("dummy_results")
+def test_markdown_repr(existing_project: Project):
     """calling markdown directly and via ipython."""
-    project = Project.open(project_file)
 
     expected = f"""\
         # Project (_test_project_)
@@ -724,7 +741,6 @@ def test_markdown_repr(project_folder: Path, project_file: Path):
 
         * dataset_1
         * dataset_1-bad
-        * test_data
 
 
         ## Model
@@ -748,9 +764,9 @@ def test_markdown_repr(project_folder: Path, project_file: Path):
 
         """
 
-    assert str(project.markdown()) == dedent(expected)
+    assert str(existing_project.markdown()) == dedent(expected)
 
-    rendered_result = format_display_data(project)[0]
+    rendered_result = format_display_data(existing_project)[0]
 
     assert "text/markdown" in rendered_result
     assert rendered_result["text/markdown"] == dedent(expected)

--- a/glotaran/project/test/test_project.py
+++ b/glotaran/project/test/test_project.py
@@ -12,6 +12,7 @@ import xarray as xr
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.recwarn import WarningsRecorder
 from IPython.core.formatters import format_display_data
+from pandas.testing import assert_frame_equal
 
 from glotaran import __version__ as gta_version
 from glotaran.builtin.io.yml.utils import load_dict
@@ -380,6 +381,34 @@ def test_show_model_definition(tmp_path: Path):
     (tmp_path / "models/yml_model.yml").write_text(file_content)
 
     assert str(project.show_model_definition("yml_model")) == "```yaml\nfoo:\n  bar\n```"
+
+
+def test_show_parameters_definition(tmp_path: Path):
+    """Syntax is correct inferred and expected file content and dataframes are returned when
+    ``as_dataframe=True`` or file is excel format."""
+    project = Project.open(tmp_path)
+    file_content = "pure_list: [1.0]"
+
+    (tmp_path / "parameters/yml_parameters.yml").write_text(file_content)
+
+    assert (
+        str(project.show_parameters_definition("yml_parameters"))
+        == "```yaml\npure_list: [1.0]\n```"
+    )
+
+    dummy_parameters = load_parameters("pure_list: [1.0]", format_name="yml_str")
+
+    assert_frame_equal(
+        project.show_parameters_definition("yml_parameters", as_dataframe=True),
+        dummy_parameters.to_dataframe(),
+    )
+
+    save_parameters(dummy_parameters, (tmp_path / "parameters/excel_parameters.xlsx"))
+
+    assert_frame_equal(
+        project.show_parameters_definition("excel_parameters"),
+        dummy_parameters.to_dataframe(),
+    )
 
 
 def test_import_data_relative_paths_script_folder_not_cwd(

--- a/glotaran/utils/ipython.py
+++ b/glotaran/utils/ipython.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 from collections import UserString
-from os import PathLike
+
+from glotaran.plugin_system.io_plugin_utils import infer_file_format
+from glotaran.typing.types import StrOrPath
 
 
 class MarkdownStr(UserString):
@@ -59,20 +61,24 @@ class MarkdownStr(UserString):
             return NotImplemented
 
 
-def display_file(path: str | PathLike[str], *, syntax: str | None = None) -> MarkdownStr:
+def display_file(path: StrOrPath, *, syntax: str | None = None) -> MarkdownStr:
     """Display a file with syntax highlighting ``syntax``.
 
     Parameters
     ----------
-    path : str | PathLike[str]
+    path : StrOrPath
         Paths to the file
-    syntax : str
-        Syntax highlighting which should be applied, by default None
+    syntax: str | None
+        Syntax used for syntax highlighting. Defaults to None which means that the syntax is
+        inferred based on the file extension. Pass the value ``""`` to deactivate syntax
+        highlighting.
 
     Returns
     -------
     MarkdownStr
         File content with syntax highlighting to render in ipython.
     """
+    if syntax is None:
+        syntax = infer_file_format(path)
     with open(path, encoding="utf8") as file:
         return MarkdownStr(file.read(), syntax=syntax)

--- a/glotaran/utils/test/test_ipython.py
+++ b/glotaran/utils/test/test_ipython.py
@@ -37,8 +37,15 @@ def test_display_file(tmp_path: Path):
     """str and PathLike give the same result"""
     file_content = "kinetic:\n  - ['1', 1]"
     expected = MarkdownStr(file_content, syntax="yaml")
-    tmp_file = tmp_path / "test.yml"
-    tmp_file.write_text(file_content)
+    yml_file = tmp_path / "test.yml"
+    yml_file.write_text(file_content)
 
-    assert display_file(tmp_file, syntax="yaml") == expected
-    assert display_file(str(tmp_file), syntax="yaml") == expected
+    assert display_file(yml_file) == expected
+    assert display_file(str(yml_file)) == expected
+
+    yaml_file = tmp_path / "test.yaml"
+    yaml_file.write_text(file_content)
+    assert display_file(yaml_file) == expected
+
+    assert str(display_file(yaml_file, syntax="json")) == f"```json\n{file_content}\n```"
+    assert str(display_file(yaml_file, syntax="")) == f"```\n{file_content}\n```"


### PR DESCRIPTION
While rewriting the quickstart guide to use the project  API I found a number of refinements that needed to be done so @joernweissenborn vision of a single import can be realized (at least for the quickstart).

The deprecation of model and parameters generators in the project API (for good) was in agreement with @joernweissenborn since they lack ease of use and don't fit in a notebook workflow (our currently recommended UI).

See #1241 for the new usage.

### Change summary

- [👌 Improved Project markdown repr](https://github.com/glotaran/pyglotaran/commit/58b0611e2879fe0627afd1910f68f3dcbba691ea)
- [👌 Made Project.optimize return the current result for usage convenience](https://github.com/glotaran/pyglotaran/commit/c05e646c0a28f3d0828b4b49f7e518b55da222a1)
- [🧹 Add quickstart output files to .gitignore](https://github.com/glotaran/pyglotaran/commit/ecad1d3abc9488439d51a8aa87c5e614273fbd80)
- [🧹 Add quickstart output files to .gitignore](https://github.com/glotaran/pyglotaran/commit/ecad1d3abc9488439d51a8aa87c5e614273fbd80)
- [🧹 Add quickstart output files to .gitignore](https://github.com/glotaran/pyglotaran/commit/ecad1d3abc9488439d51a8aa87c5e614273fbd80)
  This way the error handling is done when accessing an item
- [🧹 Consistent usage of dataset_name and model_name (no blank name)](https://github.com/glotaran/pyglotaran/commit/8421733f8bebbc238c4fa2a5bd161e64b9c23e17)
- [👌 Changed infer_file_format to return 'yaml' when file extension is 'yml'](https://github.com/glotaran/pyglotaran/commit/facc182e49b9a50cf0d0ab6c6ebce836545d3423)
  That way it can be used with display_file since using 'yml' breaks syntax highlighting
- [✨ Added show_model_definition method to project](https://github.com/glotaran/pyglotaran/commit/33e1b6b0da0359c3781061cd2bffddee832ffdb5)
- [✨ Added show_parameters_definition method to project](https://github.com/glotaran/pyglotaran/commit/b7de29bdf1f9bff818eae4f91e0ab1a206c15952)
- [✨ Added add_svd option to Project.load_data](https://github.com/glotaran/pyglotaran/commit/cd4c2de3a0c58adf800fd3d264b255b7ec1e8319)
- [✨ Added validate method to project](https://github.com/glotaran/pyglotaran/commit/1abd6cad8e813b7efb0a3c69bd7d516cbcf4bf3a)
- [♻️🧪 Refactored project tests to not be inter dependent](https://github.com/glotaran/pyglotaran/commit/589cc52a3603e0c0c402be354a0958a9e1a7f1e3)
- [🗑️ Deprecated generator from Project API](https://github.com/glotaran/pyglotaran/commit/8fd378e414199b48a8078c9949055ea1bc6063ae)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)