### PR TITLE
🩹 Fix schema generation by making private attributes private

### DIFF
--- a/glotaran/builtin/elements/baseline/element.py
+++ b/glotaran/builtin/elements/baseline/element.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 class BaselineElement(Element):
     type: Literal["baseline"]  # type:ignore[assignment]
-    _register_as: ClassVar[str] = "baseline"
+    register_as: ClassVar[str] = "baseline"
     _unique: ClassVar[bool] = True
 
     def clp_label(self) -> str:

--- a/glotaran/builtin/elements/baseline/element.py
+++ b/glotaran/builtin/elements/baseline/element.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import ClassVar
 from typing import Literal
 
 import numpy as np
@@ -16,8 +17,8 @@ if TYPE_CHECKING:
 
 class BaselineElement(Element):
     type: Literal["baseline"]  # type:ignore[assignment]
-    register_as: str = "baseline"  # type:ignore[misc]
-    unique: bool = True
+    _register_as: ClassVar[str] = "baseline"
+    _unique: ClassVar[bool] = True
 
     def clp_label(self) -> str:
         return f"baseline_{self.label}"

--- a/glotaran/builtin/elements/clp_guide/element.py
+++ b/glotaran/builtin/elements/clp_guide/element.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import ClassVar
 from typing import Literal
 
 import numpy as np
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
 
 class ClpGuideElement(Element):
     type: Literal["clp-guide"]  # type:ignore[assignment]
-    _register_as: str = "clp-guide"  # type:ignore[misc]
+    register_as: ClassVar[str] = "clp-guide"
     _exclusive: bool = True
     target: str
 

--- a/glotaran/builtin/elements/clp_guide/element.py
+++ b/glotaran/builtin/elements/clp_guide/element.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
 
 class ClpGuideElement(Element):
     type: Literal["clp-guide"]  # type:ignore[assignment]
