### PR TITLE
🚀 Prepare 0.7.2 release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,20 +1,12 @@
 # Changelog
 
-(changes-0_8_0)=
+(changes-0_7_2)=
 
-## 🚀 0.8.0 (Unreleased)
+## 🚀 0.7.2 (Unreleased)
 
 ### ✨ Features
 
-### 👌 Minor Improvements:
-
-### 🩹 Bug fixes
-
-### 📚 Documentation
-
-### 🗑️ Deprecations (due in 0.9.0)
-
-### 🗑️❌ Deprecated functionality removed in this release
+- ✨ Official numpy 1.26 support (#1374)
 
 ### 🚧 Maintenance
 

--- a/glotaran/__init__.py
+++ b/glotaran/__init__.py
@@ -4,7 +4,7 @@ from glotaran.plugin_system.base_registry import load_plugins
 
 load_plugins()
 
-__version__ = "0.8.0.dev0"
+__version__ = "0.7.2"
 
 examples = deprecate_submodule(
     deprecated_module_name="glotaran.examples",


### PR DESCRIPTION
This PR prepares the `0.7.2` release.
While only a few things on our side changed the raised numpy support is worth a release.

> [!CAUTION]
> As last change **before** merging we still need to update the release date in the change log.

### Change summary

- [⬆️🚀 Change version from 0.8.0.dev0 to 0.7.2](https://github.com/glotaran/pyglotaran/commit/982e923682ffc2d12241fb8c031a9461c23468ac)
- [⬆️📚 Update version in change log](https://github.com/glotaran/pyglotaran/commit/6be6267fa88566cc626907a4a7ee1e7344450815)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
