### PR TITLE
⬆️ Combined updates

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,7 +17,7 @@ ruamel.yaml==0.18.6
 scipy==1.13.1
 sdtfile==2024.5.24
 tabulate==0.9.0
-xarray==2024.5.0
+xarray==2024.6.0
 
 # documentation dependencies
 -r docs/requirements.txt

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ wheel>=0.38.0
 asteval==0.9.33
 attrs == 23.2.0
 click==8.1.7
-netCDF4==1.6.5
+netCDF4==1.7.0
 numba==0.59.1
 numpy==1.26.4
 odfpy==1.4.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ asteval==0.9.33
 attrs == 23.2.0
 click==8.1.7
 netCDF4==1.7.0
-numba==0.59.1
+numba==0.60.0
 numpy==1.26.4
 odfpy==1.4.1
 openpyxl==3.1.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ netCDF4==1.7.0
 numba==0.60.0
 numpy==1.26.4
 odfpy==1.4.1
-openpyxl==3.1.3
+openpyxl==3.1.4
 pandas==2.2.2
 pydantic==2.7.2
 ruamel.yaml==0.18.6


### PR DESCRIPTION
This PR combines the current dependabot updates.

### Change summary

- [Bump xarray from 2024.5.0 to 2024.6.0](https://github.com/glotaran/pyglotaran/commit/148edf99afc1402cf2bf80f8e82d565f61178285)
- [Bump netcdf4 from 1.6.5 to 1.7.0](https://github.com/glotaran/pyglotaran/commit/cfbfaf9de70cbc3bbfcbc6bd8545c593dda2aea9)
- [Bump numba from 0.59.1 to 0.60.0](https://github.com/glotaran/pyglotaran/commit/83078801152ea13951ad7f207ee8f121ce2ef3e6)
- [Bump openpyxl from 3.1.3 to 3.1.4](https://github.com/glotaran/pyglotaran/commit/20a684cef97c7cb1bd9016d20c9370284057c929)
- [Bump validation from 81b80ef to 6c48c86](https://github.com/glotaran/pyglotaran/commit/a1b1ceffe94c0e0f70dc8e4435c8bc7cb28af522)


### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #1465
closes #1466
closes #1467
closes #1468
closes #1469
