### PR TITLE
🚇🧹 Switch back to GeekyEggo/delete-artifact

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -82,9 +82,7 @@ jobs:
           overwrite: true
 
       - name: Delete Intermediate artifacts
-        #  TODO: Switch back to GeekyEggo/delete-artifact after
-        #  https://github.com/GeekyEggo/delete-artifact/pull/24 is merged
-        uses: s-weigand/delete-artifact@use-actions-artifact
+        uses: GeekyEggo/delete-artifact@v5
         with:
           name: example-plots-*
 
@@ -108,9 +106,7 @@ jobs:
           path: comparison-results-current
 
       - name: Delete Intermediate artifacts
-        #  TODO: Switch back to GeekyEggo/delete-artifact after
-        #  https://github.com/GeekyEggo/delete-artifact/pull/24 is merged
-        uses: s-weigand/delete-artifact@use-actions-artifact
+        uses: GeekyEggo/delete-artifact@v5
         with:
           name: example-results-*
 


### PR DESCRIPTION
Switch back to `GeekyEggo/delete-artifact` after the permission issue fix was released.

### Change summary

- [🚇🧹 Switch back to GeekyEggo/delete-artifact](https://github.com/glotaran/pyglotaran-extras/commit/e8fd9533ecf2446edd817132d6f0b18fa0e30055)


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)