### PR TITLE
Fix 1474 - add fields to result object - correct calculation of number of clps.

### DIFF
--- a/glotaran/optimization/optimization.py
+++ b/glotaran/optimization/optimization.py
@@ -138,11 +138,13 @@ class Optimization:
         results = [o.get_result() for o in self._objectives]
         data = dict(ChainMap(*[r.data for r in results]))
         number_of_clps = sum(r.free_clp_size for r in results)
+        additional_penalty = sum(r.additional_penalty for r in results)
         result = OptimizationResult.from_least_squares_result(
             ls_result,
             self._parameter_history,
             OptimizationHistory.from_stdout_str(self._tee.read()),
             penalty,
+            additional_penalty,
             self._free_parameter_labels,
             termination_reason,
             number_of_clps,
@@ -156,11 +158,13 @@ class Optimization:
         results = [o.get_result() for o in self._objectives]
         data = dict(ChainMap(*[r.data for r in results]))
         number_of_clps = sum(r.free_clp_size for r in results)
+        additional_penalty = sum(r.additional_penalty for r in results)
         result = OptimizationResult.from_least_squares_result(
             None,
             self._parameter_history,
             OptimizationHistory.from_stdout_str(self._tee.read()),
             penalty,
+            additional_penalty,
             self._free_parameter_labels,
             termination_reason,
             number_of_clps,

--- a/glotaran/optimization/optimization.py
+++ b/glotaran/optimization/optimization.py
@@ -137,7 +137,7 @@ class Optimization:
         penalty = np.concatenate([o.calculate() for o in self._objectives])
         results = [o.get_result() for o in self._objectives]
         data = dict(ChainMap(*[r.data for r in results]))
-        nr_clp = sum(r.free_clp_size for r in results)
+        number_of_free_clp = sum(r.free_clp_size for r in results)
         result = OptimizationResult.from_least_squares_result(
             ls_result,
             self._parameter_history,
@@ -145,7 +145,7 @@ class Optimization:
             penalty,
             self._free_parameter_labels,
             termination_reason,
-            nr_clp,
+            number_of_free_clp,
         )
         return self._parameters, data, result
 
@@ -155,7 +155,7 @@ class Optimization:
         penalty = np.concatenate([o.calculate() for o in self._objectives])
         results = [o.get_result() for o in self._objectives]
         data = dict(ChainMap(*[r.data for r in results]))
-        nr_clp = sum(r.free_clp_size for r in results)
+        number_of_free_clp = sum(r.free_clp_size for r in results)
         result = OptimizationResult.from_least_squares_result(
             None,
             self._parameter_history,
@@ -163,7 +163,7 @@ class Optimization:
             penalty,
             self._free_parameter_labels,
             termination_reason,
-            nr_clp,
+            number_of_free_clp,
         )
         return self._parameters, data, result
 

--- a/glotaran/optimization/optimization.py
+++ b/glotaran/optimization/optimization.py
@@ -135,8 +135,9 @@ class Optimization:
                 termination_reason = str(e)
 
         penalty = np.concatenate([o.calculate() for o in self._objectives])
-        data = dict(ChainMap(*[o.get_result() for o in self._objectives]))
-        nr_clp = len({str(c.data) for d in data.values() for c in d.clp_label})
+        results = [o.get_result() for o in self._objectives]
+        data = dict(ChainMap(*[r.data for r in results]))
+        nr_clp = sum(r.free_clp_size for r in results)
         result = OptimizationResult.from_least_squares_result(
             ls_result,
             self._parameter_history,
@@ -152,8 +153,9 @@ class Optimization:
         termination_reason = "Dry run."
 
         penalty = np.concatenate([o.calculate() for o in self._objectives])
-        data = dict(ChainMap(*[o.get_result() for o in self._objectives]))
-        nr_clp = len({str(c.data) for d in data.values() for c in d.clp_label})
+        results = [o.get_result() for o in self._objectives]
+        data = dict(ChainMap(*[r.data for r in results]))
+        nr_clp = sum(r.free_clp_size for r in results)
         result = OptimizationResult.from_least_squares_result(
             None,
             self._parameter_history,

--- a/glotaran/optimization/optimization.py
+++ b/glotaran/optimization/optimization.py
@@ -137,7 +137,7 @@ class Optimization:
         penalty = np.concatenate([o.calculate() for o in self._objectives])
         results = [o.get_result() for o in self._objectives]
         data = dict(ChainMap(*[r.data for r in results]))
-        number_of_free_clp = sum(r.free_clp_size for r in results)
+        number_of_clps = sum(r.free_clp_size for r in results)
         result = OptimizationResult.from_least_squares_result(
             ls_result,
             self._parameter_history,
@@ -145,7 +145,7 @@ class Optimization:
             penalty,
             self._free_parameter_labels,
             termination_reason,
-            number_of_free_clp,
+            number_of_clps,
         )
         return self._parameters, data, result
 
@@ -155,7 +155,7 @@ class Optimization:
         penalty = np.concatenate([o.calculate() for o in self._objectives])
         results = [o.get_result() for o in self._objectives]
         data = dict(ChainMap(*[r.data for r in results]))
-        number_of_free_clp = sum(r.free_clp_size for r in results)
+        number_of_clps = sum(r.free_clp_size for r in results)
         result = OptimizationResult.from_least_squares_result(
             None,
             self._parameter_history,
@@ -163,7 +163,7 @@ class Optimization:
             penalty,
             self._free_parameter_labels,
             termination_reason,
-            number_of_free_clp,
+            number_of_clps,
         )
         return self._parameters, data, result
 

--- a/glotaran/optimization/result.py
+++ b/glotaran/optimization/result.py
@@ -88,6 +88,7 @@ class OptimizationResult(BaseModel):
 
     :math:`rms = \sqrt{\chi^2_{red}}`
     """
+    additional_penalty: float | None = None
 
     @classmethod
     def from_least_squares_result(
@@ -96,6 +97,7 @@ class OptimizationResult(BaseModel):
         parameter_history: ParameterHistory,
         optimization_history: OptimizationHistory,
         penalty: ArrayLike,
+        additional_penalty: float,
         free_parameter_labels: list[str],
         termination_reason: str,
         number_of_clps: int,
@@ -116,6 +118,7 @@ class OptimizationResult(BaseModel):
 
         if success:
             result_args["number_of_clps"] = number_of_clps
+            result_args["additional_penalty"] = additional_penalty
             result_args["number_of_jacobian_evaluations"] = result.njev  # type:ignore[union-attr]
             result_args["optimality"] = float(result.optimality)  # type:ignore[union-attr]
             result_args["number_of_data_points"] = result.fun.size  # type:ignore[union-attr]

--- a/glotaran/optimization/result.py
+++ b/glotaran/optimization/result.py
@@ -61,7 +61,7 @@ class OptimizationResult(BaseModel):
 
     The rows and columns are corresponding to :attr:`free_parameter_labels`."""
 
-    number_of_free_clp: int | None = None
+    number_of_clps: int | None = None
     degrees_of_freedom: int | None = None
     """Degrees of freedom in optimization :math:`N - N_{vars}`."""
 
@@ -98,7 +98,7 @@ class OptimizationResult(BaseModel):
         penalty: ArrayLike,
         free_parameter_labels: list[str],
         termination_reason: str,
-        number_of_free_clp: int,
+        number_of_clps: int,
     ):
         success = result is not None
 
@@ -115,7 +115,7 @@ class OptimizationResult(BaseModel):
         }
 
         if success:
-            result_args["number_of_free_clp"] = number_of_free_clp
+            result_args["number_of_clps"] = number_of_clps
             result_args["number_of_jacobian_evaluations"] = result.njev  # type:ignore[union-attr]
             result_args["optimality"] = float(result.optimality)  # type:ignore[union-attr]
             result_args["number_of_data_points"] = result.fun.size  # type:ignore[union-attr]
@@ -123,7 +123,7 @@ class OptimizationResult(BaseModel):
             result_args["degrees_of_freedom"] = (
                 result_args["number_of_data_points"]
                 - result_args["number_of_parameters"]
-                - result_args["number_of_free_clp"]
+                - result_args["number_of_clps"]
             )
             result_args["chi_square"] = float(np.sum(result.fun**2))  # type:ignore[union-attr]
             result_args["reduced_chi_square"] = (

--- a/glotaran/optimization/result.py
+++ b/glotaran/optimization/result.py
@@ -61,7 +61,7 @@ class OptimizationResult(BaseModel):
 
     The rows and columns are corresponding to :attr:`free_parameter_labels`."""
 
-    number_clp: int | None = None
+    number_of_free_clp: int | None = None
     degrees_of_freedom: int | None = None
     """Degrees of freedom in optimization :math:`N - N_{vars}`."""
 
@@ -98,7 +98,7 @@ class OptimizationResult(BaseModel):
         penalty: ArrayLike,
         free_parameter_labels: list[str],
         termination_reason: str,
-        number_clp: int,
+        number_of_free_clp: int,
     ):
         success = result is not None
 
@@ -115,7 +115,7 @@ class OptimizationResult(BaseModel):
         }
 
         if success:
-            result_args["number_clp"] = number_clp
+            result_args["number_of_free_clp"] = number_of_free_clp
             result_args["number_of_jacobian_evaluations"] = result.njev  # type:ignore[union-attr]
             result_args["optimality"] = float(result.optimality)  # type:ignore[union-attr]
             result_args["number_of_data_points"] = result.fun.size  # type:ignore[union-attr]
@@ -123,7 +123,7 @@ class OptimizationResult(BaseModel):
             result_args["degrees_of_freedom"] = (
                 result_args["number_of_data_points"]
                 - result_args["number_of_parameters"]
-                - result_args["number_clp"]
+                - result_args["number_of_free_clp"]
             )
             result_args["chi_square"] = float(np.sum(result.fun**2))  # type:ignore[union-attr]
             result_args["reduced_chi_square"] = (

--- a/tests/optimization/test_objective.py
+++ b/tests/optimization/test_objective.py
@@ -26,7 +26,7 @@ def test_single_data():
     data_size = data_model.data["model"].size * data_model.data["global"].size
     assert penalty.size == data_size
 
-    result = objective.get_result()
+    result = objective.get_result().data
     assert "test" in result
 
     result_data = result["test"]
@@ -51,7 +51,7 @@ def test_global_data(weight: bool):
     data_size = data_model.data["model"].size * data_model.data["global"].size
     assert penalty.size == data_size
 
-    result = objective.get_result()
+    result = objective.get_result().data
     assert "test" in result
 
     result_data = result["test"]
@@ -90,7 +90,7 @@ def test_multiple_data():
     data_size_two = data_model_two.data["model"].size * data_model_two.data["global"].size
     assert penalty.size == data_size_one + data_size_two
 
-    result = objective.get_result()
+    result = objective.get_result().data
 
     assert "independent" in result
     result_data = result["independent"]
@@ -129,7 +129,7 @@ def test_result_data(weight: bool):
     data_size = data_model.data["model"].size * data_model.data["global"].size
     assert penalty.size == data_size
 
-    result = objective.get_result()
+    result = objective.get_result().data
     assert "test" in result
 
     result_data = result["test"]


### PR DESCRIPTION
Fixes #1474

- This adds `additional_penalty` to the result object and renames `nr_clp` back to `number_of_clps`.
- Correct degrees_of_freedom calculation.