### PR TITLE
🩹 Fix changed numpy repr breaks ascii saving

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
 
 ### 🩹 Bug fixes
 
+- 🩹 Fix changed numpy repr breaks ascii saving (#1591)
+
 ### 📚 Documentation
 
 ### 🗑️ Deprecations (due in 0.9.0)

--- a/glotaran/builtin/io/ascii/test/test_explicit_file_reader.py
+++ b/glotaran/builtin/io/ascii/test/test_explicit_file_reader.py
@@ -37,4 +37,8 @@ def test_write_explicit_file(tmp_path):
     test_data_file_write = ExplicitFile(filepath=str(test_data_file), dataset=test_dataarray_read)
     test_data_file_write.write(comment="written \n in \n test.", overwrite=True)
     test_dataarray_reread = test_data_file_write.read(prepare=False)
+    assert np.array_equal(test_dataarray_read.coords["time"], test_dataarray_reread.coords["time"])
+    assert np.array_equal(
+        test_dataarray_read.coords["spectral"], test_dataarray_reread.coords["spectral"]
+    )
     assert np.array_equal(test_dataarray_read.values, test_dataarray_reread.values)

--- a/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
+++ b/glotaran/builtin/io/ascii/wavelength_time_explicit_file.py
@@ -79,13 +79,13 @@ class ExplicitFile:
         comments = f"# Filename: {str(self._file)}\n{' '.join(comment.splitlines())}\n"
 
         if file_format == DataFileType.wavelength_explicit:
-            wav = "\t".join(repr(num) for num in self._spectral_indices)
+            wav = "\t".join(str(num) for num in self._spectral_indices)
             header = (
                 f"{comments}Wavelength explicit\nIntervalnr {len(self._spectral_indices)}\n{wav}"
             )
             raw_data = np.vstack((self._times.T, self._observations)).T
         elif file_format == DataFileType.time_explicit:
-            tim = "\t".join(repr(num) for num in self._times)
+            tim = "\t".join(str(num) for num in self._times)
             header = f"{comments}Time explicit\nIntervalnr {len(self._times)}\n{tim}"
             raw_data = np.vstack((self._spectral_indices.T, self._observations.T)).T
         else:


### PR DESCRIPTION
This change is a bug fix for the `ascii` builtin writing plugin when using a recent `numpy` version.
Recently `numpy` changed it's string representation of array items from a python float string representation to the actual type the item pointer points to e.g. `3.14` -> `np.float64(3.14)`.
This is the correct type that can be round trip evaluated, but the `ascii` plugin (one of our oldest code pieces that we need to replace!) doesn't handle this change nicely, since it uses the `repr` (used for representation in e.g. tracebacks) rather than the string representation.

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)

## Summary by Sourcery

Fix ASCII explicit file writing to use plain string representations compatible with recent NumPy changes and verify round-trip of coordinates in tests.

Bug Fixes:
- Ensure wavelength and time values in ASCII explicit files are written using standard string formatting instead of NumPy repr to remain compatible with newer NumPy versions.

Tests:
- Extend explicit file reader/writer test to assert that time and spectral coordinates are preserved on round-trip.