### PR TITLE
🧪🧹 Remove test of upstream schema creation functionality

### DIFF
--- a/tests/model/test_item.py
+++ b/tests/model/test_item.py
@@ -82,21 +82,6 @@ def test_typed_item():
     assert MockTypedItem.__item_types__ == [MockTypedItemConcrete1, MockTypedItemConcrete2]
 
 
-def test_item_schema():
-    got = MockTypedItem.model_json_schema()
-    wanted = {
-        "title": "MockTypedItem",
-        "description": "This is just a mock item for testing.",
-        "type": "object",
-        "properties": {"type": {"const": None, "title": "Type"}},
-        "required": ["type"],
-        "additionalProperties": False,
-    }
-
-    print(got)
-    assert got == wanted
-
-
 def test_get_issues():
     item = MockItem(
         cscalar=0,


### PR DESCRIPTION
Rather than testing upstream functionality for an exact match, we should test that the schema we generate for a spec file validate correctly. 
The problem with testing exact schema matching is that it is too tightly coupled to the exact syntax of the schema, even so they might be functionally equivalent, leading to failing unit tests due to upstream schema refinements.

See [this recent CI fail with unrelated changes](https://github.com/glotaran/pyglotaran/actions/runs/9428522912/job/25973949081?pr=1461):
```py
Omitting 5 identical items, use -vv to show
  Differing items:
  {'properties': {'type': {'const': None, 'enum': [None], 'title': 'Type', 'type': 'null'}}} != {'properties': {'type': {'const': None, 'title': 'Type'}}}
  
  Full diff:
    {
        'additionalProperties': False,
        'description': 'This is just a mock item for testing.',
        'properties': {
            'type': {
                'const': None,
  +             'enum': [
  +                 None,
  +             ],
                'title': 'Type',
  +             'type': 'null',
            },
        },
        'required': [
            'type',
        ],
        'title': 'MockTypedItem',
        'type': 'object',
    }
```

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)