### PR TITLE
🩹 Use svd function on raw numpy arrray instead of xarray dataarray

### DIFF
--- a/glotaran/io/prepare_dataset.py
+++ b/glotaran/io/prepare_dataset.py
@@ -85,7 +85,7 @@ def add_svd_to_dataset(
     if data_array is None:
         data_array = dataset[name] if name != "data" else dataset.data
     if f"{name}_singular_values" not in dataset:
-        l, s, r = np.linalg.svd(data_array, full_matrices=False)
+        l, s, r = np.linalg.svd(data_array.data, full_matrices=False)
         dataset[f"{name}_left_singular_vectors"] = ((lsv_dim, "left_singular_value_index"), l)
         dataset[f"{name}_singular_values"] = (("singular_value_index"), s)
         dataset[f"{name}_right_singular_vectors"] = ((rsv_dim, "right_singular_value_index"), r.T)


### PR DESCRIPTION
This should fix an issues with numpy > 2.0.1 and should be backwards compatible.

### Change summary

- In the prepare_dataset function where svd are added we use the .data attribute of the xarrray dataarray to get the numpy array to be used in the calculation. 

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] ✔️Test with both numpy 2.0.1 and numpy 1.26.4

