### PR TITLE
🩹 Add pandas 3 compatibility

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+(changes-0_7_5)=
+
+## 🚀 0.7.5 (Unreleased)
+
+### ✨ Features
+
+### 🩹 Bug fixes
+
+- 🩹 Add pandas 3 compatibility (#1607)
+
+### 📚 Documentation
+
+### 🚧 Maintenance
+
 (changes-0_7_4)=
 
 ## 🚀 0.7.4 (2025-12-31)

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -121,6 +121,28 @@ def set_transformed_expression(parameter: Parameter, attribute: Attribute, expre
         )
 
 
+def nan_repr_to_none(val: str | float | None) -> str | None:
+    """Convert a value that is "nan" or np.nan to None.
+
+    Parameters
+    ----------
+    val : str | float | None
+        The value to be converted.
+
+    Returns
+    -------
+    str | None
+        The converted value.
+    """
+    if isinstance(val, str) and val.lower() == "nan":
+        return None
+    if isinstance(val, float) and np.isnan(val):
+        return None
+    if isinstance(val, (int, float)):
+        return str(val)
+    return val
+
+
 @no_default_vals_in_repr
 @define
 class Parameter(_SupportsArray):
@@ -133,7 +155,9 @@ class Parameter(_SupportsArray):
         validator=[validators.instance_of(float)],
     )
     standard_error: float = np.nan
-    expression: str | None = ib(default=None, validator=[set_transformed_expression])
+    expression: str | None = ib(
+        default=None, converter=nan_repr_to_none, validator=[set_transformed_expression]
+    )
     maximum: float = ib(default=np.inf, validator=[validators.instance_of((int, float))])
     minimum: float = ib(default=-np.inf, validator=[validators.instance_of((int, float))])
     non_negative: bool = False

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,8 @@ numpy==2.2.6;python_version<"3.11"
 numpy==2.3.5;python_version>="3.11"
 odfpy==1.4.1
 openpyxl==3.1.5
-pandas==2.3.3
+pandas==2.3.3;python_version<"3.11"
+pandas==3.0.1;python_version>="3.11"
 pydantic==2.12.5
 ruamel.yaml==0.18.17
 scipy==1.15.3;python_version<"3.11"


### PR DESCRIPTION
This change updates pandas to the latest version for `python>=3.11` (no wheels for pandas 3 on python 3.10) and fixes nan handling for the changed pandas behaviour.

Users got an error
```py
File "glotaran\parameter\parameter.py", line 119, in set_transformed_expression
    parameter.transformed_expression = PARAMETER_EXPRESSION_REGEX.sub(
                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        r"parameters.get('\g<parameter_expression>').value", expression
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
TypeError: expected string or bytes-like object, got 'float'
```
when using `pandas>=3` because the `expression` value was a `np.nan` instead of `None`.
However, in other parts of the code the value could also be a `"nan"`, causing a different error.
To ensure `expression` has the correct expected type, the fix was implemented as a converter guard when `Parameter` is instantiated.

### Change summary

- [⬆️ Update pandas to >=3.0.1 for python >= 3.11](https://github.com/glotaran/pyglotaran/commit/32565112baaad2cc94b5daa59a6d55baa22fcbe3)
- [🩹 Add converter function for changed pandas nan handling](https://github.com/glotaran/pyglotaran/commit/3c000343e7d857e9b1b09e594f020b3f8463b4a4)

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)

## Summary by Sourcery

Ensure parameter expressions handle pandas 3 NaN representations safely during parameter creation.

Bug Fixes:
- Normalize NaN-like values in parameter expressions to None to prevent type errors when using pandas 3.

Enhancements:
- Add a converter for parameter expressions to consistently transform numeric values to strings and NaN representations to None before validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize NaN representations (numeric NaN and "nan" strings) in parameter expressions before validation and transformation.

* **Chores**
  * Update pandas requirement pins to select version based on Python runtime.

* **Documentation**
  * Add unreleased 0.7.5 changelog entry noting pandas 3 compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->