### PR TITLE
🚇 Use pyglotaran-examples@staging_rewrite for CI integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,10 +18,11 @@ jobs:
     steps:
       - name: Set example list output
         id: create-example-list
-        uses: glotaran/pyglotaran-examples@main
+        uses: glotaran/pyglotaran-examples@staging_rewrite
         with:
           example_name: set example list
           set_example_list: true
+          examples_branch: staging_rewrite
 
   run-examples:
     name: "Run Example: "
@@ -33,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install pyglotaran
@@ -43,29 +44,76 @@ jobs:
           pip install .
       - name: ${{ matrix.example_name }}
         id: example-run
-        uses: glotaran/pyglotaran-examples@main
+        uses: glotaran/pyglotaran-examples@staging_rewrite
         with:
           example_name: ${{ matrix.example_name }}
+          examples_branch: staging_rewrite
       - name: Installed packages
         if: always()
         run: |
           pip freeze
-      - name: Upload Example Plots Artifact
-        uses: actions/upload-artifact@v3
+
+      - name: Upload Example Notebook Artifact
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          name: example-plots
-          path: ${{ steps.example-run.outputs.plots-path }}
+          name: example-notebooks-${{ matrix.example_name }}
+          path: ${{ steps.example-run.outputs.notebook-path }}
 
       - name: Upload Example Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-results-${{ matrix.example_name }}
+          path: ~/pyglotaran_examples_results_staging
+
+  collect-artifacts:
+    if: always()
+    name: "Collect artifacts and reupload as bundel"
+    runs-on: ubuntu-latest
+    needs: [run-examples]
+    steps:
+      - name: Download Notebooks Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: example-notebooks
+          pattern: example-notebooks-*
+          merge-multiple: true
+
+      - name: Upload Example Notebooks Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-notebooks
+          path: example-notebooks
+          overwrite: true
+
+      - name: Delete Intermediate Notebooks artifacts
+        uses: GeekyEggo/delete-artifact@v5
+        with:
+          name: example-notebooks-*
+
+      - name: Download Result Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: example-results
+          pattern: example-results-*
+          merge-multiple: true
+
+      - name: Upload Example Result Artifact
+        uses: actions/upload-artifact@v4
         with:
           name: example-results
-          path: ~/pyglotaran_examples_results
+          path: example-results
+          overwrite: true
+
+      - name: Delete Intermediate Result artifacts
+        uses: GeekyEggo/delete-artifact@v5
+        with:
+          name: example-results-*
 
   compare-results:
     name: Compare Results
     runs-on: ubuntu-latest
-    needs: [run-examples]
+    needs: [collect-artifacts]
     steps:
       - name: Checkout compare results
         uses: actions/checkout@v4
@@ -75,7 +123,7 @@ jobs:
           path: comparison-results
 
       - name: Download result artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: example-results
           path: comparison-results-current
@@ -91,7 +139,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
With this change the integration tests used the examples ported to the staging syntax (see https://github.com/glotaran/pyglotaran-examples/pull/101 and https://github.com/glotaran/pyglotaran-examples/pull/102)

### Change summary

- [🚇 Use pyglotaran-examples@staging_rewrite for CI integration tests](https://github.com/glotaran/pyglotaran/commit/d874b863edd7c95686787ab755beddca0dee09af)


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)