### PR TITLE
🗑️ Deprecate Result.number_of_parameters in favor of Result.number_of_free_parameters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 - ✨ Allow import of xarray objects in project API import_data (#1235)
 - 🩹 Add number_of_clps to result and correct degrees_of_freedom calculation (#1249)
 - 👌 Improve Project API data handling (#1257)
+- 🗑️ Deprecate Result.number_of_parameters in favor of Result.number_of_free_parameters (#1262)
 
 ### 🩹 Bug fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,7 @@
 - `Project.generate_model` (removed without replacement)
 - `Project.generate_parameters` (removed without replacement)
 - `glotaran.project.Result.number_of_data_points` -> `glotaran.project.Result.number_of_residuals`
+- `glotaran.project.Result.number_of_parameters` -> `glotaran.project.Result.number_of_free_parameters`
 
 ### 🗑️❌ Deprecated functionality removed in this release
 

--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -170,6 +170,8 @@ class YmlProjectIo(ProjectIoInterface):
         spec = self._load_yml(result_file_path.as_posix())
         if "number_of_data_points" in spec:
             spec["number_of_residuals"] = spec.pop("number_of_data_points")
+        if "number_of_parameters" in spec:
+            spec["number_of_free_parameters"] = spec.pop("number_of_parameters")
         return fromdict(Result, spec, folder=result_file_path.parent)
 
     def save_result(

--- a/glotaran/deprecation/modules/test/test_project_result.py
+++ b/glotaran/deprecation/modules/test/test_project_result.py
@@ -11,12 +11,25 @@ from glotaran.optimization.optimize import optimize
 from glotaran.testing.simulated_data.sequential_spectral_decay import SCHEME
 
 
-def test_project_generate_model():
+def test_result_number_of_data_points():
     """Trow deprecation warning on accessing ``Result.number_of_data_points``."""
     print(SCHEME.data["dataset_1"])
     result = optimize(SCHEME, raise_exception=True)
     with pytest.warns(GlotaranApiDeprecationWarning) as records:
         result.number_of_data_points
+
+        assert len(records) == 1
+        assert Path(records[0].filename) == Path(
+            __file__
+        ), f"{Path(records[0].filename)=}, {Path(__file__)=}"
+
+
+def test_result_number_of_parameters():
+    """Trow deprecation warning on accessing ``Result.number_of_parameters``."""
+    print(SCHEME.data["dataset_1"])
+    result = optimize(SCHEME, raise_exception=True)
+    with pytest.warns(GlotaranApiDeprecationWarning) as records:
+        result.number_of_parameters
 
         assert len(records) == 1
         assert Path(records[0].filename) == Path(

--- a/glotaran/optimization/optimizer.py
+++ b/glotaran/optimization/optimizer.py
@@ -235,10 +235,10 @@ class Optimizer:
             result_args["number_of_clps"] = sum(
                 group.number_of_clps for group in self._optimization_groups
             )
-            result_args["number_of_parameters"] = self._optimization_result.x.size
+            result_args["number_of_free_parameters"] = self._optimization_result.x.size
             result_args["degrees_of_freedom"] = (
                 result_args["number_of_residuals"]
-                - result_args["number_of_parameters"]
+                - result_args["number_of_free_parameters"]
                 - result_args["number_of_clps"]
             )
             result_args["chi_square"] = float(np.sum(self._optimization_result.fun**2))

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -119,8 +119,8 @@ class Result:
     """Number of values in the residual vector :math:`N`."""
     number_of_jacobian_evaluations: int | None = None
     """The number of jacobian evaluations."""
-    number_of_parameters: int | None = None
-    """Number of parameters in optimization :math:`N_{vars}`"""
+    number_of_free_parameters: int | None = None
+    """Number of free parameters in optimization :math:`N_{vars}`"""
     optimality: float | None = None
     reduced_chi_square: float | None = None
     r"""The reduced chi-square of the optimization.
@@ -150,6 +150,23 @@ class Result:
     @property
     @deprecate(
         deprecated_qual_name_usage="glotaran.project.Result.number_of_data_points",
+        new_qual_name_usage="glotaran.project.Result.number_of_free_parameters",
+        to_be_removed_in_version="0.8.0",
+        importable_indices=(2, 2),
+    )
+    def number_of_parameters(self) -> int | None:
+        """Return the number of free parameters in optimization :math:`N_{vars}`.
+
+        Returns
+        -------
+        int | None
+            Number of free parameters in optimization :math:`N_{vars}`.
+        """
+        return self.number_of_free_parameters
+
+    @property
+    @deprecate(
+        deprecated_qual_name_usage="glotaran.project.Result.number_of_parameters",
         new_qual_name_usage="glotaran.project.Result.number_of_residuals",
         to_be_removed_in_version="0.8.0",
         importable_indices=(2, 2),
@@ -221,7 +238,7 @@ class Result:
         general_table_rows: list[list[Any]] = [
             ["Number of residual evaluation", self.number_of_function_evaluations],
             ["Number of residuals", self.number_of_residuals],
-            ["Number of parameters", self.number_of_parameters],
+            ["Number of free parameters", self.number_of_free_parameters],
             ["Number of conditionally linear parameters", self.number_of_clps],
             ["Degrees of freedom", self.degrees_of_freedom],
             ["Chi Square", f"{self.chi_square or np.nan:.2e}"],


### PR DESCRIPTION
This change makes it more clear that `number_of_parameters` always meant `number_of_free_parameters`.

### Change summary

- [🗑️ Deprecate Result.number_of_parameters in favor of Result.number_of_free_parameters](https://github.com/glotaran/pyglotaran/commit/a6b66a4cb6cd77c008bcc0a1b01b0ea27d967ff0)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)