### PR TITLE
🧰 Fix pre-commit config issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,12 +112,11 @@ repos:
         additional_dependencies: [types-tabulate, numpy, pydantic]
 
   - repo: https://github.com/econchick/interrogate
-    rev: 1.5.0
+    rev: 1.7.0
     hooks:
       - id: interrogate
         args: [--config=pyproject.toml, glotaran]
         pass_filenames: false
-        additional_dependencies: [click<8, setuptools]
 
   # - repo: https://github.com/pre-commit/pygrep-hooks
   #   rev: v1.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,7 +109,7 @@ repos:
     hooks:
       - id: mypy
         exclude: "docs|benchmark/|tests/.*"
-        additional_dependencies: [types-all, pydantic]
+        additional_dependencies: [types-tabulate, numpy, pydantic]
 
   - repo: https://github.com/econchick/interrogate
     rev: 1.5.0
@@ -117,7 +117,7 @@ repos:
       - id: interrogate
         args: [--config=pyproject.toml, glotaran]
         pass_filenames: false
-        additional_dependencies: [click<8]
+        additional_dependencies: [click<8, setuptools]
 
   # - repo: https://github.com/pre-commit/pygrep-hooks
   #   rev: v1.10.0


### PR DESCRIPTION
Fixes 2 issues with faulty pre-commit configuration
- error when initializing clean pre-commit environment due to yanking of types-all
- fail in interrogate pipeline on missing pkg_resources in some environments due to interrogate not declaring explicit dependency on setuptools

