### PR TITLE
🧹 Remove doc render workaround in result markdown repr

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # Python interpreter
   - python=3.10
-  - pandoc>=2.19.2
+  - pandoc>=3.2.1
   - pip
   - pip:
       - -r requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ sphinx-copybutton>=0.3.0
 myst-parser>=0.12.0
 numpydoc>=0.8.0
 # notebook docs
-nbsphinx>=0.8.1
+nbsphinx>=0.9.4
 sphinx-last-updated-by-git>=0.3.0
 jupyterlab>=3.0.0
 matplotlib>=3.0.0

--- a/glotaran/project/result.py
+++ b/glotaran/project/result.py
@@ -135,10 +135,16 @@ class Result:
     :math:`rms = \sqrt{\chi^2_{red}}`
     """
     source_path: StrOrPath = field(
-        default="result.yml", init=False, repr=False, metadata={"exclude_from_dict": True}
+        default="result.yml",
+        init=False,
+        repr=False,
+        metadata={"exclude_from_dict": True},
     )
     loader: Callable[[StrOrPath], Result] = field(
-        default=load_result, init=False, repr=False, metadata={"exclude_from_dict": True}
+        default=load_result,
+        init=False,
+        repr=False,
+        metadata={"exclude_from_dict": True},
     )
 
     def __post_init__(self):
@@ -244,7 +250,10 @@ class Result:
             ["Degrees of freedom", self.degrees_of_freedom],
             ["Chi Square", f"{self.chi_square or np.nan:.2e}"],
             ["Reduced Chi Square", f"{self.reduced_chi_square or np.nan:.2e}"],
-            ["Root Mean Square Error (RMSE)", f"{self.root_mean_square_error or np.nan:.2e}"],
+            [
+                "Root Mean Square Error (RMSE)",
+                f"{self.root_mean_square_error or np.nan:.2e}",
+            ],
         ]
         if self.additional_penalty is not None and any(
             len(penalty) != 0 for penalty in self.additional_penalty
@@ -285,15 +294,7 @@ class Result:
             if wrap_model_in_details is False:
                 result_table = f"{result_table}\n\n{model_md}"
             else:
-                # The section part is just a hack to generate properly rendering docs due to a bug
-                # in sphinx which causes a wrong tag opening and closing order of html tags
-                # Since model_md contains 2 heading levels we need to close 2 sections
-                result_table = (
-                    f"{result_table}\n\n<br><details>\n\n{model_md}\n"
-                    f"{'</section>'*(2)}"
-                    "</details>"
-                    f"{'<section>'*(2)}"
-                )
+                result_table = f"{result_table}\n\n<br><details>\n\n{model_md}\n</details>"
 
         return MarkdownStr(result_table)
 


### PR DESCRIPTION
This PR removes the hacky workaround added in #1244 for the details section the `Result` markdown repr not to break the render.

Looking in the pandoc [release notes](https://pandoc.org/releases.html#pandoc-2.10-2020-06-29) I found this note.

> Add summary to list of block-level HTML tags ([#6385](https://github.com/jgm/pandoc/issues/6385)). This improves support for summary/details inside Markdown. NOTE: you need to include a blank line before the closing </details>, if you want the last part of the content to be parsed as a paragraph.

So I gave it a shot and it worked locally.
I'm a bit confused about our initial problem since the repr before #1244 also included a newline before closing the tab 🤷‍♀️

### Change summary

- [🧹 Remove doc render workaround in result markdown repr](https://github.com/glotaran/pyglotaran/commit/e6953e5d1814ad3c13fa4df32444b23b86248ba8)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
