### PR TITLE
🩹 Fix loading of old results containing number_of_data_points

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,7 @@
 - 👌 Refine project API (#1240)
 <!-- Fix within the 0.7.0 release cycle, therefore hidden:
 - 🩹 Fix the matrix provider alignment/reduction ('grouping') issues introduced in #1175 (#1190)
+- 🩹 Fix loading of old results containing number_of_data_points (#1255)
   -->
 
 ### 📚 Documentation

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -168,6 +168,8 @@ class YmlProjectIo(ProjectIoInterface):
         if result_file_path.suffix not in [".yml", ".yaml"]:
             result_file_path = result_file_path / "result.yml"
         spec = self._load_yml(result_file_path.as_posix())
+        if "number_of_data_points" in spec:
+            spec["number_of_residuals"] = spec.pop("number_of_data_points")
         return fromdict(Result, spec, folder=result_file_path.parent)
 
     def save_result(


### PR DESCRIPTION
This change allows the loading of results with `load_result` created before merging #1249 which deprecated `number_of_data_points` and removed it from the init.

### Change summary

- [🩹 Fix loading of old results containing number_of_data_points](https://github.com/glotaran/pyglotaran/commit/ed22b135dcabba4c0b9adf6d52c2e9b4ec993f24)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)