### PR TITLE
📚🩹 Fix rendering of Result with nbsphinx (workaround)

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,11 @@
+name: RTD-env
+channels:
+  - conda-forge
+dependencies:
+  # Python interpreter
+  - python=3.10
+  - pandoc>=2.19.2
+  - pip
+  - pip:
+      - -r requirements.txt
+      - ..

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -244,7 +244,14 @@ class Result:
             if wrap_model_in_details is False:
                 result_table = f"{result_table}\n\n{model_md}"
             else:
-                result_table = f"{result_table}\n\n<br><details>\n\n{model_md}\n</details>"
+                # The section part is just a hack to generate properly rendering docs due to a bug
+                # in sphinx which causes a wrong tag opening and closing order of html tags
+                result_table = (
+                    f"{result_table}\n\n<br><details>\n\n{model_md}\n"
+                    f"{'</section>'*(base_heading_level+1)}"
+                    "</details>"
+                    f"{'<section>'*(base_heading_level+1)}"
+                )
 
         return MarkdownStr(result_table)
 

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -246,11 +246,12 @@ class Result:
             else:
                 # The section part is just a hack to generate properly rendering docs due to a bug
                 # in sphinx which causes a wrong tag opening and closing order of html tags
+                # Since model_md contains 2 heading levels we need to close 2 sections
                 result_table = (
                     f"{result_table}\n\n<br><details>\n\n{model_md}\n"
-                    f"{'</section>'*(base_heading_level+1)}"
+                    f"{'</section>'*(2)}"
                     "</details>"
-                    f"{'<section>'*(base_heading_level+1)}"
+                    f"{'<section>'*(2)}"
                 )
 
         return MarkdownStr(result_table)

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,10 +8,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "mambaforge-4.10"
 
-python:
-  install:
-    - requirements: docs/requirements.txt
-    - method: pip
-      path: .
+conda:
+  environment: docs/environment.yml


### PR DESCRIPTION
This is just a hack for the docs to render properly with the markdown repr of `Result`.

See current [docs on main](https://pyglotaran.readthedocs.io/en/latest/notebooks/quickstart/quickstart.html) (will be different in the future when looking back at this PR) and [the build for this PR](https://pyglotaran--1244.org.readthedocs.build/en/1244/notebooks/quickstart/quickstart.html) (might be deleted) 


<details>

<summary>
Down the rabbit hole
</summary>

The problem is the markdown repr of the Result and our notebook docs plugin (nbsphinx) using pandoc to transform markdown to  reST as the intermediate format that sphinx can then picked up by sphinx (doc building framework) to create html, latex ...

The markdown repr of Result looks something like this

```
TABLE<in md>
<details>
# Model
## Modelitem
...
</details>
```

Which is totally valid markdown since that is a superset of html
When we build the docs this string gets extracted by  nbsphinx  which then uses pandoc  to transform it into reST  which looks like this

```
TABLE<in reST>

.. raw:: html

   <details>

Model
~~~~~

Modelitem
^^^^^^^^^
...

.. raw:: html

   </details>
```

So far so good, but when sphinx takes over to generate html  the problem starts since it assumes that ``</details>``  is part of the section

```
TABLE<in html>

<details>
<section>
<h2>Model</h2>
<section>
<h3>Modelitem</h3>
...
</details>
</section>
</section>
```

This breaks the opening and closing order in such a way that the browser moves out the last cells from the main context wrapper into the document root which is why it look so messed up
The very dirty workaround is to wrap `</details>`  into two empty section tags first closing the two parent section and than opening two new ones that get closed by the existing closing tags
So the new markdown would be

The markdown repr of Result looks something like this

```
TABLE<in md>

<details>
# Model
## Modelitem
...

</section>
</section>
</details>
<section>
<section>
```

Which then gives us the following reST

```
TABLE<in reST>

.. raw:: html

   <details>

Model
~~~~~

Modelitem
^^^^^^^^^
...

.. raw:: html

   </section>
   </section>
   </details>
   <section>
   <section>
```

Which then finally gets transformed in none broken HTML

```
TABLE<in html>

<details>
<section>
<h2>Model</h2>
<section>
<h3>Modelitem</h3>
...
</section>
</section>
</details>
<section>
<section>
</section>
</section>
```

</details>

 The markdown renders fine in vscode and jupyter lab but it is a bloody mess, just to compensate the wrong assumption on sphinx 🤷‍♀️
 But I looked into all the steps of the translation process and there seems to be no quick and easy way around it.

### Change summary

- [📚🩹 Fix rendering of Result with nbsphinx (workaround)](https://github.com/glotaran/pyglotaran/commit/e0a1228c7b9299610ade9bafb60ecb606a5e800b)
- [🤔 Use conda build on RTD to control pandoc version](https://github.com/glotaran/pyglotaran/pull/1244/commits/7ea3cf4484caa4ec9074b7ebab8f03b29023c6f8)
- [🩹 Fix wrong number of sections closed in hack](https://github.com/glotaran/pyglotaran/pull/1244/commits/8692e0d46277e16290bfe2ec3b0c86c432174233)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)