### PR TITLE
🩹🚇 Fix integration test pipeline

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Upload Example Plots Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: example-plots-${{ matrix.example_name }}
-          path: ${{ steps.example-run.outputs.plots-path }}
+          name: example-notebooks-${{ matrix.example_name }}
+          path: ${{ steps.example-run.outputs.notebook-path }}
 
       - name: Upload Example Results
         uses: actions/upload-artifact@v4
@@ -62,34 +62,54 @@ jobs:
           name: example-results-${{ matrix.example_name }}
           path: ~/pyglotaran_examples_results
 
-  collect-plot-artifacts:
-    name: "Collect plot artifacts and reupload as bundel"
+  collect-artifacts:
+    if: always()
+    name: "Collect artifacts and reupload as bundle"
     runs-on: ubuntu-latest
     needs: [run-examples]
     steps:
-      - name: Download All Artifacts
+      - name: Download Notebooks Artifacts
         uses: actions/download-artifact@v4
         with:
-          path: example-plots
-          pattern: example-plots-*
+          path: example-notebooks
+          pattern: example-notebooks-*
           merge-multiple: true
 
-      - name: Upload Example Plots Artifact
+      - name: Upload Example Notebooks Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: example-plots
-          path: example-plots
+          name: example-notebooks
+          path: example-notebooks
           overwrite: true
 
-      - name: Delete Intermediate artifacts
+      - name: Delete Intermediate Notebooks artifacts
         uses: GeekyEggo/delete-artifact@v5
         with:
-          name: example-plots-*
+          name: example-notebooks-*
+
+      - name: Download Result Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: example-results
+          pattern: example-results-*
+          merge-multiple: true
+
+      - name: Upload Example Result Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-results
+          path: example-results
+          overwrite: true
+
+      - name: Delete Intermediate Result artifacts
+        uses: GeekyEggo/delete-artifact@v5
+        with:
+          name: example-results-*
 
   compare-results:
     name: Compare Results
     runs-on: ubuntu-latest
-    needs: [run-examples]
+    needs: [collect-artifacts]
     steps:
       - name: Checkout compare results
         uses: actions/checkout@v4
@@ -101,8 +121,7 @@ jobs:
       - name: Download result artifact
         uses: actions/download-artifact@v4
         with:
-          pattern: example-results-*
-          merge-multiple: true
+          name: example-results
           path: comparison-results-current
 
       - name: Delete Intermediate artifacts


### PR DESCRIPTION
Changing the `glotaran/pyglotaran-examples` to use notebooks broke the integration test pipeline because the output variable was changed from `plots-path` to `notebook-path`.

### Change summary

- [🩹🚇 Fix integration test pipeline](https://github.com/glotaran/pyglotaran/commit/62caaebaf0bdc6692410316c9039238e2da983da)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
