### PR TITLE
🩹Fix order of parameters involved in parameters expresssion

### DIFF
--- a/glotaran/model/item.py
+++ b/glotaran/model/item.py
@@ -314,9 +314,9 @@ def iterate_parameter_fields(
 
 def add_to_initial(label: str, parameters: Parameters, initial: Parameters) -> Parameter:
     if not parameters.has(label):
-        parameters.add(initial.get(label).model_copy())
-        for dep_label in parameters.get(label).get_dependency_parameters():
+        for dep_label in initial.get(label).get_dependency_parameters():
             add_to_initial(dep_label, parameters, initial)
+        parameters.add(initial.get(label).model_copy())
     return parameters.get(label)
 
 

--- a/tests/model/test_item.py
+++ b/tests/model/test_item.py
@@ -228,15 +228,15 @@ def _test_add_to_initial(initial_parameters):
     check_expressions(parameters)
 
 
-def initial_parameters_b_first():
+def test_add_to_initial_b_first():
     return _test_add_to_initial(Parameters.from_dict({**B_DICT, **RATES_DICT}))
 
 
-def initial_parameters_b_last():
+def test_add_to_initial_b_last():
     return _test_add_to_initial(Parameters.from_dict({**RATES_DICT, **B_DICT}))
 
 
 if __name__ == "__main__":
     for _ in range(1000):
-        initial_parameters_b_first()
-        initial_parameters_b_last()
+        test_add_to_initial_b_first()
+        test_add_to_initial_b_last()


### PR DESCRIPTION
Add the dependent parameters after its dependencies.

Parameters involved in a relation (parameter expression) should be added before the parameter that declares a dependency on them.

### Change summary

- 🩹Fix order of parameters involved in parameters expresssion

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 👌 Closes issue (mandatory for ✨ feature and 🩹 bug fix PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

### Closes issues

closes #1499
