### PR TITLE
🧹 Remove redundant backsweep flag from GaussianActivationParameters

### DIFF
--- a/glotaran/builtin/elements/kinetic/element.py
+++ b/glotaran/builtin/elements/kinetic/element.py
@@ -136,7 +136,6 @@ class KineticElement(ExtendableElement, Kinetic):
                 np.array([[p.center for p in ps] for ps in parameters]),  # type:ignore[union-attr]
                 np.array([[p.width for p in ps] for ps in parameters]),  # type:ignore[union-attr]
                 scales,
-                parameters[0][0].backsweep,  # type:ignore[index]
                 parameters[0][0].backsweep_period,  # type:ignore[index]
             )
         else:
@@ -147,7 +146,6 @@ class KineticElement(ExtendableElement, Kinetic):
                 np.array([p.center for p in parameters]),  # type:ignore[union-attr]
                 np.array([p.width for p in parameters]),  # type:ignore[union-attr]
                 scales,
-                parameters[0].backsweep,  # type:ignore[union-attr]
                 parameters[0].backsweep_period,  # type:ignore[union-attr]
             )
         if activation.normalize:

--- a/glotaran/builtin/items/activation/gaussian.py
+++ b/glotaran/builtin/items/activation/gaussian.py
@@ -81,7 +81,6 @@ class GaussianActivationParameters:
     center: float
     width: float
     scale: float
-    backsweep: bool
     backsweep_period: float
 
     def shift(self, value: float):
@@ -170,7 +169,6 @@ class MultiGaussianActivation(Activation):
                 widths = widths * nr_gaussians
 
         scales = self.scale or [1.0] * nr_gaussians
-        backsweep = self.backsweep is not None
         backsweep_period = float(self.backsweep) if self.backsweep is not None else 0
 
         parameters: list[GaussianActivationParameters] = [
@@ -178,7 +176,6 @@ class MultiGaussianActivation(Activation):
                 float(center),
                 float(width),
                 float(scale),
-                backsweep,
                 backsweep_period,
             )
             for center, width, scale in zip(centers, widths, scales)

--- a/tests/builtin/items/activation/test_activation.py
+++ b/tests/builtin/items/activation/test_activation.py
@@ -18,7 +18,6 @@ def test_gaussian_activation():
     )
     parameter = activation.parameters(np.array([0]))
     assert len(parameter) == 1
-    assert parameter[0].backsweep
     assert parameter[0].backsweep_period == 2
     assert parameter[0].center == 1
     assert parameter[0].width == 10
@@ -33,7 +32,7 @@ def test_multi_gaussian_activation():
     )
     parameter = activation.parameters(np.array([0]))
     assert len(parameter) == 2
-    assert not parameter[0].backsweep
+    assert parameter[0].backsweep_period == 0
     assert parameter[0].center == 1
     assert parameter[0].width == 10
     assert parameter[1].center == 2


### PR DESCRIPTION
Just a small additional clean-up after #1422 to get rid of the `backsweep` boolean flag, which is a residual of the [`< 0.8` model syntax when we had this as user input](https://github.com/glotaran/pyglotaran-examples/blob/dc7436798fdc44e5b8fc74c20e9afe452f8e10ee/pyglotaran_examples/study_fluorescence/models/model-target.yaml#L31).

### Change summary

- [🧹 Remove redundant backsweep flag from GaussianActivationParameters](https://github.com/glotaran/pyglotaran/commit/438a7e9a3fa9bf0874dd5c76e7b2958838c14962)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)