### PR TITLE
🧹 Use element plugin registry to define LibraryType

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "1.5.1"
+    rev: "1.7.0"
     hooks:
       - id: pyproject-fmt
 
@@ -51,7 +51,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.6
+    rev: v0.2.0
     hooks:
       - id: ruff
         name: "ruff sort notebooks"
@@ -77,7 +77,7 @@ repos:
   # Linters
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.2.0
     hooks:
       - id: ruff
         name: "ruff sort imports"
@@ -105,7 +105,7 @@ repos:
   #       additional_dependencies: [flake8-docstrings, darglint==1.8.0]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.0
+    rev: v1.8.0
     hooks:
       - id: mypy
         exclude: "docs|benchmark/|tests/.*"

--- a/.ruff-notebooks.toml
+++ b/.ruff-notebooks.toml
@@ -1,7 +1,10 @@
 #:schema https://json.schemastore.org/ruff.json
+
 extend = ".ruff.toml"
+
+[lint]
 extend-ignore = ["D", "E402", "F404", "N811", "E703", "T201"]
 
-[isort]
+[lint.isort]
 required-imports = []
 force-single-line = false

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,14 @@
+extend-exclude = ["venv", "docs/conf.py"]
 
+line-length = 99
+
+# Assume Python 3.10.
+target-version = "py310"
+
+# Enable using ruff with notebooks
+extend-include = ["*.ipynb"]
+
+[lint]
 select = [
   "E", # pycodestyle
   "W", # pycodestyle
@@ -6,14 +16,14 @@ select = [
   "F", # pyflakes
   # "UP", # pyupgrade
   # "D", # pydocstyle
-  "N", # pep8-naming
+  "N",   # pep8-naming
   "YTT", # flake8-2020
   "BLE", # flake8-blind-except
   # "FBT", # flake8-boolean-trap
   # "B", # flake8-bugbear
-  "C4", # flake8-comprehensions
+  "C4",  # flake8-comprehensions
   "T10", # flake8-debugger
-  "FA", # flake8-future-annotations
+  "FA",  # flake8-future-annotations
   # "EM", # flake8-errmsg
   "ISC", # flake8-implicit-str-concat
   "INP", # flake8-no-pep420
@@ -27,7 +37,7 @@ select = [
   # "ARG", # flake8-unused-arguments
   "PTH", # flake8-use-pathlib
   # "ERA", # eradicate
-  "PD", # pandas-vet
+  "PD",  # pandas-vet
   "PGH", # pygrep-hooks
   "NPY", # NumPy-specific
   "RUF", # Ruff-specific
@@ -49,27 +59,12 @@ ignore = [
   "ISC001",
 ]
 
-# Exclude a variety of commonly ignored directories.
-extend-exclude = [
-  "venv",
-  "docs/conf.py",
-]
-# Same as Black.
-line-length = 99
-
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.10.
-target-version = "py310"
-
-# Enable using ruff with notebooks
-extend-include = ["*.ipynb"]
-
-[lint]
 unfixable = ["F401"]
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "*/test_*.py" = ["ARG001", "RUF012", "N811", "T20", "PIE804"]
 "*/__init__.py" = ["F401"]
 "glotaran/builtin/io/netCDF/netCDF.py" = ["N999"]
@@ -77,7 +72,7 @@ unfixable = ["F401"]
 # Needs a full rewrite anyway
 "glotaran/builtin/io/ascii/wavelength_time_explicit_file.py" = ["PTH"]
 
-[isort]
+[lint.isort]
 required-imports = ["from __future__ import annotations"]
 known-first-party = ["glotaran"]
 force-single-line = true

--- a/glotaran/model/element.py
+++ b/glotaran/model/element.py
@@ -5,7 +5,6 @@ import abc
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Literal
 
 from pydantic import ConfigDict
 
@@ -104,11 +103,3 @@ class ExtendableElement(Element):
     @abc.abstractmethod
     def extend(self, other: ExtendableElement) -> ExtendableElement:
         pass
-
-
-class InternalMockElement(Element):
-    """An internal model for testing purpose, since at least 2 items
-    are needed for pydanticx discriminators.
-    """
-
-    type: Literal["internal_mock"]  # type:ignore[assignment]

--- a/glotaran/model/item.py
+++ b/glotaran/model/item.py
@@ -47,7 +47,7 @@ class GlotaranFieldMetadata(UserDict):
     @property
     def validator(self) -> Callable | None:
         """Glotaran validator function if defined, else None."""
-        return self[META_VALIDATOR] if META_VALIDATOR in self else None
+        return self.get(META_VALIDATOR, None)
 
 
 def extract_glotaran_field_metadata(info: FieldInfo) -> GlotaranFieldMetadata:

--- a/glotaran/project/library.py
+++ b/glotaran/project/library.py
@@ -2,14 +2,18 @@ from __future__ import annotations
 
 from functools import reduce
 from typing import TypeAlias
+from typing import Union
 
 from pydantic import RootModel
 
-from glotaran.model.element import Element
 from glotaran.model.element import ExtendableElement
 from glotaran.model.errors import GlotaranModelError
+from glotaran.plugin_system.base_registry import __PluginRegistry
 
-LibraryType: TypeAlias = dict[str, Element.get_annotated_type()]  # type:ignore[misc,valid-type]
+LibraryType: TypeAlias = dict[  # type:ignore[misc,valid-type]
+    str,
+    Union[tuple(__PluginRegistry.element.values())],
+]
 
 
 class ModelLibrary(RootModel[LibraryType]):

--- a/tests/deprecation/test_deprecation_utils.py
+++ b/tests/deprecation/test_deprecation_utils.py
@@ -437,7 +437,7 @@ def test_deprecate_dict_key_does_not_apply_swap_keys():
 )
 @pytest.mark.usefixtures("glotaran_0_3_0")
 def test_deprecate_dict_key_does_not_apply(
-    replace_rules: tuple[Mapping[Hashable, Any], Mapping[Hashable, Any]]
+    replace_rules: tuple[Mapping[Hashable, Any], Mapping[Hashable, Any]],
 ):
     """Don't warn if the dict doesn't change because old_key or old_value didn't match"""
     with pytest.warns(

--- a/tests/parameter/test_parameter.py
+++ b/tests/parameter/test_parameter.py
@@ -72,7 +72,7 @@ def test_parameter_repr(parameter: Parameter, expected_repr: str):
     """Repr creates code to recreate the object."""
     print(parameter.__repr__())
     assert parameter.__repr__() == expected_repr
-    assert parameter._deep_equals(eval(expected_repr))  # noqa: PGH001
+    assert parameter._deep_equals(eval(expected_repr))
 
 
 def test_parameter_from_list():

--- a/tests/parameter/test_parameters_rendering.py
+++ b/tests/parameter/test_parameters_rendering.py
@@ -111,7 +111,7 @@ def test_parameters_repr():
 
     print(result.__repr__())
     assert result.__repr__() == expected
-    assert result == eval(expected)  # noqa: PGH001
+    assert result == eval(expected)
 
 
 def test_parameters_ipython_rendering():


### PR DESCRIPTION
By using the plugin registry instead of looking up inheritance we can ensure that only elements that were explicitly added are valid types (e.g. `ExtendableElement` is not instantiable by itself and should not be part of `LibraryType`).

### Change summary

- [🧹 Use element plugin registry to define LibraryType](https://github.com/glotaran/pyglotaran/commit/becc4b6a88232169950f32a05674eb769b967182)
- [🧹 Remove InternalMockElement](https://github.com/glotaran/pyglotaran/commit/fa8b6775b939f12dc03bf5b4d44e9afc4f8968ad)
- [🧰⬆️ Update pre-commit config](https://github.com/glotaran/pyglotaran/commit/28e405141889baac9b0378b3ffb97838223a707a)


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)