### PR TITLE
🚧🚇👌 Improve dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
         update-types:
           - minor
           - patch
+    rebase-strategy: "disabled"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -37,6 +38,7 @@ updates:
         update-types:
           - minor
           - patch
+    rebase-strategy: "disabled"
 
   # Update git submodules
   - package-ecosystem: "gitsubmodule"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,15 @@ updates:
     open-pull-requests-limit: 20
     reviewers:
       - jsnel
+      - s-weigand
     assignees:
       - jsnel
+      - s-weigand
+    groups:
+      runtime-dependencies:
+        update-types:
+          - minor
+          - patch
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -25,6 +32,11 @@ updates:
       - s-weigand
     assignees:
       - s-weigand
+    groups:
+      GH-Actions:
+        update-types:
+          - minor
+          - patch
 
   # Update git submodules
   - package-ecosystem: "gitsubmodule"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,3 +48,57 @@ updates:
       day: friday
       time: "20:00"
       timezone: Europe/Amsterdam
+
+  # Staging branch
+
+  - package-ecosystem: pip
+    target-branch: staging
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: friday
+      time: "20:00"
+      timezone: Europe/Amsterdam
+    open-pull-requests-limit: 20
+    reviewers:
+      - jsnel
+      - s-weigand
+    assignees:
+      - jsnel
+      - s-weigand
+    groups:
+      runtime-dependencies:
+        update-types:
+          - minor
+          - patch
+    rebase-strategy: "disabled"
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    target-branch: staging
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: friday
+      time: "20:00"
+      timezone: Europe/Amsterdam
+    reviewers:
+      - s-weigand
+    assignees:
+      - s-weigand
+    groups:
+      GH-Actions:
+        update-types:
+          - minor
+          - patch
+    rebase-strategy: "disabled"
+
+  # Update git submodules
+  - package-ecosystem: "gitsubmodule"
+    target-branch: staging
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: friday
+      time: "20:00"
+      timezone: Europe/Amsterdam


### PR DESCRIPTION
This PR improves the efficiency of `dependabot` updates by grouping them instead of open PRs for each dependency. It also deactivates autorebase to not unnecessarily spam the CI (we can still use `@dependabot rebase` or local rebase and push if needed).
It also activates `dependabot` for the `staging branch`.

### Change summary

- [🚧🚇👌 Use dependabot groups to reduce the amount of PRs](https://github.com/glotaran/pyglotaran/commit/d01c493fb7a8df1871bc42c2f298572f6fd30e03)
- [🚧🚇👌 Disable dependabot auto rebase to reduce CI spam](https://github.com/glotaran/pyglotaran/commit/7efc302a23aea6c4180c25c926b2b0d34e99ea34)
- [🚧🚇👌 Activate dependabot for staging](https://github.com/glotaran/pyglotaran/commit/49d77b3dcde6bd35aef6e0066f57db6eab158f14)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
