### PR TITLE
🩹 Fix AttributeError validating bad DOAS user definition

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 ### 🩹 Bug fixes
 
 - 🩹 Fix ordering bug in MatrixProvider class (#1512)
+- 🩹 Fix AttributeError validating bad DOAS user definition (#1513)
 
 ### 🚧 Maintenance
 

--- a/glotaran/builtin/megacomplexes/damped_oscillation/damped_oscillation_megacomplex.py
+++ b/glotaran/builtin/megacomplexes/damped_oscillation/damped_oscillation_megacomplex.py
@@ -32,7 +32,7 @@ class OscillationParameterIssue(ItemIssue):
 
     def to_string(self) -> str:
         return (
-            f"Size of labels ({self.len_labels}), frequencies ({self.len_frequencies}) "
+            f"The size of labels ({self.len_labels}), frequencies ({self.len_frequencies}), "
             f"and rates ({self.len_rates}) does not match for damped oscillation "
             f"megacomplex '{self.label}'."
         )

--- a/glotaran/builtin/megacomplexes/damped_oscillation/damped_oscillation_megacomplex.py
+++ b/glotaran/builtin/megacomplexes/damped_oscillation/damped_oscillation_megacomplex.py
@@ -25,10 +25,10 @@ if TYPE_CHECKING:
 
 class OscillationParameterIssue(ItemIssue):
     def __init__(self, label: str, len_labels: int, len_frequencies: int, len_rates: int):
-        self._label = label
-        self._len_labels = len_labels
-        self._len_frequencies = len_frequencies
-        self._len_rates = len_rates
+        self.label = label
+        self.len_labels = len_labels
+        self.len_frequencies = len_frequencies
+        self.len_rates = len_rates
 
     def to_string(self) -> str:
         return (

--- a/glotaran/builtin/megacomplexes/damped_oscillation/test/test_doas_model.py
+++ b/glotaran/builtin/megacomplexes/damped_oscillation/test/test_doas_model.py
@@ -389,9 +389,9 @@ def test_doas_model(suite):
 
 
 def test_doas_model_validate():
-    """A ``OscillationParameterIssue`` should be raise if there is list length mismatch.
+    """An ``OscillationParameterIssue`` should be raised if there is a list length mismatch.
 
-    List values are: ``labels``, ``frequencies``, ``rates``
+    List values are: ``labels``, ``frequencies``, ``rates``.
     """
     model_data = OneOscillation.sim_model.as_dict()
     model_data["megacomplex"]["m1"]["labels"].append("extra-label")
@@ -399,6 +399,6 @@ def test_doas_model_validate():
     validation_msg = model.validate()
     assert (
         validation_msg == "Your model has 1 problem:\n\n"
-        " * Size of labels (2), frequencies (1) and rates (1) does not match for damped "
+        " * The size of labels (2), frequencies (1), and rates (1) does not match for damped "
         "oscillation megacomplex 'm1'."
     )

--- a/glotaran/builtin/megacomplexes/damped_oscillation/test/test_doas_model.py
+++ b/glotaran/builtin/megacomplexes/damped_oscillation/test/test_doas_model.py
@@ -386,3 +386,19 @@ def test_doas_model(suite):
     assert "damped_oscillation_sin" in resultdata
     assert "damped_oscillation_associated_spectra" in resultdata
     assert "damped_oscillation_phase" in resultdata
+
+
+def test_doas_model_validate():
+    """A ``OscillationParameterIssue`` should be raise if there is list length mismatch.
+
+    List values are: ``labels``, ``frequencies``, ``rates``
+    """
+    model_data = OneOscillation.sim_model.as_dict()
+    model_data["megacomplex"]["m1"]["labels"].append("extra-label")
+    model = DampedOscillationsModel(**model_data)
+    validation_msg = model.validate()
+    assert (
+        validation_msg == "Your model has 1 problem:\n\n"
+        " * Size of labels (2), frequencies (1) and rates (1) does not match for damped "
+        "oscillation megacomplex 'm1'."
+    )


### PR DESCRIPTION
During the review of #1510 we found an inherited bug from the DOAS megacomplex where a faulty user definition would raise an `AttributeError` when the `ItemIssue` get converted to a string that is show to users.

### Change summary

- [🧪 Add failing test reproducing the AttributeError validating a bad DOAS user definition](https://github.com/glotaran/pyglotaran/commit/5409d4d163405d68c4b09036fc64d0643d3fc58f)
- [🩹 Fix AttributeError validating bad DOAS user definition](https://github.com/glotaran/pyglotaran/commit/1f697b98a2c703cc46ec04465f529980d3695e48)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)
- [ ] 🚧 Added changes to changelog (mandatory for all PR's)
