### PR TITLE
⬆️ Combined python updates

### DIFF
--- a/glotaran/builtin/io/pandas/csv.py
+++ b/glotaran/builtin/io/pandas/csv.py
@@ -33,7 +33,7 @@ class CsvProjectIo(ProjectIoInterface):
         """
         df = pd.read_csv(file_name, skipinitialspace=True, na_values=["None", "none"], sep=sep)
         df.columns = [column.lower() for column in df.columns]
-        df.rename(columns=OPTION_NAMES_DESERIALIZED, inplace=True)
+        df = df.rename(columns=OPTION_NAMES_DESERIALIZED)
         safe_dataframe_fillna(df, "minimum", -np.inf)
         safe_dataframe_fillna(df, "maximum", np.inf)
         return Parameters.from_dataframe(df, source=file_name)

--- a/glotaran/builtin/io/pandas/xlsx.py
+++ b/glotaran/builtin/io/pandas/xlsx.py
@@ -31,7 +31,7 @@ class ExcelProjectIo(ProjectIoInterface):
         """
         df = pd.read_excel(file_name, na_values=["None", "none"])
         df.columns = [column.lower() for column in df.columns]
-        df.rename(columns=OPTION_NAMES_DESERIALIZED, inplace=True)
+        df = df.rename(columns=OPTION_NAMES_DESERIALIZED)
         safe_dataframe_fillna(df, "minimum", -np.inf)
         safe_dataframe_fillna(df, "maximum", np.inf)
         return Parameters.from_dataframe(df, source=file_name)

--- a/glotaran/utils/io.py
+++ b/glotaran/utils/io.py
@@ -266,7 +266,7 @@ def safe_dataframe_fillna(df: pd.DataFrame, column_name: str, fill_value: Any) -
         Value to fill NaNs with
     """
     if column_name in df.columns:
-        df[column_name].fillna(fill_value, inplace=True)
+        df[column_name] = df[column_name].fillna(fill_value)
 
 
 def safe_dataframe_replace(
@@ -291,7 +291,7 @@ def safe_dataframe_replace(
     if not isinstance(to_be_replaced_values, (list, tuple)):
         to_be_replaced_values = [to_be_replaced_values]
     if column_name in df.columns:
-        df[column_name].replace(to_be_replaced_values, replace_value, inplace=True)
+        df[column_name] = df[column_name].replace(to_be_replaced_values, replace_value)
 
 
 def get_script_dir(*, nesting: int = 0) -> Path:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ asteval==0.9.31
 attrs == 23.1.0
 click==8.1.7
 netCDF4==1.6.5
-numba==0.58.1
+numba==0.59.0
 numpy==1.26.2
 odfpy==1.4.1
 openpyxl==3.1.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ numba==0.58.1
 numpy==1.26.2
 odfpy==1.4.1
 openpyxl==3.1.2
-pandas==2.1.4
+pandas==2.2.1
 pydantic==1.10.13
 ruamel.yaml==0.18.5
 scipy==1.11.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ pip>=18.0
 wheel>=0.38.0
 
 # glotaran setup dependencies
-asteval==0.9.31
+asteval==0.9.32
 attrs == 23.1.0
 click==8.1.7
 netCDF4==1.6.5

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ attrs == 23.1.0
 click==8.1.7
 netCDF4==1.6.5
 numba==0.59.0
-numpy==1.26.2
+numpy==1.26.4
 odfpy==1.4.1
 openpyxl==3.1.2
 pandas==2.2.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ wheel>=0.38.0
 
 # glotaran setup dependencies
 asteval==0.9.32
-attrs == 23.1.0
+attrs == 23.2.0
 click==8.1.7
 netCDF4==1.6.5
 numba==0.59.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,7 +13,7 @@ odfpy==1.4.1
 openpyxl==3.1.2
 pandas==2.2.1
 pydantic==1.10.14
-ruamel.yaml==0.18.5
+ruamel.yaml==0.18.6
 scipy==1.11.4
 sdtfile==2023.9.28
 tabulate==0.9.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,7 +17,7 @@ ruamel.yaml==0.18.6
 scipy==1.12.0
 sdtfile==2023.9.28
 tabulate==0.9.0
-xarray==2023.11.0
+xarray==2024.2.0
 
 # documentation dependencies
 -r docs/requirements.txt

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ numpy==1.26.4
 odfpy==1.4.1
 openpyxl==3.1.2
 pandas==2.2.1
-pydantic==1.10.13
+pydantic==1.10.14
 ruamel.yaml==0.18.5
 scipy==1.11.4
 sdtfile==2023.9.28

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,7 +14,7 @@ openpyxl==3.1.2
 pandas==2.2.1
 pydantic==1.10.14
 ruamel.yaml==0.18.6
-scipy==1.11.4
+scipy==1.12.0
 sdtfile==2023.9.28
 tabulate==0.9.0
 xarray==2023.11.0


### PR DESCRIPTION
Combined update of python dependencies

### Change summary

- [Bump pandas from 2.1.4 to 2.2.1](https://github.com/glotaran/pyglotaran/commit/24e9878d6b5094265e98f5673665de261034e24f)
- [🩹🗑️ Fix pandas deprecations](https://github.com/glotaran/pyglotaran/commit/db8fab4752bdc70c653f10ff6c0b4ff1ea2da28d)
- [Bump numba from 0.58.1 to 0.59.0](https://github.com/glotaran/pyglotaran/commit/a6a592b2e4cbd4241609fe6db450dcf902464ead)
- [Bump numpy from 1.26.2 to 1.26.4](https://github.com/glotaran/pyglotaran/commit/a477445bbb1a2003c6a0c2a954b9023c9a2b3f4a)
- [Bump asteval from 0.9.31 to 0.9.32](https://github.com/glotaran/pyglotaran/commit/3b18dc4d3d71ad60ce02447675c939fa82d2c991)
- [Bump attrs from 23.1.0 to 23.2.0](https://github.com/glotaran/pyglotaran/commit/b4d24126b97e54f0aa5087379c97846e5d46dc4c)
- [Bump pydantic from 1.10.13 to 1.10.14](https://github.com/glotaran/pyglotaran/commit/dee9056747b348586bbfd4c31ce4c2033dc2b27d)
- [Bump ruamel-yaml from 0.18.5 to 0.18.6](https://github.com/glotaran/pyglotaran/commit/1cdf87d7b107064c1a605c6d36d13df838bb7de6)
- [Bump scipy from 1.11.4 to 1.12.0](https://github.com/glotaran/pyglotaran/commit/1d7b3261f8714dc150300a3e7d6748ee541d4b6c)
- [Bump xarray from 2023.11.0 to 2024.2.0](https://github.com/glotaran/pyglotaran/commit/06edc16fa70c8024f46b4b22324cc72c14538c1a)


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

closes #1413
closes #1416
closes #1421
closes #1428 
closes #1430 
closes #1431 
closes #1432 
closes #1433 
closes #1434
