### PR TITLE
🩹📚 Fix search in docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 - 🩹 Fix wrong file loading due to partial filename matching in Project (#1212)
 - 🩹 Fix `Project.import_data` path resolving for different script and cwd (#1214)
 - 👌 Refine project API (#1240)
+- 🩹📚 Fix search in docs (#1268)
 <!-- Fix within the 0.7.0 release cycle, therefore hidden:
 - 🩹 Fix the matrix provider alignment/reduction ('grouping') issues introduced in #1175 (#1190)
 - 🩹 Fix loading of old results containing number_of_data_points (#1255)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,10 @@
 # documentation dependencies
 Sphinx>=3.2.0
 sphinx-click>=3.0.1
-sphinx-rtd-theme>=0.5.1
+sphinx-rtd-theme>=1.2.0
+# Needed for the search to work
+# Ref.: https://github.com/readthedocs/sphinx_rtd_theme/issues/1434
+sphinxcontrib-jquery>=4.1
 sphinx-copybutton>=0.3.0
 myst-parser>=0.12.0
 numpydoc>=0.8.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -61,6 +61,7 @@ extensions = [
     "myst_parser",
     "numpydoc",
     "sphinx_copybutton",
+    "sphinx_rtd_theme",
 ]
 
 autoclass_content = "both"


### PR DESCRIPTION
Currently, the search functionality in our docs hangs indefinitely.
The error you get in the dev tools console is 
```js
Uncaught ReferenceError: jQuery is not defined
```
This relates to a change in the rtd theme and how to use it (old config).

### Change summary

- [🩹📚 Fix search in docs](https://github.com/glotaran/pyglotaran/commit/cc534bd8381f7a9046cc2dd90f6890730f6993e2)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)