### PR TITLE
🩹Fix for when the backsweep is a parameter rather than constant

### DIFF
--- a/glotaran/builtin/items/activation/gaussian.py
+++ b/glotaran/builtin/items/activation/gaussian.py
@@ -12,7 +12,6 @@ from glotaran.model.errors import GlotaranUserError
 from glotaran.model.errors import ItemIssue
 from glotaran.model.item import Attribute
 from glotaran.model.item import ParameterType
-from glotaran.parameter.parameter import Parameter
 
 if TYPE_CHECKING:
     from glotaran.parameter import Parameters
@@ -172,9 +171,7 @@ class MultiGaussianActivation(Activation):
 
         scales = self.scale or [1.0] * nr_gaussians
         backsweep = self.backsweep is not None
-        backsweep_period = self.backsweep if backsweep else 0
-        if isinstance(backsweep_period, Parameter):
-            backsweep_period = backsweep_period.value
+        backsweep_period = float(self.backsweep) if backsweep else 0
 
         parameters: list[GaussianActivationParameters] = [
             GaussianActivationParameters(

--- a/glotaran/builtin/items/activation/gaussian.py
+++ b/glotaran/builtin/items/activation/gaussian.py
@@ -171,7 +171,7 @@ class MultiGaussianActivation(Activation):
 
         scales = self.scale or [1.0] * nr_gaussians
         backsweep = self.backsweep is not None
-        backsweep_period = float(self.backsweep) if backsweep else 0
+        backsweep_period = float(self.backsweep) if self.backsweep is not None else 0
 
         parameters: list[GaussianActivationParameters] = [
             GaussianActivationParameters(
@@ -179,7 +179,7 @@ class MultiGaussianActivation(Activation):
                 float(width),
                 float(scale),
                 backsweep,
-                backsweep_period,  # type:ignore[arg-type]
+                backsweep_period,
             )
             for center, width, scale in zip(centers, widths, scales)
         ]

--- a/glotaran/builtin/items/activation/gaussian.py
+++ b/glotaran/builtin/items/activation/gaussian.py
@@ -12,6 +12,7 @@ from glotaran.model.errors import GlotaranUserError
 from glotaran.model.errors import ItemIssue
 from glotaran.model.item import Attribute
 from glotaran.model.item import ParameterType
+from glotaran.parameter.parameter import Parameter
 
 if TYPE_CHECKING:
     from glotaran.parameter import Parameters
@@ -172,6 +173,8 @@ class MultiGaussianActivation(Activation):
         scales = self.scale or [1.0] * nr_gaussians
         backsweep = self.backsweep is not None
         backsweep_period = self.backsweep if backsweep else 0
+        if isinstance(backsweep_period, Parameter):
+            backsweep_period = backsweep_period.value
 
         parameters: list[GaussianActivationParameters] = [
             GaussianActivationParameters(

--- a/glotaran/builtin/items/activation/gaussian.py
+++ b/glotaran/builtin/items/activation/gaussian.py
@@ -12,6 +12,7 @@ from glotaran.model.errors import GlotaranUserError
 from glotaran.model.errors import ItemIssue
 from glotaran.model.item import Attribute
 from glotaran.model.item import ParameterType
+from glotaran.parameter.parameter import Parameter
 
 if TYPE_CHECKING:
     from glotaran.parameter import Parameters
@@ -171,7 +172,9 @@ class MultiGaussianActivation(Activation):
 
         scales = self.scale or [1.0] * nr_gaussians
         backsweep = self.backsweep is not None
-        backsweep_period = float(self.backsweep) if backsweep else 0
+        backsweep_period = self.backsweep if backsweep else 0
+        if isinstance(backsweep_period, Parameter):
+            backsweep_period = backsweep_period.value
 
         parameters: list[GaussianActivationParameters] = [
             GaussianActivationParameters(


### PR DESCRIPTION
The optimizer would crash

When setting the values in the model scheme from a constant to a parameter, the optimizer would crash with "Cannot determine Numba type of <class 'glotaran.parameter.parameter.Parameter'> " as it tried to use the parameter as a numeric value. Ultimately numba would complain as that's where the value would be first used.

Specifically: `"glotaran\builtin\elements\kinetic\matrix.py", line 27`

<sub>Note: This PR doesn't add a unit test (yet), but that should be added at the level of the optimizer since the element tests themselves work only with numeric definitions.</sub>
