### PR TITLE
🧪 Test numba 0.57.0 result comparison

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -117,7 +117,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,10 +32,10 @@ jobs:
         example_name: ${{fromJson(needs.create-example-list.outputs.example-list)}}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install pyglotaran
         run: |
           pip install wheel
@@ -90,10 +90,10 @@ jobs:
           echo "♻️ pyglotaran-examples commit: $(< comparison-results-current/example_commit_sha.txt)"
           echo "::endgroup::"
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Run result validator
         uses: glotaran/pyglotaran-validation@main

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,11 +41,13 @@ jobs:
           pip install wheel
           pip install -r requirements_dev.txt
           pip install .
+          pip install git+https://github.com/s-weigand/pyglotaran-extras.git@raise-max-python
       - name: ${{ matrix.example_name }}
         id: example-run
         uses: glotaran/pyglotaran-examples@main
         with:
           example_name: ${{ matrix.example_name }}
+          install_extras: false
       - name: Installed packages
         if: always()
         run: |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -131,7 +131,7 @@ Before you submit a pull request, check that it meets these guidelines:
 1.  The pull request should include tests.
 2.  If the pull request adds functionality, the docs should be updated. Put
     your new functionality into a function with a `docstring`_.
-3.  The pull request should work for Python 3.10
+3.  The pull request should work for Python 3.10 and 3.11
     Check your Github Actions ``https://github.com/<your_name_here>/pyglotaran/actions``
     and make sure that the tests pass for all supported Python versions.
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ asteval==0.9.29
 attrs == 23.1.0
 click==8.1.3
 netCDF4==1.6.3
-numba==0.56.4
+numba==0.57.0
 numpy==1.23.5
 odfpy==1.4.1
 openpyxl==3.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     sdtfile>=2020.8.3
     tabulate>=0.8.9
     xarray>=2022.3.0
-python_requires = >=3.10, <3.11
+python_requires = >=3.10, <3.12
 tests_require = pytest
 zip_safe = True
 


### PR DESCRIPTION
Since `numba` is one of our core dependencies and currently the blocker to support python 3.11, we should help them test their release candidate.

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)