### PR TITLE
🩹 Fix array dimensionality issues in add_svd_to_dataset and simulation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 ### 🩹 Bug fixes
 
 - 🩹 Add pandas 3 compatibility (#1607)
+- 🩹 Fix array dimensionality issues in add_svd_to_dataset and simulation (#1608)
 
 ### 📚 Documentation
 

--- a/glotaran/io/prepare_dataset.py
+++ b/glotaran/io/prepare_dataset.py
@@ -85,7 +85,9 @@ def add_svd_to_dataset(
     if data_array is None:
         data_array = dataset[name] if name != "data" else dataset.data
     if f"{name}_singular_values" not in dataset:
-        l, s, r = np.linalg.svd(data_array.data, full_matrices=False)
+        l, s, r = np.linalg.svd(
+            data_array.transpose(lsv_dim, rsv_dim).to_numpy(), full_matrices=False
+        )
         dataset[f"{name}_left_singular_vectors"] = ((lsv_dim, "left_singular_value_index"), l)
         dataset[f"{name}_singular_values"] = (("singular_value_index"), s)
         dataset[f"{name}_right_singular_vectors"] = ((rsv_dim, "right_singular_value_index"), r.T)

--- a/glotaran/io/test/__init__.py
+++ b/glotaran/io/test/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the glotaran.io module."""

--- a/glotaran/io/test/test_prepare_dataset.py
+++ b/glotaran/io/test/test_prepare_dataset.py
@@ -1,0 +1,117 @@
+"""Tests for the glotaran.io.prepare_dataset module."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from glotaran.io.prepare_dataset import add_svd_to_dataset
+
+
+@pytest.fixture
+def data_array() -> xr.DataArray:
+    """Return a small 2D data array with explicit time and spectral coordinates."""
+
+    return xr.DataArray(
+        np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
+        dims=("time", "spectral"),
+        coords={"time": [0.0, 1.0, 2.0], "spectral": [700.0, 710.0]},
+    )
+
+
+def test_add_svd_to_dataset_adds_expected_variables(data_array: xr.DataArray):
+    """Add SVD outputs for the default dataset variable and dimensions."""
+
+    dataset = data_array.to_dataset(name="data")
+
+    add_svd_to_dataset(dataset)
+
+    left_vectors, singular_values, right_vectors = np.linalg.svd(
+        data_array.data, full_matrices=False
+    )
+
+    assert dataset.data_left_singular_vectors.dims == ("time", "left_singular_value_index")
+    assert dataset.data_singular_values.dims == ("singular_value_index",)
+    assert dataset.data_right_singular_vectors.dims == (
+        "spectral",
+        "right_singular_value_index",
+    )
+    np.testing.assert_allclose(dataset.data_left_singular_vectors.to_numpy(), left_vectors)
+    np.testing.assert_allclose(dataset.data_singular_values.to_numpy(), singular_values)
+    np.testing.assert_allclose(dataset.data_right_singular_vectors.to_numpy(), right_vectors.T)
+
+
+def test_add_svd_to_dataset_works_with_transposed_data(data_array: xr.DataArray):
+    """Exercise the transposed-data path using the dataset's default variable."""
+
+    dataset = data_array.T.to_dataset(name="data")
+
+    add_svd_to_dataset(dataset)
+
+    left_vectors, singular_values, right_vectors = np.linalg.svd(
+        data_array.data, full_matrices=False
+    )
+
+    assert dataset.data_left_singular_vectors.dims == ("time", "left_singular_value_index")
+    assert dataset.data_singular_values.dims == ("singular_value_index",)
+    assert dataset.data_right_singular_vectors.dims == (
+        "spectral",
+        "right_singular_value_index",
+    )
+    np.testing.assert_allclose(dataset.data_left_singular_vectors.to_numpy(), left_vectors)
+    np.testing.assert_allclose(dataset.data_singular_values.to_numpy(), singular_values)
+    np.testing.assert_allclose(dataset.data_right_singular_vectors.to_numpy(), right_vectors.T)
+
+
+def test_add_svd_to_dataset_uses_custom_name_dims_and_data_array(data_array: xr.DataArray):
+    """Use a provided data array and custom output names for the SVD variables."""
+
+    dataset = xr.Dataset()
+
+    add_svd_to_dataset(
+        dataset,
+        name="fitted_data",
+        lsv_dim="model_time",
+        rsv_dim="wavelength",
+        data_array=data_array.rename(time="model_time", spectral="wavelength"),
+    )
+
+    left_vectors, singular_values, right_vectors = np.linalg.svd(
+        data_array.data, full_matrices=False
+    )
+
+    assert dataset.fitted_data_left_singular_vectors.dims == (
+        "model_time",
+        "left_singular_value_index",
+    )
+    assert dataset.fitted_data_singular_values.dims == ("singular_value_index",)
+    assert dataset.fitted_data_right_singular_vectors.dims == (
+        "wavelength",
+        "right_singular_value_index",
+    )
+    np.testing.assert_allclose(dataset.fitted_data_left_singular_vectors.to_numpy(), left_vectors)
+    np.testing.assert_allclose(dataset.fitted_data_singular_values.to_numpy(), singular_values)
+    np.testing.assert_allclose(
+        dataset.fitted_data_right_singular_vectors.to_numpy(), right_vectors.T
+    )
+
+
+def test_add_svd_to_dataset_skips_recomputing_existing_svd(
+    data_array: xr.DataArray, monkeypatch: pytest.MonkeyPatch
+):
+    """Skip the SVD calculation when singular values already exist on the dataset."""
+
+    dataset = data_array.to_dataset(name="data")
+    dataset["data_singular_values"] = (("singular_value_index",), np.array([42.0, 24.0]))
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("np.linalg.svd should not be called when SVD data already exists")
+
+    monkeypatch.setattr(np.linalg, "svd", fail_if_called)
+
+    add_svd_to_dataset(dataset)
+
+    np.testing.assert_allclose(dataset.data_singular_values.to_numpy(), np.array([42.0, 24.0]))
+    assert "data_left_singular_vectors" not in dataset
+    assert "data_right_singular_vectors" not in dataset

--- a/glotaran/simulation/simulation.py
+++ b/glotaran/simulation/simulation.py
@@ -85,7 +85,14 @@ def simulate(
     if noise:
         if noise_seed is not None:
             np.random.seed(noise_seed)
-        result["data"] = (result.data.dims, np.random.normal(result.data, noise_std_dev))
+        sorted_dims = sorted(result.data.dims)
+        data_with_noise = np.random.normal(result.data.transpose(*sorted_dims), noise_std_dev)
+        result["data"] = (
+            result.data.dims,
+            xr.DataArray(data_with_noise, dims=sorted_dims, coords=result.data.coords)
+            .transpose(*result.data.dims)
+            .to_numpy(),
+        )
 
     return result
 

--- a/glotaran/simulation/simulation.py
+++ b/glotaran/simulation/simulation.py
@@ -87,12 +87,9 @@ def simulate(
             np.random.seed(noise_seed)
         sorted_dims = sorted(result.data.dims)
         data_with_noise = np.random.normal(result.data.transpose(*sorted_dims), noise_std_dev)
-        result["data"] = (
-            result.data.dims,
-            xr.DataArray(data_with_noise, dims=sorted_dims, coords=result.data.coords)
-            .transpose(*result.data.dims)
-            .to_numpy(),
-        )
+        # Build inverse permutation: for each orig dim, find its position in sorted_dims
+        inv = [sorted_dims.index(d) for d in result.data.dims]
+        result["data"] = (result.data.dims, data_with_noise.transpose(inv))
 
     return result
 

--- a/glotaran/simulation/test/test_simulation.py
+++ b/glotaran/simulation/test/test_simulation.py
@@ -1,7 +1,10 @@
+from copy import deepcopy
+
 import numpy as np
 import pytest
 
 from glotaran.optimization.test.models import SimpleTestModel
+from glotaran.optimization.test.suites import FullModel
 from glotaran.parameter import Parameters
 from glotaran.simulation import simulate
 
@@ -56,3 +59,43 @@ def test_simulate_dataset(index_dependent, noise):
                 ]
             ).T,
         )
+
+
+def test_simulate_full_model_same_result_when_swapping_global_and_model_megacomplex():
+    """Same result when swapping the global and model megacomplex of a dataset model.
+
+    The difference originated from applying the noise, which operated on the raw
+    transposed numpy array. This then lead to the noise being applied differently.
+    """
+    model = deepcopy(FullModel.model)
+    swapped_model = deepcopy(FullModel.model)
+    noise_seed = 42
+
+    dataset_model = model.dataset["dataset1"]
+    swapped_dataset_model = swapped_model.dataset["dataset1"]
+    swapped_dataset_model.megacomplex = dataset_model.global_megacomplex
+    swapped_dataset_model.global_megacomplex = dataset_model.megacomplex
+
+    result = simulate(
+        model,
+        "dataset1",
+        FullModel.parameters,
+        FullModel.coordinates,
+        noise=True,
+        noise_std_dev=0.1,
+        noise_seed=noise_seed,
+    )
+    swapped_result = simulate(
+        swapped_model,
+        "dataset1",
+        FullModel.parameters,
+        FullModel.coordinates,
+        noise=True,
+        noise_std_dev=0.1,
+        noise_seed=noise_seed,
+    )
+
+    assert np.array_equal(result["global"], swapped_result["global"])
+    assert np.array_equal(result["model"], swapped_result["model"])
+    assert result.data.shape == swapped_result.data.T.shape
+    np.testing.assert_allclose(result.data, swapped_result.data.T)


### PR DESCRIPTION
This PR fixes two dimension-order dependent bugs that showed up when data or simulated results were represented with a different axis order than the code assumed.

The first issue was in SVD preparation. `add_svd_to_dataset` used the raw underlying array, so datasets with transposed dimensions or custom left/right singular vector dimensions could result in an exception due to dimensionality mismatch.

```py
xarray.structure.alignment.AlignmentError: cannot reindex or align along dimension 'time' because of conflicting dimension sizes: {2, 3} (note: an index is found along that dimension with size=3)
```

The fix normalizes the input `DataArray` to the requested `lsv_dim`/`rsv_dim` order before calling `np.linalg.svd`.

The second issue was in the simulation noise generation. Noise was previously applied directly to the current array layout, which meant swapping `megacomplex` and `global_megacomplex` in an equivalent full model could produce different noisy results because the random draws were consumed in a different dimension order. The fix applies noise in a normalized dimension order and then transposes the result back, making seeded simulations deterministic regardless of whether the same model is expressed with swapped model/global megacomplex assignments.

### Before
<img width="1281" height="933" alt="image" src="https://github.com/user-attachments/assets/415ec0ff-9c8d-4389-aa85-41dee301bd06" />

### After
<img width="1299" height="933" alt="image" src="https://github.com/user-attachments/assets/ac5d559e-d060-4a16-9e90-f13e2acf2bdc" />


### Change summary

- Fix `add_svd_to_dataset` to compute SVD on data transposed to the requested left/right singular vector dimensions
- Add regression tests for `add_svd_to_dataset`, including transposed input, custom dims, and the no-recompute path
- Fix simulation noise application so seeded noise is independent of dataset dimension ordering
- Add a `FullModel`-based regression test showing that swapping `megacomplex` and `global_megacomplex` yields the same noisy simulation result

### Checklist

- [x] ✔️ Passing the tests (mandatory for all PR's)
- [x] 🚧 Added changes to changelog (mandatory for all PR's)
- [x] 🧪 Adds new tests for the feature (mandatory for ✨ feature and 🩹 bug fix PR's)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SVD input orientation so singular vectors align with intended dimensions.
  * Fixed noise application to preserve correct axis alignment when adding noise.

* **Tests**
  * Added comprehensive tests for SVD behavior (default, transposed, custom names, skip-recompute).
  * Added test ensuring simulation consistency when swapping megacomplex configurations.

* **Documentation**
  * Added changelog entry and test module docstring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->