### PR TITLE
⬆️ Combined dependency updates

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ attrs == 23.1.0
 click==8.1.6
 netCDF4==1.6.4
 numba==0.57.1
-numpy==1.24.3
+numpy==1.24.4
 odfpy==1.4.1
 openpyxl==3.1.2
 pandas==2.0.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ numpy==1.24.3
 odfpy==1.4.1
 openpyxl==3.1.2
 pandas==2.0.3
-pydantic==1.10.9
+pydantic==1.10.11
 rich==13.4.2
 ruamel.yaml==0.17.32
 scipy==1.11.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,7 +18,7 @@ ruamel.yaml==0.17.32
 scipy==1.11.1
 sdtfile==2022.9.28
 tabulate==0.9.0
-xarray==2023.6.0
+xarray==2023.7.0
 
 # documentation dependencies
 -r docs/requirements.txt

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ pip>=18.0
 wheel>=0.38.0
 
 # glotaran setup dependencies
-asteval==0.9.30
+asteval==0.9.31
 attrs == 23.1.0
 click==8.1.6
 netCDF4==1.6.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ wheel>=0.38.0
 # glotaran setup dependencies
 asteval==0.9.30
 attrs == 23.1.0
-click==8.1.5
+click==8.1.6
 netCDF4==1.6.4
 numba==0.57.1
 numpy==1.24.3


### PR DESCRIPTION
Combined dependency updates

### Change summary

- [Bump pydantic from 1.10.9 to 1.10.11](https://github.com/glotaran/pyglotaran/commit/71b736c06cf47d67b8fb0af6e762fc98b620d44f)
- [Bump xarray from 2023.6.0 to 2023.7.0](https://github.com/glotaran/pyglotaran/commit/c7c1eaec078254f10f6c9d55be02470c50a2d4ee)
- [Bump click from 8.1.5 to 8.1.6](https://github.com/glotaran/pyglotaran/commit/ee102dc2bb1634d53f07d6a04c8d33bcacb41f03)
- [Bump asteval from 0.9.30 to 0.9.31](https://github.com/glotaran/pyglotaran/commit/4258c78107ae4edddb05b5fc3c9aef84b32b996e)
- [Bump numpy from 1.24.3 to 1.24.4](https://github.com/glotaran/pyglotaran/commit/a525ea263b19fdaeb48a4e6f5dcf723490542e26)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)

### Closes issues

closes #1332 
closes #1330 
closes #1331  
closes #1329
closes #1328 
