### PR TITLE
🧹 Remove unused dependency: rich

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,8 @@
 
 (changes-0_7_1)=
 
+- 🧹 Remove unused dependency: 'rich' (#1345)
+
 ## 🚀 0.7.1 (2023-07-28)
 
 ### ✨ Features

--- a/changelog.md
+++ b/changelog.md
@@ -18,9 +18,9 @@
 
 ### 🚧 Maintenance
 
-(changes-0_7_1)=
-
 - 🧹 Remove unused dependency: 'rich' (#1345)
+
+(changes-0_7_1)=
 
 ## 🚀 0.7.1 (2023-07-28)
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,7 +13,6 @@ odfpy==1.4.1
 openpyxl==3.1.2
 pandas==2.0.3
 pydantic==1.10.12
-rich==13.4.2
 ruamel.yaml==0.17.32
 scipy==1.11.2
 sdtfile==2022.9.28

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     openpyxl>=3.0.10
     pandas>=1.3.4
     pydantic>=1.10.2
-    rich>=10.9.0
     ruamel.yaml>=0.17.17
     scipy>=1.7.2
     sdtfile>=2020.8.3


### PR DESCRIPTION
## Summary

This pull request removes the unused dependency `rich` from the `requirements_dev.txt` and `setup.cfg` configuration files. The removal of this dependency is a finding from ongoing research aimed at identifying and eliminating code bloat within software projects.

## Rationale

The `rich` library was introduced in the project in 2f1afe78 for its use in `glotaran/testing/test/test_model_generators.py`. However, the relevant file was removed on 09de6b2, rendering the dependency unnecessary. Despite its removal from the source code, `rich` remained listed as a requirement in the project's configuration files. Removing this unused dependency  reduces the overall footprint of the application, mitigating potential security risks, and simplifying the dependency management process.

## Changes

- Removed the `rich` dependency from `requirements_dev.txt` and `setup.cfg`

## Impact

- **Reduced Package Size**: The removal of this unused dependency will lead to a decrease in the overall size of the installed packages.
- **Simplified Dependency Tree**: Fewer dependencies make the project easier to maintain and can speed up installation.


### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)


