### PR TITLE
🚀🚇 Add pipeline to release examples and validation on release

### DIFF
--- a/.github/workflows/release-validataion.yml
+++ b/.github/workflows/release-validataion.yml
@@ -1,0 +1,66 @@
+name: 🚀🚇 Release Validation and Examples
+
+on:
+  push:
+    tags:
+      - v**
+
+jobs:
+  release-examples:
+    name: 🚀 Release Examples
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: ⏬ Checkout examples repo
+        uses: actions/checkout@v3
+        with:
+          repository: glotaran/pyglotaran-examples
+          fetch-depth: 1
+
+      - name: 🏷️ Get tag name
+        id: tag
+        uses: devops-actions/action-get-tag@v1.0.2
+
+      - name: 📚 Create release body
+        run: |
+          echo "# pyglotaran-examples ${{ steps.tag.outputs.tag }} Release Notes" > ${{ github.workspace }}-release-body.txt
+          echo "This repository hold examples showcasing the use of [pyglotaran](https://github.com/glotaran/pyglotaran/)." >> ${{ github.workspace }}-release-body.txt
+          echo "And was used for validation of the [pyglotaran ${{ steps.tag.outputs.tag }} release](https://github.com/glotaran/pyglotaran/releases/tag/${{ steps.tag.outputs.tag }})." >> ${{ github.workspace }}-release-body.txt
+
+      - name: 🚀 Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: s-weigand/pyglotaran-examples
+          body_path: ${{ github.workspace }}-release-body.txt
+          token: ${{ secrets.release_token }}
+
+  release-validation:
+    name: 🚀 Release Validation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: ⏬ Checkout validation repo
+        uses: actions/checkout@v3
+        with:
+          repository: glotaran/pyglotaran-validation
+          fetch-depth: 1
+
+      - name: 🏷️ Get tag name
+        id: tag
+        uses: devops-actions/action-get-tag@v1.0.2
+
+      - name: 📚 Create release body
+        run: |
+          echo "# pyglotaran-validation ${{ steps.tag.outputs.tag }} Release Notes" > ${{ github.workspace }}-release-body.txt
+          echo "This repository was used for validation of the [pyglotaran ${{ steps.tag.outputs.tag }} release](https://github.com/glotaran/pyglotaran/releases/tag/${{ steps.tag.outputs.tag }})." >> ${{ github.workspace }}-release-body.txt
+
+      - name: 🚀 Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: s-weigand/pyglotaran-validation
+          body_path: ${{ github.workspace }}-release-body.txt
+          generate_release_notes: true
+          append_body: true
+          token: ${{ secrets.release_token }}

--- a/.github/workflows/release-validataion.yml
+++ b/.github/workflows/release-validataion.yml
@@ -31,7 +31,7 @@ jobs:
       - name: 🚀 Create Release
         uses: softprops/action-gh-release@v1
         with:
-          repository: s-weigand/pyglotaran-examples
+          repository: glotaran/pyglotaran-examples
           body_path: ${{ github.workspace }}-release-body.txt
           token: ${{ secrets.release_token }}
 
@@ -59,7 +59,7 @@ jobs:
       - name: 🚀 Create Release
         uses: softprops/action-gh-release@v1
         with:
-          repository: s-weigand/pyglotaran-validation
+          repository: glotaran/pyglotaran-validation
           body_path: ${{ github.workspace }}-release-body.txt
           generate_release_notes: true
           append_body: true


### PR DESCRIPTION
I added a pipeline that automatically creates a release on [pyglotaran-validation](https://github.com/glotaran/pyglotaran-validation) and [pyglotaran-examples](https://github.com/glotaran/pyglotaran-examples) when a release for pyglotaran is created.
For the examples, it also triggers a pipeline in that repo uploading comparison results.
This way each pyglotaran release will automatically become reproducible validation wise.

I tested it on my fork and [this pyglotaran release on my fork](https://github.com/s-weigand/pyglotaran/releases/tag/vFinalAutoreleaseTest) created those releases on [validation fork](https://github.com/s-weigand/pyglotaran-validation/releases/tag/vFinalAutoreleaseTest) and [examples fork](https://github.com/s-weigand/pyglotaran-examples/releases).

### Change summary

- [🚀🚇 Add pileline to release examples and validation on release](https://github.com/glotaran/pyglotaran/commit/c647bf93ae13059f0b30245a3cbb454c86df203e)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

