### PR TITLE
👌 Make PreProcessingPipeline methods return a new instance

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 - ✨ Add optimization history to result and iteration column to parameter history (#1134)
 - ♻️ Complete refactor of model and parameter packages using attrs (#1135)
 - ♻️ Move index dependent calculation to megacomplexes for speed-up (#1175)
+- ✨ Add PreProcessingPipeline (#1256, #1263)
 
 ### 👌 Minor Improvements:
 

--- a/glotaran/io/preprocessor/pipeline.py
+++ b/glotaran/io/preprocessor/pipeline.py
@@ -39,16 +39,6 @@ class PreProcessingPipeline(BaseModel):
             result = action.apply(result)
         return result
 
-    def _push_action(self, action: PipelineAction):
-        """Push an action.
-
-        Parameters
-        ----------
-        action: PipelineAction
-            The action to push.
-        """
-        self.actions.append(action)
-
     def correct_baseline_value(self, value: float) -> PreProcessingPipeline:
         """Correct a dataset by subtracting baseline value.
 
@@ -61,8 +51,7 @@ class PreProcessingPipeline(BaseModel):
         -------
         PreProcessingPipeline
         """
-        self._push_action(CorrectBaselineValue(value=value))
-        return self
+        return PreProcessingPipeline(actions=[*self.actions, CorrectBaselineValue(value=value)])
 
     def correct_baseline_average(
         self,
@@ -84,5 +73,6 @@ class PreProcessingPipeline(BaseModel):
         -------
         PreProcessingPipeline
         """
-        self._push_action(CorrectBaselineAverage(exclude=exclude, select=select))
-        return self
+        return PreProcessingPipeline(
+            actions=[*self.actions, CorrectBaselineAverage(exclude=exclude, select=select)]
+        )

--- a/glotaran/io/preprocessor/test/test_preprocessor.py
+++ b/glotaran/io/preprocessor/test/test_preprocessor.py
@@ -5,8 +5,7 @@ from glotaran.io.preprocessor import PreProcessingPipeline
 
 
 def test_correct_baseline_value():
-    pl = PreProcessingPipeline()
-    pl.correct_baseline_value(1)
+    pl = PreProcessingPipeline().correct_baseline_value(1)
     data = xr.DataArray([[1]])
     result = pl.apply(data)
     assert result == data - 1
@@ -14,16 +13,16 @@ def test_correct_baseline_value():
 
 @pytest.mark.parametrize("indexer", (slice(0, 2), [0, 1]))
 def test_correct_baseline_average(indexer: slice | list[int]):
-    pl = PreProcessingPipeline()
-    pl.correct_baseline_average(select={"dim_0": 0, "dim_1": indexer})
+    pl = PreProcessingPipeline().correct_baseline_average(select={"dim_0": 0, "dim_1": indexer})
     data = xr.DataArray([[1.1, 0.9]])
     result = pl.apply(data)
     assert (result == data - 1).all()
 
 
 def test_correct_baseline_average_exclude():
-    pl = PreProcessingPipeline()
-    pl.correct_baseline_average(select={"dim_0": 0}, exclude={"dim_1": 1})
+    pl = PreProcessingPipeline().correct_baseline_average(
+        select={"dim_0": 0}, exclude={"dim_1": 1}
+    )
     data = xr.DataArray([[1.1, 0.9]])
     result = pl.apply(data)
     print(result)
@@ -31,9 +30,11 @@ def test_correct_baseline_average_exclude():
 
 
 def test_to_from_dict():
-    pl = PreProcessingPipeline()
-    pl.correct_baseline_value(1)
-    pl.correct_baseline_average({"dim_1": slice(0, 2)})
+    pl = (
+        PreProcessingPipeline()
+        .correct_baseline_value(1)
+        .correct_baseline_average({"dim_1": slice(0, 2)})
+    )
     pl_dict = pl.dict()
     assert pl_dict == {
         "actions": [


### PR DESCRIPTION
This changes the behavior of methods on `PreProcessingPipeline ` to be closer to how `pandas` or `xarray` work (object creation instead of in place mutation), which makes it more intuitive and prevents accidental state changes in the pipeline (e.g. executing a cell in a notebook that does not include the instantiation multiple times).

### Change summary

- [👌 Make PreProcessingPipeline methods return a new instance](https://github.com/glotaran/pyglotaran/commit/85766610a17123b5ba890cca67e11725629c8e27)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)