### PR TITLE
🩹 Transform standard error if parameter has non_negative constraint

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -48,6 +48,7 @@
 - 🩹 Add number_of_clps to result and correct degrees_of_freedom calculation (#1249)
 - 👌 Improve Project API data handling (#1257)
 - 🗑️ Deprecate Result.number_of_parameters in favor of Result.number_of_free_parameters (#1262)
+- 👌Improve reporting of standard error in case of non_negative constraint in the parameter (#1320)
 
 ### 🩹 Bug fixes
 

--- a/glotaran/parameter/parameters.py
+++ b/glotaran/parameter/parameters.py
@@ -522,7 +522,7 @@ def param_dict_to_markdown(
                 parameter.label_short,
                 parameter.value,
                 parameter.standard_error,
-                repr(pretty_format_numerical(parameter.value / parameter.standard_error)),
+                repr(pretty_format_numerical(abs(parameter.value / parameter.standard_error))),
                 parameter.minimum,
                 parameter.maximum,
                 parameter.vary,

--- a/glotaran/parameter/parameters.py
+++ b/glotaran/parameter/parameters.py
@@ -522,7 +522,7 @@ def param_dict_to_markdown(
                 parameter.label_short,
                 parameter.value,
                 parameter.standard_error,
-                repr(pretty_format_numerical(abs(parameter.value / parameter.standard_error))),
+                repr(pretty_format_numerical(parameter.value / parameter.standard_error)),
                 parameter.minimum,
                 parameter.maximum,
                 parameter.vary,


### PR DESCRIPTION
Correctly report standard error in the case that non_negative contraint is used.

### Change summary

- 👌Improve reporting of standard error in case of non_negative constraint in the parameter

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 🚧 Added changes to changelog (mandatory for all PR's)
- [ ] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)
- [ ] 📚 Adds documentation of the feature

