### PR TITLE
✨ Add official Python 3.12 support

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -117,7 +117,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+(changes-0_7_3)=
+
+## 🚀 0.7.3 (Not released)
+
+### ✨ Features
+
+- ✨ Add official Python 3.12 support (#1437)
+
 (changes-0_7_2)=
 
 ## 🚀 0.7.2 (2023-12-07)

--- a/glotaran/plugin_system/base_registry.py
+++ b/glotaran/plugin_system/base_registry.py
@@ -8,6 +8,7 @@ This is to prevent issues with circular imports.
 from __future__ import annotations
 
 import os
+import sys
 from collections.abc import Iterable
 from importlib import metadata
 from typing import TYPE_CHECKING
@@ -122,10 +123,15 @@ def load_plugins():
     - ``glotaran.plugins.project_io``
     """
     if "DEACTIVATE_GTA_PLUGINS" not in os.environ:  # pragma: no branch
-        for entry_point_name, entry_points in metadata.entry_points().items():
-            if entry_point_name.startswith("glotaran.plugins"):
-                for entry_point in entry_points:
-                    entry_point.load()
+        if sys.version_info < (3, 12):
+            for entry_point_name, entry_points in metadata.entry_points().items():
+                if entry_point_name.startswith("glotaran.plugins"):
+                    for entry_point in entry_points:
+                        entry_point.load()
+        else:
+            for entry_point in metadata.entry_points():
+                if entry_point.group.startswith("glotaran.plugins"):  # type:ignore[attr-defined]
+                    entry_point.load()  # type:ignore[attr-defined]
 
 
 def set_plugin(

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     sdtfile>=2020.8.3
     tabulate>=0.8.9
     xarray>=2022.3.0
-python_requires = >=3.10, <3.12
+python_requires = >=3.10, <3.13
 tests_require = pytest
 zip_safe = True
 


### PR DESCRIPTION
[Numba 0.59.0 added python 3.12 support](https://github.com/numba/numba/releases/tag/0.59.0), which means so can we.

### Change summary

- [✨ Add official Python 3.12 support](https://github.com/glotaran/pyglotaran/commit/2c993be287b3a8ab8c16668bde0a478b5431d8c8)


### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
