### PR TITLE
🩹 Use .data attribute in add_svd_to_dataset function to fix numpy>2 issue

### DIFF
--- a/glotaran/io/prepare_dataset.py
+++ b/glotaran/io/prepare_dataset.py
@@ -85,7 +85,7 @@ def add_svd_to_dataset(
     if data_array is None:
         data_array = dataset[name] if name != "data" else dataset.data
     if f"{name}_singular_values" not in dataset:
-        lsv, sv, rsv = np.linalg.svd(data_array, full_matrices=False)
+        lsv, sv, rsv = np.linalg.svd(data_array.data, full_matrices=False)
         dataset[f"{name}_left_singular_vectors"] = ((lsv_dim, "left_singular_value_index"), lsv)
         dataset[f"{name}_singular_values"] = (("singular_value_index"), sv)
         dataset[f"{name}_right_singular_vectors"] = (


### PR DESCRIPTION
Forward port of #1520

### Change summary

- 🩹Fix prepare_dataset's add_svd_to_dataset function by using raw numpy .data array instead of xarray dataarray by to resolve an issue with numpy>2.

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
