### PR TITLE
🩹 Fix load_plugins deprecation warning

### DIFF
--- a/glotaran/__init__.py
+++ b/glotaran/__init__.py
@@ -6,7 +6,6 @@ load_plugins()
 
 __version__ = "0.8.0.dev0"
 
-load_plugins()
 
 examples = deprecate_submodule(
     deprecated_module_name="glotaran.examples",

--- a/glotaran/plugin_system/base_registry.py
+++ b/glotaran/plugin_system/base_registry.py
@@ -127,7 +127,9 @@ def load_plugins():
             "glotaran.plugins.project_io",
         ]
         entry_points = metadata.entry_points()
-        for entry_points in [entry_points[p] for p in plugin_names]:  # type:ignore[assignment]
+        for entry_points in [  # type:ignore[assignment]
+            entry_points.select(group=plugin_name) for plugin_name in plugin_names
+        ]:
             for entry_point in entry_points:
                 entry_point.load()  # type:ignore[attr-defined]
 


### PR DESCRIPTION
This fixes the deprecation warning caused by `load_plugins` we see in the tests

```py
glotaran/plugin_system/base_registry.py:130
glotaran/plugin_system/base_registry.py:130
glotaran/plugin_system/base_registry.py:130
glotaran/plugin_system/base_registry.py:130
glotaran/plugin_system/base_registry.py:130
glotaran/plugin_system/base_registry.py:130
  /home/runner/work/pyglotaran/pyglotaran/glotaran/plugin_system/base_registry.py:130: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for entry_points in [entry_points[p] for p in plugin_names]:  # type:ignore[assignment]
```