### PR TITLE
🚧 Change back to development mode for 0.8.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,26 @@
 # Changelog
 
+(changes-0_8_0)=
+
+## 🚀 0.8.0 (Unreleased)
+
+### ✨ Features
+
+### 👌 Minor Improvements:
+
+### 🩹 Bug fixes
+
+### 📚 Documentation
+
+### 🗑️ Deprecations (due in 0.9.0)
+
+### 🗑️❌ Deprecated functionality removed in this release
+
+### 🚧 Maintenance
+
 (changes-0_7_0)=
 
-## 🚀 0.7.0 (2023-03-27)
+## 🚀 0.7.0 (Unreleased)
 
 ### 💥 BREAKING CHANGE
 

--- a/glotaran/__init__.py
+++ b/glotaran/__init__.py
@@ -4,7 +4,7 @@ from glotaran.plugin_system.base_registry import load_plugins
 
 load_plugins()
 
-__version__ = "0.7.0"
+__version__ = "0.8.0.dev0"
 
 examples = deprecate_submodule(
     deprecated_module_name="glotaran.examples",


### PR DESCRIPTION
Change back to a development version after the 0.7.0 release.

### Change summary

- [🚧📚 Added boilerplate changelog section for 0.8.0](https://github.com/glotaran/pyglotaran/commit/9f2f3ec606f58a63ec18363dd42a11c3a6a40a10)
- [🚧 Changed version from 0.7.0 to 0.8.0.dev0](https://github.com/glotaran/pyglotaran/commit/1290c836899c2ee02c1b67b30ff26311d287d906)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)