### PR TITLE
🚧 Back to 0.8.0 development

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,23 @@
 # Changelog
 
+(changes-0_8_0)=
+
+## 🚀 0.8.0 (Unreleased)
+
+### ✨ Features
+
+### 👌 Minor Improvements:
+
+### 🩹 Bug fixes
+
+### 📚 Documentation
+
+### 🗑️ Deprecations (due in 0.9.0)
+
+### 🗑️❌ Deprecated functionality removed in this release
+
+### 🚧 Maintenance
+
 (changes-0_7_1)=
 
 ## 🚀 0.7.1 (2023-07-28)

--- a/glotaran/__init__.py
+++ b/glotaran/__init__.py
@@ -4,7 +4,7 @@ from glotaran.plugin_system.base_registry import load_plugins
 
 load_plugins()
 
-__version__ = "0.7.1"
+__version__ = "0.8.0.dev0"
 
 examples = deprecate_submodule(
     deprecated_module_name="glotaran.examples",


### PR DESCRIPTION
After the `0.7.1` release we can go back to the `0.8.0` development

### Change summary

- [🚧 Back to 0.8.0 development](https://github.com/glotaran/pyglotaran/commit/83889cefbe1b7b8489c6dd35de7b101425a42e3d)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)