-    register_as: str = "clp-guide"  # type:ignore[misc]
-    exclusive: bool = True
+    _register_as: str = "clp-guide"  # type:ignore[misc]
+    _exclusive: bool = True
     target: str
 
     def calculate_matrix(

--- a/glotaran/builtin/elements/coherent_artifact/element.py
+++ b/glotaran/builtin/elements/coherent_artifact/element.py
@@ -22,9 +22,9 @@ if TYPE_CHECKING:
 
 class CoherentArtifactElement(Element):
     type: Literal["coherent-artifact"]  # type:ignore[assignment]
-    _register_as: str = "coherent-artifact"  # type:ignore[misc]
+    register_as: ClassVar[str] = "coherent-artifact"
     dimension: str = "time"
-    _data_model_type: ClassVar[type[DataModel]] = ActivationDataModel  # type:ignore[valid-type]
+    data_model_type: ClassVar[type[DataModel]] = ActivationDataModel  # type:ignore[valid-type]
     order: int
     width: ParameterType | None = None
 

--- a/glotaran/builtin/elements/coherent_artifact/element.py
+++ b/glotaran/builtin/elements/coherent_artifact/element.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import ClassVar
 from typing import Literal
 
 import numba as nb
@@ -21,9 +22,9 @@ if TYPE_CHECKING:
 
 class CoherentArtifactElement(Element):
     type: Literal["coherent-artifact"]  # type:ignore[assignment]
-    register_as: str = "coherent-artifact"  # type:ignore[misc]
+    _register_as: str = "coherent-artifact"  # type:ignore[misc]
     dimension: str = "time"
-    data_model_type: type[DataModel] = ActivationDataModel  # type:ignore[misc,valid-type]
+    _data_model_type: ClassVar[type[DataModel]] = ActivationDataModel  # type:ignore[valid-type]
     order: int
     width: ParameterType | None = None
 

--- a/glotaran/builtin/elements/damped_oscillation/element.py
+++ b/glotaran/builtin/elements/damped_oscillation/element.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import ClassVar
 from typing import Literal
 
 import numpy as np
@@ -34,11 +35,9 @@ class Oscillation(Item):
 
 class DampedOscillationElement(Element):
     type: Literal["damped-oscillation"]  # type:ignore[assignment]
-    register_as: str = "damped-oscillation"  # type:ignore[misc]
+    _register_as: str = "damped-oscillation"  # type:ignore[misc]
     dimension: str = "time"
-    data_model_type: type[  # type:ignore[misc,valid-type]
-        DataModel
-    ] = ActivationDataModel
+    _data_model_type: ClassVar[type[DataModel]] = ActivationDataModel  # type:ignore[valid-type]
     oscillations: dict[str, Oscillation]
 
     def calculate_matrix(  # type:ignore[override]

--- a/glotaran/builtin/elements/damped_oscillation/element.py
+++ b/glotaran/builtin/elements/damped_oscillation/element.py
@@ -35,9 +35,9 @@ class Oscillation(Item):
 
 class DampedOscillationElement(Element):
     type: Literal["damped-oscillation"]  # type:ignore[assignment]
-    _register_as: str = "damped-oscillation"  # type:ignore[misc]
+    register_as: ClassVar[str] = "damped-oscillation"
     dimension: str = "time"
-    _data_model_type: ClassVar[type[DataModel]] = ActivationDataModel  # type:ignore[valid-type]
+    data_model_type: ClassVar[type[DataModel]] = ActivationDataModel  # type:ignore[valid-type]
     oscillations: dict[str, Oscillation]
 
     def calculate_matrix(  # type:ignore[override]

--- a/glotaran/builtin/elements/kinetic/element.py
+++ b/glotaran/builtin/elements/kinetic/element.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from functools import reduce
 from typing import TYPE_CHECKING
+from typing import ClassVar
 from typing import Literal
 
 import numpy as np
@@ -23,8 +24,8 @@ if TYPE_CHECKING:
 
 class KineticElement(ExtendableElement, Kinetic):
     type: Literal["kinetic"]  # type:ignore[assignment]
-    register_as: str = "kinetic"  # type:ignore[misc]
-    data_model_type: type[DataModel] = ActivationDataModel  # type:ignore[misc, valid-type]
+    _register_as: ClassVar[str] = "kinetic"
+    _data_model_type: ClassVar[type[DataModel]] = ActivationDataModel  # type:ignore[valid-type]
     dimension: str = "time"
 
     def extend(self, other: KineticElement):  # type:ignore[override]

--- a/glotaran/builtin/elements/kinetic/element.py
+++ b/glotaran/builtin/elements/kinetic/element.py
@@ -24,8 +24,8 @@ if TYPE_CHECKING:
 
 class KineticElement(ExtendableElement, Kinetic):
     type: Literal["kinetic"]  # type:ignore[assignment]
-    _register_as: ClassVar[str] = "kinetic"
-    _data_model_type: ClassVar[type[DataModel]] = ActivationDataModel  # type:ignore[valid-type]
+    register_as: ClassVar[str] = "kinetic"
+    data_model_type: ClassVar[type[DataModel]] = ActivationDataModel  # type:ignore[valid-type]
     dimension: str = "time"
 
     def extend(self, other: KineticElement):  # type:ignore[override]

--- a/glotaran/builtin/elements/spectral/element.py
+++ b/glotaran/builtin/elements/spectral/element.py
@@ -23,9 +23,9 @@ class SpectralDataModel(DataModel):
 
 class SpectralElement(Element):
     type: Literal["spectral"]  # type:ignore[assignment]
-    _register_as: str = "spectral"  # type:ignore[misc]
+    register_as: ClassVar[str] = "spectral"
     dimension: str = "spectral"
-    _data_model_type: ClassVar[type[DataModel]] = SpectralDataModel  # type:ignore[valid-type]
+    data_model_type: ClassVar[type[DataModel]] = SpectralDataModel  # type:ignore[valid-type]
     shapes: dict[str, SpectralShape.get_annotated_type()]  # type:ignore[valid-type]
 
     def calculate_matrix(  # type:ignore[override]

--- a/glotaran/builtin/elements/spectral/element.py
+++ b/glotaran/builtin/elements/spectral/element.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import ClassVar
 from typing import Literal
 
 import numpy as np
@@ -22,9 +23,9 @@ class SpectralDataModel(DataModel):
 
 class SpectralElement(Element):
     type: Literal["spectral"]  # type:ignore[assignment]
-    register_as: str = "spectral"  # type:ignore[misc]
+    _register_as: str = "spectral"  # type:ignore[misc]
     dimension: str = "spectral"
-    data_model_type: type[DataModel] = SpectralDataModel  # type:ignore[misc,valid-type]
+    _data_model_type: ClassVar[type[DataModel]] = SpectralDataModel  # type:ignore[valid-type]
     shapes: dict[str, SpectralShape.get_annotated_type()]  # type:ignore[valid-type]
 
     def calculate_matrix(  # type:ignore[override]

--- a/glotaran/model/data_model.py
+++ b/glotaran/model/data_model.py
@@ -114,14 +114,14 @@ def get_element_issues(value: list[str | Element] | None, is_global: bool) -> li
         elements = [v for v in value if isinstance(v, Element)]
         for element in elements:
             element_type = element.__class__
-            if element_type._is_exclusive and len(elements) > 1:
+            if element_type.is_exclusive and len(elements) > 1:
                 issues.append(
                     ExclusiveModelIssue(
                         element.label, element.type, is_global  # type:ignore[arg-type]
                     )
                 )
             if (
-                element_type._is_unique
+                element_type.is_unique
                 and len([m for m in elements if m.__class__ is element_type]) > 1
             ):
                 issues.append(
@@ -207,7 +207,7 @@ class DataModel(Item):
     def create_class_for_elements(elements: set[type[Element]]) -> type[DataModel]:
         data_model_cls_name = f"GlotaranDataModel_{str(uuid4()).replace('-','_')}"
         data_models = (
-            *tuple({e._data_model_type for e in elements if e._data_model_type is not None}),
+            *tuple({e.data_model_type for e in elements if e.data_model_type is not None}),
             DataModel,
         )
         return create_model(data_model_cls_name, __base__=data_models)

--- a/glotaran/model/data_model.py
+++ b/glotaran/model/data_model.py
@@ -114,14 +114,14 @@ def get_element_issues(value: list[str | Element] | None, is_global: bool) -> li
         elements = [v for v in value if isinstance(v, Element)]
         for element in elements:
             element_type = element.__class__
-            if element_type.is_exclusive and len(elements) > 1:
+            if element_type._is_exclusive and len(elements) > 1:
                 issues.append(
                     ExclusiveModelIssue(
                         element.label, element.type, is_global  # type:ignore[arg-type]
                     )
                 )
             if (
-                element_type.is_unique
+                element_type._is_unique
                 and len([m for m in elements if m.__class__ is element_type]) > 1
             ):
                 issues.append(
@@ -207,14 +207,7 @@ class DataModel(Item):
     def create_class_for_elements(elements: set[type[Element]]) -> type[DataModel]:
         data_model_cls_name = f"GlotaranDataModel_{str(uuid4()).replace('-','_')}"
         data_models = (
-            *tuple(
-                {
-                    e.model_fields["data_model_type"].default
-                    for e in elements
-                    if "data_model_type" in e.model_fields
-                    and e.model_fields["data_model_type"].default is not None
-                }
-            ),
+            *tuple({e._data_model_type for e in elements if e._data_model_type is not None}),
             DataModel,
         )
         return create_model(data_model_cls_name, __base__=data_models)

--- a/glotaran/model/element.py
+++ b/glotaran/model/element.py
@@ -22,10 +22,10 @@ class Element(TypedItem, abc.ABC):
     Subclasses must overwrite :method:`glotaran.model.Element.calculate_matrix`.
     """
 
-    data_model_type: ClassVar[type | None] = None
-    is_exclusive: ClassVar[bool] = False
-    is_unique: ClassVar[bool] = False
-    register_as: ClassVar[str | None] = None
+    _data_model_type: ClassVar[type | None] = None
+    _is_exclusive: ClassVar[bool] = False
+    _is_unique: ClassVar[bool] = False
+    _register_as: ClassVar[str | None] = None
 
     dimension: str | None = None
     label: str
@@ -33,8 +33,8 @@ class Element(TypedItem, abc.ABC):
     def __init_subclass__(cls):
         """Register the model if necessary."""
         super().__init_subclass__()
-        if cls.register_as is not None:
-            register_element(cls.register_as, cls)
+        if cls._register_as is not None:
+            register_element(cls._register_as, cls)
 
     @abc.abstractmethod
     def calculate_matrix(

--- a/glotaran/model/element.py
+++ b/glotaran/model/element.py
@@ -17,15 +17,12 @@ if TYPE_CHECKING:
 
 
 class Element(TypedItem, abc.ABC):
-    """
+    """Subclasses must overwrite :method:`glotaran.model.Element.calculate_matrix`."""
 
-    Subclasses must overwrite :method:`glotaran.model.Element.calculate_matrix`.
-    """
-
-    _data_model_type: ClassVar[type | None] = None
-    _is_exclusive: ClassVar[bool] = False
-    _is_unique: ClassVar[bool] = False
-    _register_as: ClassVar[str | None] = None
+    data_model_type: ClassVar[type | None] = None
+    is_exclusive: ClassVar[bool] = False
+    is_unique: ClassVar[bool] = False
+    register_as: ClassVar[str | None] = None
 
     dimension: str | None = None
     label: str
@@ -33,8 +30,8 @@ class Element(TypedItem, abc.ABC):
     def __init_subclass__(cls):
         """Register the model if necessary."""
         super().__init_subclass__()
-        if cls._register_as is not None:
-            register_element(cls._register_as, cls)
+        if cls.register_as is not None:
+            register_element(cls.register_as, cls)
 
     @abc.abstractmethod
     def calculate_matrix(

--- a/glotaran/model/test/test_data_model.py
+++ b/glotaran/model/test/test_data_model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import ClassVar
 from typing import Literal
 
 import numpy as np
@@ -23,7 +24,7 @@ class MockDataModel(DataModel):
 class MockElementWithDataModel(Element):
     type: Literal["mock-w-datamodel"]
     dimension: str = "model"
-    data_model_type: type[DataModel] = MockDataModel
+    _data_model_type: ClassVar[type[DataModel]] = MockDataModel
 
     def calculate_matrix(
         self,
@@ -59,7 +60,7 @@ class MockElementNonUniqueExclusive(Element):
 
 class MockElementExclusive(Element):
     type: Literal["test_element_exclusive"]
-    is_exclusive = True
+    _is_exclusive = True
 
     def calculate_matrix():
         pass
@@ -67,7 +68,7 @@ class MockElementExclusive(Element):
 
 class MockElementUnique(Element):
     type: Literal["test_element_unique"]
-    is_unique = True
+    _is_unique = True
 
     def calculate_matrix():
         pass

--- a/glotaran/model/test/test_data_model.py
+++ b/glotaran/model/test/test_data_model.py
@@ -24,7 +24,7 @@ class MockDataModel(DataModel):
 class MockElementWithDataModel(Element):
     type: Literal["mock-w-datamodel"]
     dimension: str = "model"
-    _data_model_type: ClassVar[type[DataModel]] = MockDataModel
+    data_model_type: ClassVar[type[DataModel]] = MockDataModel
 
     def calculate_matrix(
         self,
@@ -60,7 +60,7 @@ class MockElementNonUniqueExclusive(Element):
 
 class MockElementExclusive(Element):
     type: Literal["test_element_exclusive"]
-    _is_exclusive = True
+    is_exclusive = True
 
     def calculate_matrix():
         pass
@@ -68,7 +68,7 @@ class MockElementExclusive(Element):
 
 class MockElementUnique(Element):
     type: Literal["test_element_unique"]
-    _is_unique = True
+    is_unique = True
 
     def calculate_matrix():
         pass


### PR DESCRIPTION
With pydantic 2 we had crashes when calling `.model_json_schema()` e.g.

```py
from glotaran.project import Scheme

Scheme.model_json_schema()
```

The main reason for this was pydatic failure to serialize `data_model_type` to json since the value is a class.

~~This can all be prevented by making internal only fields "private" (leading `_`) so they get excluded from the schema since we don't want users to put values for them anyway.~~

As @joernweissenborn  noted properly typing the fields with `ClassVar` those variables will also not be considered for the schema.