### PR TITLE
🩹 Fix ordering bug in MatrixProvider class

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@
 
 - ✨ Add official Python 3.12 support (#1437)
 
+### 🩹 Bug fixes
+
+- 🩹 Fix ordering bug in MatrixProvider class (#1512)
+
 ### 🚧 Maintenance
 
 -🧹🚇 Remove asv benchmarks and binder integration

--- a/glotaran/optimization/matrix_provider.py
+++ b/glotaran/optimization/matrix_provider.py
@@ -222,13 +222,14 @@ class MatrixProvider:
         tuple[list[str], ArrayLike]:
             The combined clp labels and matrix.
         """
+        if len(matrix_left.shape) < len(matrix_right.shape):
+            matrix_left, matrix_right = matrix_right, matrix_left
+            clp_labels_left, clp_labels_right = clp_labels_right, clp_labels_left
+
         result_clp_labels = clp_labels_left + [
             c for c in clp_labels_right if c not in clp_labels_left
         ]
         result_clp_size = len(result_clp_labels)
-
-        if len(matrix_left.shape) < len(matrix_right.shape):
-            matrix_left, matrix_right = matrix_right, matrix_left
 
         left_index_dependent = len(matrix_left.shape) == 3
         right_index_dependent = len(matrix_right.shape) == 3


### PR DESCRIPTION
In the call to combine_megacomplex_matrices the matrices would be reordered independent of their labels resulting in a combined matrix that would be ordered differently than expected. This issue was specifically found in the case of multiple types of different megacomplexes.

This bug fix was orginally part of #1510 but was seperated out because of its broader scope.

### Change summary

- Fix an ordering bug in the combine_megacomplex_matrices method of MatrixProvider

### Checklist

- [ ] 🚧 Added changes to changelog (mandatory for all PR's)
